### PR TITLE
fix(hooks): use plugin root path and deterministic stop script

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ./hooks/session-start.mjs"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs"
           }
         ]
       }
@@ -14,9 +14,8 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Check if Specwright has active work. Read .specwright/state/workflow.json. If currentWork exists and currentWork.status is NOT 'shipped', 'abandoned', or null, respond: {\"ok\": false, \"reason\": \"Specwright has active work: [work-id] (status: [status], [completed]/[total] tasks done). Consider running /sw-status before ending this session, or /sw-status --reset to abandon.\"}. If no active work or file does not exist, respond: {\"ok\": true}. IMPORTANT: Check $ARGUMENTS — if stop_hook_active is true, always respond {\"ok\": true} to prevent loops.",
-            "timeout": 10
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-stop.mjs"
           }
         ]
       }

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -1,0 +1,38 @@
+/**
+ * Specwright session-stop hook.
+ * Checks if there's active work and warns the user before ending the session.
+ * Deterministic — no LLM involved.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const cwd = process.cwd();
+const statePath = join(cwd, '.specwright', 'state', 'workflow.json');
+
+if (!existsSync(statePath)) {
+  // No Specwright state — nothing to warn about
+  console.log(JSON.stringify({ ok: true }));
+  process.exit(0);
+}
+
+try {
+  const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+  const work = state.currentWork;
+
+  if (work && !['shipped', 'abandoned', null].includes(work.status)) {
+    const completed = work.tasksCompleted?.length ?? 0;
+    const total = work.tasksTotal ?? '?';
+    console.log(JSON.stringify({
+      ok: false,
+      reason: `Specwright has active work: ${work.id} (status: ${work.status}, ${completed}/${total} tasks done). Consider running /sw-status before ending this session, or /sw-status --reset to abandon.`
+    }));
+  } else {
+    console.log(JSON.stringify({ ok: true }));
+  }
+} catch {
+  // Don't block session end on read errors
+  console.log(JSON.stringify({ ok: true }));
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

- Fix SessionStart hook to resolve script path from `${CLAUDE_PLUGIN_ROOT}` instead of relative CWD (caused MODULE_NOT_FOUND in every non-Specwright project)
- Replace Stop hook's non-deterministic LLM prompt (`type: "prompt"`) with a deterministic Node.js script (`type: "command"`) that outputs clean JSON

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| AC-1 | SessionStart hook resolves from plugin root | PASS | `hooks/hooks.json:8` — uses `${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs` |
| AC-2 | Stop hook produces deterministic JSON | PASS | `hooks/hooks.json:18` — `type: "command"`, `hooks/session-stop.mjs:26` — `console.log(JSON.stringify(...))` |
| AC-3 | Stop hook degrades gracefully | PASS | `hooks/session-stop.mjs:13-16` (missing file), `:33-35` (parse error), `:23-29` (active work) |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| build | SKIP | No build command configured |
| tests | SKIP | No test runner configured |
| security | SKIP | Quick intensity |
| wiring | SKIP | Quick intensity |
| spec | WARN | 0/1/0 — no automated test coverage (project has no test runner) |

## Evidence

- Spec compliance report: `.specwright/work/fix-hooks-reliability/evidence/spec-compliance.md`

---

Work unit: `fix-hooks-reliability` | Intensity: quick

🤖 Generated with [Claude Code](https://claude.com/claude-code)