### PR TITLE
feat(skills): add native task tracking to sw-build

### DIFF
--- a/skills/sw-build/SKILL.md
+++ b/skills/sw-build/SKILL.md
@@ -130,5 +130,6 @@ When delegating, include in the prompt:
 | Build/test command not configured | STOP: "Configure commands in config.json or run /sw-init" |
 | Tester writes tests that pass immediately | Tests are wrong. Re-delegate with instruction to write tests that FAIL first. |
 | Executor can't pass tests after 2 build-fixer attempts | STOP. Show error to user. Don't loop forever. |
-| Compaction during build | Read workflow.json, find last completed task, resume next task |
+| Compaction during build | Read workflow.json, find last completed task, resume next task. Create fresh Claude Code tasks from spec/plan, sync status from workflow.json. |
+| Task tracking tools unavailable | Continue with workflow.json-only tracking. Graceful degradation — task tracking is best-effort. |
 | Lock held by another skill | STOP with lock info. Don't force-clear. |


### PR DESCRIPTION
## Summary

- Add Claude Code native task tracking tools (TaskCreate/TaskUpdate/TaskList/TaskGet) to sw-build as a visual overlay for intra-workunit task progress
- workflow.json remains the durable source of truth; task tracking is best-effort UX enhancement
- Includes write ordering, orchestrator-only constraints, tool disambiguation, graceful degradation, and compaction recovery

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| AC-1 | Frontmatter includes TaskCreate, TaskUpdate, TaskList, TaskGet | PASS |
| AC-2 | Task tracking constraint with LOW freedom, no procedures | PASS |
| AC-3 | Write ordering: workflow.json FIRST, TaskUpdate best-effort | PASS |
| AC-4 | Best-effort semantics explicit, failures never halt build | PASS |
| AC-5 | Orchestrator-only: delegated agents don't update task status | PASS |
| AC-6 | blockedBy/blocks prohibited, sequential loop handles ordering | PASS |
| AC-7 | Tool disambiguation: Task (delegation) vs TaskCreate (tracking) | PASS |
| AC-8 | Recovery includes fresh task creation from spec/plan | PASS |
| AC-9 | Graceful degradation failure mode for unavailable tools | PASS |
| AC-10 | Token budget preserved: 135 lines, constraint is 7 lines | PASS |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| Build | SKIP | 0/0/0 |
| Tests | PASS | 0/4/5 |
| Security | PASS | 0/0/4 |
| Wiring | PASS | 0/1/4 |
| Spec | PASS | 10/10 criteria mapped |

## Evidence

- 77/77 structural validation checks passing across 3 test suites
- Spec: `build-task-tracking/spec.md`
- Design: `build-task-tracking/design.md`

**Work unit:** `build-task-tracking`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Specwright](https://github.com/Obsidian-Owl/specwright)