### PR TITLE
docs: update skills tables and file counts for sw-effectiveness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 | `sw-build` | TDD implementation of one work unit. |
 | `sw-verify` | Interactive quality gates. Shows findings, validates against spec. |
 | `sw-ship` | Strategy-aware merge via PR. |
+| `sw-debug` | Investigation-first debugging. Scope → investigate → diagnose → fix/log/defer. |
+| `sw-pivot` | Mid-build course correction. Revises remaining tasks via architect; append-only. |
+| `sw-doctor` | Read-only installation health check. 9 checks, repair hints. |
 | `sw-guard` | Detect stack and interactively configure guardrails (hooks, CI, settings). |
 | `sw-status` | Current state and progress. |
 | `sw-learn` | Post-ship capture of patterns and learnings. |
@@ -55,6 +58,8 @@ Skills reference shared protocols in `protocols/` for fragile operations:
 - `landscape.md` -- Codebase reference document format and freshness rules
 - `assumptions.md` -- Design assumption format, classification, and resolution lifecycle
 - `audit.md` -- Codebase health findings format, IDs, and lifecycle
+- `backlog.md` -- Backlog item format, BL-{n} IDs, markdown and GitHub Issues targets
+- `spec-review.md` -- Spec quality review dimensions, finding levels, resolution flow
 
 ## Key Rules
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ Two optional **reference documents** accelerate research and track health:
 **Utilities**
 | Skill | Purpose |
 |-------|---------|
+| `/sw-debug` | Investigation-first debugging |
+| `/sw-pivot` | Mid-build course correction |
+| `/sw-doctor` | Installation health check |
 | `/sw-guard` | Configure guardrails (hooks, CI) |
 | `/sw-status` | Progress and state |
 | `/sw-learn` | Pattern capture |
@@ -253,8 +256,8 @@ See `DESIGN.md` for the complete architecture document.
 
 ```
 specwright/
-├── skills/       # 15 SKILL.md files (10 user + 5 gates)
-├── protocols/    # 14 shared protocols (loaded on demand)
+├── skills/       # 18 SKILL.md files (13 user + 5 gates)
+├── protocols/    # 16 shared protocols (loaded on demand)
 ├── agents/       # 6 custom subagent definitions
 ├── hooks/        # Session lifecycle hooks
 ├── DESIGN.md     # Full architecture


### PR DESCRIPTION
## Summary

Updates README.md and CLAUDE.md to reflect the four work units shipped in the sw-effectiveness project.

**README.md**
- Skills table: add `/sw-debug`, `/sw-pivot`, `/sw-doctor` to Utilities
- Architecture section: skill count 15 → 18 (13 user + 5 gates), protocol count 14 → 16

**CLAUDE.md**
- Skills table: add `sw-debug`, `sw-pivot`, `sw-doctor` with descriptions
- Protocols list: add `backlog.md` and `spec-review.md`

No functional changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)