### PR TITLE
fix(dist): add install step and prevent manifest conflicts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,7 @@
     {
       "name": "specwright",
       "source": "./",
+      "strict": false,
       "description": "Spec-driven development with quality gates. Ensures you get what you asked for.",
       "version": "0.1.1",
       "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Plugin source path in marketplace.json (`"."` → `"./"`) — was preventing installation
-- Installation command in README (`claude plugin add` → `/plugin marketplace add`)
+- Installation command in README — now shows both steps (marketplace add + plugin install)
 - Removed `bash` language tag from slash command code blocks in README
 
 ### Added
 - `$schema` reference in marketplace.json for validation
+- `strict: false` in marketplace.json to prevent manifest merge conflicts
 
 ### Removed
 - `displayName` field from plugin.json (not in official schema)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Most AI development frameworks focus on the specification phase. Specwright clos
 
 ## Installation
 
-In Claude Code, add the marketplace:
+In Claude Code, add the marketplace and install the plugin:
 ```
 /plugin marketplace add Obsidian-Owl/specwright
+/plugin install specwright@specwright
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Added `/plugin install specwright@specwright` step to README — marketplace add alone does not install the plugin
- Added `strict: false` to marketplace.json to prevent merge conflicts between marketplace entry and plugin.json
- Updated CHANGELOG

## Test plan
- [ ] `/plugin marketplace add Obsidian-Owl/specwright`
- [ ] `/plugin install specwright@specwright`
- [ ] Verify skills appear and are invocable

## Post-merge
Retag v0.1.1 to the new merge commit:
```
git tag -d v0.1.1
git push origin :refs/tags/v0.1.1
git tag v0.1.1
git push origin v0.1.1
```
Then update the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)