### PR TITLE
feat(ci): split release into PR + finalize workflows

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,55 @@
+name: Release Finalize
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section between ## [VERSION] and the next ## [
+          sed -n "/^## \[${VERSION}\]/,/^## \[/{/^## \[/d;p}" CHANGELOG.md > /tmp/release_notes.md
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin "v${VERSION}"
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file /tmp/release_notes.md
+
+      - name: Cleanup release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          git push origin --delete "$BRANCH" 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,10 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
+  release-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,7 +44,6 @@ jobs:
           echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog
-        id: changelog
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$PREV_TAG" ]; then
@@ -53,17 +53,7 @@ jobs:
           fi
 
           # Format commits as markdown bullets
-          BODY=$(echo "$COMMITS" | sed 's/^[a-f0-9]* /- /')
-
-          # Write to file (multi-line safe)
-          echo "$BODY" > /tmp/changelog_body.md
-
-          # Also set as output using delimiter
-          {
-            echo "body<<CHANGELOG_EOF"
-            echo "$BODY"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "$COMMITS" | sed 's/^[a-f0-9]* /- /' > /tmp/changelog_body.md
 
       - name: Update plugin.json
         run: |
@@ -104,19 +94,30 @@ jobs:
             sed -n '/^## \[/,$p' CHANGELOG.md
           } > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
 
-      - name: Commit and tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json README.md CHANGELOG.md .github/banner.svg
-          git commit -m "chore(release): v${{ steps.next.outputs.version }}"
-          git tag -a "v${{ steps.next.outputs.version }}" -m "v${{ steps.next.outputs.version }}"
-          git push origin main --follow-tags
-
-      - name: Create GitHub Release
+      - name: Create release branch and PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.next.outputs.version }}" \
-            --title "v${{ steps.next.outputs.version }}" \
-            --notes-file /tmp/changelog_body.md
+          VERSION="${{ steps.next.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json README.md CHANGELOG.md .github/banner.svg
+          git commit -m "chore(release): v${VERSION}"
+          git push origin "$BRANCH"
+
+          {
+            echo "## Release v${VERSION}"
+            echo ""
+            echo "**Bump:** ${{ inputs.bump }} (v${{ steps.current.outputs.version }} → v${VERSION})"
+            echo ""
+            echo "### Changes"
+            echo ""
+            cat /tmp/changelog_body.md
+          } > /tmp/pr_body.md
+
+          gh pr create \
+            --title "chore(release): v${VERSION}" \
+            --body-file /tmp/pr_body.md


### PR DESCRIPTION
## Summary

- Release workflow now opens a `release/vX.Y.Z` PR instead of pushing directly to main
- New `release-finalize.yml` creates the git tag and GitHub release when the release PR is merged
- Compatible with branch protection rules (no direct pushes to main)

## How it works

1. Trigger `Release` workflow (workflow_dispatch with bump type)
2. Workflow creates `release/vX.Y.Z` branch with version bumps, opens a PR
3. Review and merge the PR
4. `Release Finalize` workflow triggers on merge, creates tag + GitHub release, cleans up branch

## Test plan

- [ ] Trigger release workflow and verify PR is created with correct version bumps
- [ ] Merge the release PR and verify tag + GitHub release are created
- [ ] Verify release branch is deleted after finalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)