### PR TITLE
docs: document experimental agent teams feature in README and DESIGN

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -96,6 +96,18 @@ Solution architecture and implementation planning are separate skills:
 - For single-unit work: writes `spec.md` and `plan.md` at the work root (flat layout, unchanged).
 - Parent `context.md` (design research) is never overwritten.
 
+### Parallel Build (Experimental)
+
+sw-build supports optional parallel task execution using Claude Code Agent Teams. When enabled and tasks are independent (no file overlap), the build orchestrator:
+
+1. Analyzes plan.md file targets to classify tasks as independent or dependent
+2. Creates isolated git worktrees (`.specwright/worktrees/{task-id}`)
+3. Spawns teammates — each runs the full TDD cycle (tester → executor → refactor) in its worktree
+4. Cherry-picks completed worktree commits onto the feature branch
+5. Falls back to sequential execution for dependent or failed tasks
+
+Double opt-in: `config.experimental.agentTeams.enabled` + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var. Procedure in `protocols/parallel-build.md`. Graceful degradation at every level — if any prerequisite fails, sw-build executes tasks sequentially with no error.
+
 ### Verify Skill Gates
 
 Configurable per project (set up in init). Each gate:
@@ -132,7 +144,7 @@ Extracted once in `protocols/`, referenced by skills. Loaded on demand.
 | `spec-review.md` | Spec quality review dimensions, finding levels, resolution flow | ~610 |
 | `parallel-build.md` | Parallel task execution with agent teams (experimental) | ~815 |
 
-Total: ~5,560 words (loaded on demand, not all at once).
+Total: ~6,375 words (loaded on demand, not all at once).
 
 ## Skill Anatomy
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ graph LR
 | **Research** | Investigate external docs, APIs, patterns; produce validated briefs | Evidence-graded findings with confidence scoring |
 | **Design** | Triage as Full / Lite / Quick, research codebase, design solution, adversarial critic | Right-sized ceremony — trivial fixes skip the full cycle |
 | **Plan** | Decompose into work units, write testable acceptance criteria | Specs grounded in approved design artifacts |
-| **Build** | TDD — tester writes hard-to-pass tests, executor makes them pass | Adversarial test-first, not test-after |
+| **Build** | TDD — tester writes hard-to-pass tests, executor makes them pass. Optional parallel execution via agent teams (experimental). | Adversarial test-first, not test-after |
 | **Verify** | 5 quality gates with evidence capture | Findings shown inline, not just pass/fail badges |
 | **Ship** | PR with acceptance criteria mapped to evidence | Every requirement traceable to code + test |
 | **Learn** | Capture patterns, promote to constitution | Knowledge compounds across sessions |
@@ -216,6 +216,12 @@ Three optional **reference documents** accelerate research and track health:
 
 **`research/*.md`** — External research briefs: API contracts, SDK docs, industry patterns. Confidence-scored, stale after 90 days.
 
+## Experimental: Parallel Builds with Agent Teams
+
+When a work unit has 4+ independent tasks, Specwright can execute them in parallel using [Claude Code Agent Teams](https://docs.anthropic.com/en/docs/claude-code/agent-teams). Each teammate works in an isolated git worktree, runs the full TDD cycle with its own tester/executor agents, and commits independently. The lead cherry-picks results onto the feature branch.
+
+**Requirements:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var + `config.experimental.agentTeams.enabled: true`. Falls back to sequential execution when prerequisites aren't met — no errors, no configuration needed to ignore it.
+
 ## Skills
 
 <table>
@@ -273,7 +279,7 @@ See `DESIGN.md` for the complete architecture document.
 ```
 specwright/
 ├── skills/       # 19 SKILL.md files (14 user + 5 gates)
-├── protocols/    # 17 shared protocols (loaded on demand)
+├── protocols/    # 18 shared protocols (loaded on demand)
 ├── agents/       # 6 custom subagent definitions
 ├── hooks/        # Session lifecycle hooks
 ├── DESIGN.md     # Full architecture


### PR DESCRIPTION
## Summary

- Adds "Experimental: Parallel Builds with Agent Teams" section to README
- Adds "Parallel Build (Experimental)" subsection to DESIGN.md architecture
- Updates protocol count from 17 to 18 and word total from ~5,560 to ~6,375
- Updates Build phase description in README to mention optional parallel execution

Follow-up to #63 (agent teams build integration) — the docs update wasn't included before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)