### PR TITLE
fix(dist): remove agents and hooks from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,5 @@
     "workflow",
     "verification"
   ],
-  "skills": "./skills/",
-  "agents": "./agents/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Removed `agents` and `hooks` fields from plugin.json — they fail schema validation (`agents: Invalid input`)
- Working plugins (oh-my-claudecode, superpowers) don't declare these fields; Claude Code discovers `agents/` and `hooks/` directories by convention

## Test plan
- [ ] `/plugin marketplace add Obsidian-Owl/specwright` — no schema error
- [ ] `/plugin install specwright@specwright` — installs successfully
- [ ] Verify skills, agents, and hooks all load

## Post-merge
Retag v0.1.1 and recreate release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)