### PR TITLE
docs: fix opencode package name to scoped @obsidian-owl/opencode-specwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Add the plugin to your `opencode.json`:
 
 ```json
 {
-  "plugin": ["opencode-specwright@latest"]
+  "plugin": ["@obsidian-owl/opencode-specwright@latest"]
 }
 ```
 

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -8,7 +8,7 @@ Add to your `opencode.json`:
 
 ```json
 {
-  "plugin": ["opencode-specwright@latest"]
+  "plugin": ["@obsidian-owl/opencode-specwright@latest"]
 }
 ```
 


### PR DESCRIPTION
## Summary

- Fix install instructions in README.md and adapter README to use the published scoped package name `@obsidian-owl/opencode-specwright@latest` instead of the old unscoped `opencode-specwright@latest`

## Also updated (outside PR)

- Repo description now mentions both Claude Code and Opencode
- Added topics: `opencode`, `opencode-plugin`, `npm-package`

🤖 Generated with [Claude Code](https://claude.com/claude-code)