### PR TITLE
fix: correct broken links in README comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Specwright closes the **entire loop** — design, plan, build, verify, ship, lea
 
 ### How It Compares
 
-| Capability | Specwright | [Spec Kit](https://github.com/spec-kit/spec-kit) | [Oh-My-ClaudeCode](https://github.com/anthropics/oh-my-claudecode) | Manual workflows |
+| Capability | Specwright | [Spec Kit](https://github.com/github/spec-kit) | [Oh-My-ClaudeCode](https://github.com/Yeachan-Heo/oh-my-claudecode) | Manual workflows |
 |---|---|---|---|---|
 | Structured spec writing | Yes | **Yes** — core strength | Partial | DIY |
 | Adversarial TDD (separate tester/executor) | **Yes** | No | No | No |


### PR DESCRIPTION
## Summary

- Fix Spec Kit link: `github/spec-kit` not `spec-kit/spec-kit`
- Fix Oh-My-ClaudeCode link: `Yeachan-Heo/oh-my-claudecode` not `anthropics/oh-my-claudecode`

Both links in the "How It Compares" table were returning 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)