### PR TITLE
feat(sw-plan): rewrite for per-unit specs with individual review

### DIFF
--- a/skills/sw-plan/SKILL.md
+++ b/skills/sw-plan/SKILL.md
@@ -140,4 +140,5 @@ The parent `context.md` (design research) is never overwritten.
 | Required artifact missing | STOP: "Run /sw-design first" (design.md for full, context.md for lite) |
 | Design too vague for specs | Ask user for clarification with concrete options |
 | Active work already in progress | Ask user: continue existing, or start new? |
-| Compaction during planning | Read workflow.json, check which artifacts exist, resume |
+| Compaction during planning | Read workflow.json. Check `workUnits` entries: skip `planned` units, resume from first `pending` unit. If a `pending` unit has partially written artifacts (spec.md exists), re-present to user for approval. |
+| Decomposition revision after partial approval | Partial teardown not supported. User must `/sw-status --reset` and re-run `/sw-plan`. |


### PR DESCRIPTION
## Summary

- Rewrites `skills/sw-plan/SKILL.md` so each work unit gets its own directory with independent `spec.md`, `plan.md`, and `context.md`
- Adds per-unit spec loop with individual user approval via `AskUserQuestion` before moving to the next unit
- Preserves single-unit flat layout for backward compatibility

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| AC-1 | Multi-unit outputs in `units/{unit-id}/` directory | PASS |
| AC-2 | No spec/plan at work root for multi-unit | PASS |
| AC-3 | Single-unit flat layout preserved | PASS |
| AC-4 | `workUnits` populated at `pending` before loop | PASS |
| AC-5 | Single-unit decomposition uses flat layout | PASS |
| AC-6 | User approves decomposition before directories created | PASS |
| AC-7 | Per-unit directory with context, plan, spec | PASS |
| AC-8 | Individual AskUserQuestion approval per unit | PASS |
| AC-9 | Revision loop until approved | PASS |
| AC-10 | Unit status → `planned` after approval | PASS |
| AC-11 | `designing` → `planning` at start | PASS |
| AC-12 | `planning` → `building` with unitId/workDir activation | PASS |
| AC-13 | Gates reset on first unit activation | PASS |
| AC-14 | Curated context subset per unit | PASS |
| AC-15 | Self-contained unit context | PASS |
| AC-16 | Compaction recovery with skip/resume | PASS |
| AC-17 | Decomposition revision requires reset | PASS |
| AC-18 | No implementation code in stage boundary | PASS |
| AC-19 | Handoff to `/sw-build` after activation | PASS |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| spec | PASS | 0/0/0 |
| build | SKIP | N/A (markdown-only) |
| tests | SKIP | N/A (markdown-only) |
| security | SKIP | N/A (markdown-only) |
| wiring | SKIP | N/A (markdown-only) |

## Evidence

- [Spec Compliance](.specwright/work/per-unit-specs/units/sw-plan-rewrite/evidence/spec-compliance.md) — 19/19 criteria PASS with line-level mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)