### PR TITLE
refactor: prefix user-facing skills with sw- to avoid clashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,18 +5,18 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 ## Workflow
 
 ```
-/specwright:init → /specwright:plan → /specwright:build → /specwright:verify → /specwright:ship
+/sw-init → /sw-plan → /sw-build → /sw-verify → /sw-ship
 ```
 
 | Skill | Purpose |
 |-------|---------|
-| `init` | Project setup. Creates constitution + charter. Configures gates and hooks. |
-| `plan` | Triage, research, design, critic review, decompose. Produces specs. |
-| `build` | TDD implementation of one work unit. |
-| `verify` | Interactive quality gates. Shows findings, validates against spec. |
-| `ship` | Trunk-based merge to main. |
-| `status` | Current state and progress. |
-| `learn` | Post-ship capture of patterns and learnings. |
+| `sw-init` | Project setup. Creates constitution + charter. Configures gates and hooks. |
+| `sw-plan` | Triage, research, design, critic review, decompose. Produces specs. |
+| `sw-build` | TDD implementation of one work unit. |
+| `sw-verify` | Interactive quality gates. Shows findings, validates against spec. |
+| `sw-ship` | Trunk-based merge to main. |
+| `sw-status` | Current state and progress. |
+| `sw-learn` | Post-ship capture of patterns and learnings. |
 
 ## Anchor Documents
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,13 +38,13 @@ What is this repo? What are we building? Who are the consumers? Architectural in
 
 | Skill | Purpose | Key Innovation |
 |-------|---------|----------------|
-| `init` | Project setup | Ask, detect, configure. Creates constitution + charter |
-| `plan` | Understand + design + decompose | Triage, deep research, critic review, user questions throughout |
-| `build` | TDD implementation | Tester → executor delegation. Context doc travels with agents |
-| `verify` | Interactive quality gates | Shows findings, not badges. Orchestrates gate skills in dependency order |
-| `ship` | Trunk-based merge | PR with evidence-mapped body |
-| `status` | Where am I, what's done, what's next | Supports --reset to abandon work |
-| `learn` | Post-ship capture. What worked, what to remember | Promotes patterns to constitution |
+| `sw-init` | Project setup | Ask, detect, configure. Creates constitution + charter |
+| `sw-plan` | Understand + design + decompose | Triage, deep research, critic review, user questions throughout |
+| `sw-build` | TDD implementation | Tester → executor delegation. Context doc travels with agents |
+| `sw-verify` | Interactive quality gates | Shows findings, not badges. Orchestrates gate skills in dependency order |
+| `sw-ship` | Trunk-based merge | PR with evidence-mapped body |
+| `sw-status` | Where am I, what's done, what's next | Supports --reset to abandon work |
+| `sw-learn` | Post-ship capture. What worked, what to remember | Promotes patterns to constitution |
 
 ### Internal Gate Skills (5)
 
@@ -139,13 +139,13 @@ Target: 600 tokens per SKILL.md (40% of the 1,500 token ceiling).
 ```
 specwright/
 ├── skills/           # SKILL.md files (12 skills)
-│   ├── init/         # User-facing
-│   ├── plan/
-│   ├── build/
-│   ├── verify/
-│   ├── ship/
-│   ├── status/
-│   ├── learn/
+│   ├── sw-init/      # User-facing
+│   ├── sw-plan/
+│   ├── sw-build/
+│   ├── sw-verify/
+│   ├── sw-ship/
+│   ├── sw-status/
+│   ├── sw-learn/
 │   ├── gate-build/   # Internal (invoked by verify)
 │   ├── gate-tests/
 │   ├── gate-security/

--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ In Claude Code, add the marketplace and install the plugin:
 
 Initialize your project:
 ```
-/specwright:init
+/sw-init
 ```
 
 Create a specification:
 ```
-/specwright:plan payment-integration
+/sw-plan payment-integration
 ```
 
 Build with test-first discipline:
 ```
-/specwright:build payment-integration
+/sw-build payment-integration
 ```
 
 Verify quality and ship:
 ```
-/specwright:verify
-/specwright:ship payment-integration
+/sw-verify
+/sw-ship payment-integration
 ```
 
 ## Workflow
@@ -66,13 +66,13 @@ Verify quality and ship:
 ## Skills
 
 **User-Facing** (7 core skills):
-- `/specwright:init` — Project configuration and setup
-- `/specwright:plan` — Specification with triage, research, design, critic, decompose
-- `/specwright:build` — TDD implementation with test-first discipline
-- `/specwright:verify` — Interactive quality gates with findings
-- `/specwright:ship` — Trunk-based PR with evidence mapping
-- `/specwright:status` — Workflow progress and state
-- `/specwright:learn` — Pattern capture and promotion
+- `/sw-init` — Project configuration and setup
+- `/sw-plan` — Specification with triage, research, design, critic, decompose
+- `/sw-build` — TDD implementation with test-first discipline
+- `/sw-verify` — Interactive quality gates with findings
+- `/sw-ship` — Trunk-based PR with evidence mapping
+- `/sw-status` — Workflow progress and state
+- `/sw-learn` — Pattern capture and promotion
 
 **Quality Gates** (5 gates, configurable):
 - `gate-build` — Compilation, test pass (BLOCK)

--- a/protocols/context.md
+++ b/protocols/context.md
@@ -20,7 +20,7 @@ Load when needed for alignment/verification:
 
 ```javascript
 if (!exists('.specwright/config.json')) {
-  error("Run /specwright:init first.");
+  error("Run /sw-init first.");
 }
 ```
 
@@ -28,7 +28,7 @@ if (!exists('.specwright/config.json')) {
 
 ```javascript
 if (!state.currentWorkUnit && requiresWorkUnit) {
-  error("Run /specwright:plan first.");
+  error("Run /sw-plan first.");
 }
 ```
 

--- a/skills/sw-build/SKILL.md
+++ b/skills/sw-build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: build
+name: sw-build
 description: >-
   TDD implementation of one work unit. Delegates test writing to the tester
   agent and implementation to the executor agent. Commits per task.
@@ -97,8 +97,8 @@ When delegating, include in the prompt:
 
 | Condition | Action |
 |-----------|--------|
-| No active work unit | STOP: "Run /specwright:plan first" |
-| Build/test command not configured | STOP: "Configure commands in config.json or run /specwright:init" |
+| No active work unit | STOP: "Run /sw-plan first" |
+| Build/test command not configured | STOP: "Configure commands in config.json or run /sw-init" |
 | Tester writes tests that pass immediately | Tests are wrong. Re-delegate with instruction to write tests that FAIL first. |
 | Executor can't pass tests after 2 build-fixer attempts | STOP. Show error to user. Don't loop forever. |
 | Compaction during build | Read workflow.json, find last completed task, resume next task |

--- a/skills/sw-init/SKILL.md
+++ b/skills/sw-init/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: init
+name: sw-init
 description: >-
   Initializes Specwright in a project. Detects stack, asks about practices,
   creates constitution and charter, configures quality gates and hooks.

--- a/skills/sw-learn/SKILL.md
+++ b/skills/sw-learn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: learn
+name: sw-learn
 description: >-
   Captures patterns and learnings from the current work unit. Reviews
   build failures, gate findings, and architecture decisions. Promotes

--- a/skills/sw-plan/SKILL.md
+++ b/skills/sw-plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan
+name: sw-plan
 description: >-
   Understands the user's request, researches the codebase deeply, designs
   a solution, challenges it adversarially, and produces actionable specs.

--- a/skills/sw-ship/SKILL.md
+++ b/skills/sw-ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ship
+name: sw-ship
 description: >-
   Ships the current work unit. Verifies all gates passed, creates a PR
   with evidence-mapped body, updates workflow state to shipped.
@@ -78,7 +78,7 @@ ships when gates have passed.
 
 | Condition | Action |
 |-----------|--------|
-| Gates not passed | STOP: "Run /specwright:verify first" |
+| Gates not passed | STOP: "Run /sw-verify first" |
 | No git changes to ship | STOP: "Nothing to ship. No changes detected." |
 | PR creation fails | Show error. Don't update state. User can retry. |
 | Evidence files missing | WARN in PR body: "Evidence not available for gate X" |

--- a/skills/sw-status/SKILL.md
+++ b/skills/sw-status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: status
+name: sw-status
 description: >-
   Shows current Specwright state — active work unit, task progress, gate
   results, and lock status. Supports --reset to abandon work in progress.
@@ -38,8 +38,8 @@ next. If they're stuck, give them a way out with `--reset`.
 **Display (HIGH freedom):**
 - Read workflow.json and format it clearly for the user.
 - Show gate results with freshness (e.g., "PASS (12 min ago)").
-- If no active work: say so and suggest `/specwright:plan`.
-- If work is complete: suggest `/specwright:ship`.
+- If no active work: say so and suggest `/sw-plan`.
+- If work is complete: suggest `/sw-ship`.
 - Be concise. This is a dashboard, not a report.
 
 **Reset mode (LOW freedom):**
@@ -58,6 +58,6 @@ next. If they're stuck, give them a way out with `--reset`.
 
 | Condition | Action |
 |-----------|--------|
-| workflow.json doesn't exist | "Specwright not initialized. Run /specwright:init" |
+| workflow.json doesn't exist | "Specwright not initialized. Run /sw-init" |
 | workflow.json parse error | Show raw error. Suggest manual fix or re-init. |
 | Stale lock detected (>30 min) | Offer to auto-clear with warning |

--- a/skills/sw-verify/SKILL.md
+++ b/skills/sw-verify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: verify
+name: sw-verify
 description: >-
   Orchestrates quality gates for the current work unit. Runs enabled gates
   in dependency order, shows findings interactively, produces an aggregate
@@ -90,7 +90,7 @@ and be able to discuss or override before proceeding to ship.
 
 | Condition | Action |
 |-----------|--------|
-| No active work unit | STOP: "Nothing to verify. Run /specwright:plan and /specwright:build first." |
+| No active work unit | STOP: "Nothing to verify. Run /sw-plan and /sw-build first." |
 | No gates enabled in config | WARN and skip to ready-to-ship state |
 | Gate skill file not found | ERROR for that gate, continue with remaining gates |
 | All gates skipped by user | WARN: "All gates skipped. Proceed at own risk." |


### PR DESCRIPTION
## Summary
- Renamed 7 user-facing skill directories and frontmatter names with `sw-` prefix
- `init` → `sw-init`, `plan` → `sw-plan`, `build` → `sw-build`, `verify` → `sw-verify`, `ship` → `sw-ship`, `status` → `sw-status`, `learn` → `sw-learn`
- Updated all references in CLAUDE.md, README.md, protocols/context.md, and cross-referencing SKILL.md files
- Gate skills (`gate-build`, `gate-security`, etc.) unchanged — already have a distinctive prefix

## Why
Claude Code plugin skills appear in autocomplete by their `name` field without the plugin prefix. Generic names like `status`, `init`, `build` clash with built-in commands and other plugins. The `sw-` prefix makes them distinctive while staying short.

## Test plan
- [ ] Install plugin and verify `/sw-init`, `/sw-plan` etc. appear in autocomplete
- [ ] Verify no clashes with built-in `/status` command
- [ ] Verify gate skills still appear as `gate-build`, `gate-security` etc.

## Post-merge
Retag v0.1.1 and recreate release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)