### PR TITLE
test(claude-code): comprehensive build output test suite

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,5 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Run Claude Code build tests
         run: tests/test-claude-code-build.sh

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -21,6 +21,7 @@
 #   Exit 0 = all pass, exit 1 = any failure
 
 set -uo pipefail
+trap 'rm -rf "$DIST_DIR"' EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -82,7 +83,7 @@ extract_body() {
 # Extract allowed-tools list items from YAML frontmatter
 extract_allowed_tools() {
   local fm="$1"
-  echo "$fm" | sed -n '/^allowed-tools:/,/^[a-z]/{/^  - /p;}' | sed 's/^  - //'
+  echo "$fm" | sed -n '/^allowed-tools:/,/^[^ ]/{/^  - /p;}' | sed 's/^  - //'
 }
 
 # ─── Pre-flight ──────────────────────────────────────────────────────
@@ -177,8 +178,9 @@ if [ -d "$CC_DIST/skills" ]; then
       MISSING_SKILLS="$MISSING_SKILLS $skill_name"
     fi
   done
-  assert_eq "$SKILL_FILE_COUNT" "$EXPECTED_SKILL_COUNT" "all $EXPECTED_SKILL_COUNT skill directories contain SKILL.md"
-  if [ -n "$MISSING_SKILLS" ]; then
+  if [ -z "$MISSING_SKILLS" ]; then
+    pass "all $EXPECTED_SKILL_COUNT skill directories contain SKILL.md"
+  else
     fail "skills missing SKILL.md:$MISSING_SKILLS"
   fi
 
@@ -330,11 +332,11 @@ if [ "$LOWERCASE_TOOL_FOUND" -eq 0 ]; then
   pass "no skill has lowercase tool names in allowed-tools (identity mapping correct)"
 fi
 
-# Parser sanity: at least 15 skills should have non-empty allowed-tools
-if [ "$SKILLS_WITH_TOOLS" -ge 15 ]; then
+# Parser sanity: all skills should have non-empty allowed-tools
+if [ "$SKILLS_WITH_TOOLS" -ge "$EXPECTED_SKILL_COUNT" ]; then
   pass "tool parser found allowed-tools in $SKILLS_WITH_TOOLS skills (sanity check)"
 else
-  fail "tool parser only found allowed-tools in $SKILLS_WITH_TOOLS skills (expected 15+, parser may be broken)"
+  fail "tool parser only found allowed-tools in $SKILLS_WITH_TOOLS skills (expected $EXPECTED_SKILL_COUNT, parser may be broken)"
 fi
 
 echo "--- Spot-check: sw-init has Read, Write, Bash ---"
@@ -876,24 +878,20 @@ if [ -f "$ROOT_DIR/core/agents/specwright-tester.md" ]; then
   fi
 fi
 
-echo "--- Core skill content integrity ---"
+echo "--- Core and adapter source integrity (git diff) ---"
 
-# Verify a few core files have not been altered by checking git status
-for skill in sw-init sw-build sw-verify; do
-  core_skill="$ROOT_DIR/core/skills/$skill/SKILL.md"
-  if [ -f "$core_skill" ]; then
-    # Check the file still starts with frontmatter
-    FIRST_LINE=$(head -n 1 "$core_skill")
-    assert_eq "$FIRST_LINE" "---" "core/$skill/SKILL.md still starts with ---"
-  fi
-done
+if git -C "$ROOT_DIR" diff --exit-code -- core/ adapters/ &>/dev/null; then
+  pass "no core/ or adapters/ source files were modified by the build (git diff clean)"
+else
+  fail "build modified source files in core/ or adapters/ (run 'git diff -- core/ adapters/' for details)"
+fi
 
 # ─── Cleanup ─────────────────────────────────────────────────────────
 
 echo ""
 echo "--- Cleanup ---"
 rm -rf "$DIST_DIR"
-pass "dist/ cleaned up"
+echo "  INFO: dist/ cleaned up"
 
 # ─── Summary ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add 155-assertion test suite (`tests/test-claude-code-build.sh`) verifying all aspects of the claude-code adapter build output
- Add `test-claude-code` CI job to `validate.yml` for PR validation
- Brings claude-code adapter to test parity with the opencode adapter (audit finding F6)

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| AC-1 | Test file with helpers (pass, fail, assert_eq, extract_frontmatter, extract_body) | PASS |
| AC-2 | Build output structure (skills/19, agents/6, protocols/19, hooks, .claude-plugin, CLAUDE.md, README.md) | PASS |
| AC-3 | Identity mapping — tools stay uppercase across ALL skills | PASS |
| AC-4 | Agent identity — no mode:subagent, shorthand models, array-style tools | PASS |
| AC-5 | Protocol refs — bare `protocols/` paths, no `.specwright/protocols/` | PASS |
| AC-6 | Hook files valid JavaScript (`node --check`) + match adapter source | PASS |
| AC-7 | Plugin manifest valid JSON with name and version fields | PASS |
| AC-8 | No platform markers remain in ANY output file | PASS |
| AC-9 | sw-build Claude Code content preserved (Task tools, Task tracking, Mid-build checks) | PASS |
| AC-10 | No opencode-specific content (no commands/, package.json, plugin.ts) | PASS |
| AC-11 | Source files not modified by build | PASS |
| AC-12 | Test added to CI pipeline (`test-claude-code` job in validate.yml) | PASS |
| AC-13 | Test exits 0 with 0 failures | PASS |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| gate-build | SKIP | 0/0/0 — no build/test commands configured |
| gate-tests | WARN | 0/1/0 — hardcoded counts (accepted project pattern) |
| gate-security | PASS | 0/0/0 |
| gate-wiring | PASS | 0/0/0 |
| gate-spec | PASS | 0/0/0 — 13/13 criteria mapped |

## Evidence

- `build-report.md` — SKIP (no commands configured)
- `test-quality.md` — WARN (hardcoded counts match opencode test pattern)
- `security-report.md` — PASS (no secrets, no injection, safe CI config)
- `wiring-report.md` — PASS (test integrated in CI, no orphans)
- `spec-compliance.md` — PASS (13/13 criteria with file:line evidence)

## Work Unit

`claude-code-tests` — unit 2 of 3 in `audit-remediation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)