### PR TITLE
fix(dist): correct plugin distribution config and docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "specwright",
   "owner": {
     "name": "Obsidian-Owl"
@@ -6,9 +7,9 @@
   "plugins": [
     {
       "name": "specwright",
-      "source": ".",
+      "source": "./",
       "description": "Spec-driven development with quality gates. Ensures you get what you asked for.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "ObsidianOwl",
         "url": "https://github.com/Obsidian-Owl"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "specwright",
-  "displayName": "Specwright",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spec-driven development with quality gates. Ensures you get what you asked for.",
   "author": {
     "name": "ObsidianOwl",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to Specwright will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2026-02-11
+
+### Fixed
+- Plugin source path in marketplace.json (`"."` → `"./"`) — was preventing installation
+- Installation command in README (`claude plugin add` → `/plugin marketplace add`)
+- Removed `bash` language tag from slash command code blocks in README
+
+### Added
+- `$schema` reference in marketplace.json for validation
+
+### Removed
+- `displayName` field from plugin.json (not in official schema)
+
+## [0.1.0] - 2026-02-10
+
+### Added
+- Complete spec-driven workflow: init → plan → build → verify → ship → learn
+- 7 user-facing skills and 5 quality gate skills
+- 6 specialized agents (architect, tester, executor, reviewer, build-fixer, researcher)
+- 7 shared protocols for fragile operations
+- Anchor documents (Constitution + Charter)
+- Session recovery via hooks
+- Evidence-based quality gates with adversarial testing

--- a/README.md
+++ b/README.md
@@ -21,29 +21,30 @@ Most AI development frameworks focus on the specification phase. Specwright clos
 
 ## Installation
 
-```bash
-claude plugin add Obsidian-Owl/specwright
+In Claude Code, add the marketplace:
+```
+/plugin marketplace add Obsidian-Owl/specwright
 ```
 
 ## Quick Start
 
 Initialize your project:
-```bash
+```
 /specwright:init
 ```
 
 Create a specification:
-```bash
+```
 /specwright:plan payment-integration
 ```
 
 Build with test-first discipline:
-```bash
+```
 /specwright:build payment-integration
 ```
 
 Verify quality and ship:
-```bash
+```
 /specwright:verify
 /specwright:ship payment-integration
 ```
@@ -145,6 +146,6 @@ MIT License. Copyright (c) 2026 ObsidianOwl.
 
 ---
 
-**Version**: 0.1.0
+**Version**: 0.1.1
 **Author**: ObsidianOwl
 **Repository**: https://github.com/Obsidian-Owl/specwright


### PR DESCRIPTION
## Summary
- Fixed plugin `source` path in marketplace.json (`"."` → `"./"`) that prevented installation
- Fixed installation command in README (`claude plugin add` → `/plugin marketplace add`)
- Added `$schema` reference to marketplace.json
- Removed non-schema `displayName` field from plugin.json
- Removed `bash` language tag from slash command code blocks in README
- Added CHANGELOG.md
- Bumped version to 0.1.1

## Test plan
- [ ] Run `/plugin marketplace add Obsidian-Owl/specwright` — should install without schema error
- [ ] Verify all 12 skills appear after installation
- [ ] Verify all 6 agents are available

## Post-merge
Tag the release:
```
git tag v0.1.1
git push origin v0.1.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)