### PR TITLE
feat(protocols): add per-unit spec support to state protocol

### DIFF
--- a/protocols/state.md
+++ b/protocols/state.md
@@ -69,6 +69,8 @@ The `designing → building` transition is only valid when `currentWork.intensit
 
 When `workUnits` exists, also update the matching entry's status in the array.
 
+**Gates reset:** When a new unit is activated (via sw-plan or sw-ship unit advancement), the `gates` section is reset to `{}`. Historical gate results for shipped units persist in their `{unitWorkDir}/evidence/` directories.
+
 ## Path Resolution Convention
 
 Two scopes exist for resolving work artifact paths:


### PR DESCRIPTION
## Summary

- Adds `unitId` field to `currentWork` for tracking the active unit in multi-unit work
- Adds `workDir` and `planned` status to `workUnits` entries for per-unit artifact directories
- Establishes path resolution convention (unit-local vs design-level scopes) and gates reset rule

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| AC-1 | `unitId` field in currentWork schema | PASS — `state.md:17` |
| AC-2 | `workDir` field in workUnits entries | PASS — `state.md:32` |
| AC-3 | `planned` status in workUnits enum | PASS — `state.md:32,47` |
| AC-4 | `shipped → building` transition, no `shipped → planning` | PASS — `state.md:62` |
| AC-5 | `planning → building` with sw-plan trigger | PASS — `state.md:58` |
| AC-6 | Path Resolution Convention section | PASS — `state.md:74-85` |
| AC-7 | Gates reset rule documented | PASS — `state.md:72` |
| AC-8 | Single-unit backward compatibility | PASS — `state.md:42-45` |
| AC-9 | workUnits null note preserved | PASS — `state.md:42` |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| gate-build | SKIP | 0/0/0 |
| gate-tests | SKIP | 0/0/0 |
| gate-security | SKIP | 0/0/0 |
| gate-wiring | SKIP | 0/0/0 |
| gate-spec | PASS | 0/0/0 |

## Context

This is Unit 1 of 4 in the `per-unit-specs` work. It establishes the state protocol foundation that Units 2-4 depend on.

Work units:
1. **state-protocol** ← this PR
2. sw-plan-rewrite
3. build-and-ship
4. downstream-and-docs