### PR TITLE
refactor(evals): remove unnecessary plugin_dir threading

### DIFF
--- a/evals/__main__.py
+++ b/evals/__main__.py
@@ -64,16 +64,6 @@ def main(args=None):
         metavar="PATH",
         help="Serve a results directory in the browser",
     )
-    # Auto-detect plugin dir: evals/ -> repo root -> adapters/claude-code
-    _default_plugin_dir = os.path.abspath(
-        os.path.join(_EVALS_DIR, "..", "adapters", "claude-code")
-    )
-    parser.add_argument(
-        "--plugin-dir",
-        metavar="PATH",
-        default=_default_plugin_dir if os.path.isdir(_default_plugin_dir) else None,
-        help="Path to Specwright plugin directory (default: auto-detected from repo)",
-    )
     parser.add_argument(
         "--timeout",
         type=int,
@@ -139,7 +129,6 @@ def main(args=None):
         timeout=parsed.timeout,
         case_filter=parsed.case,
         dry_run=parsed.dry_run,
-        plugin_dir=parsed.plugin_dir,
         results_dir=parsed.results_dir,
     )
 

--- a/evals/framework/chainer.py
+++ b/evals/framework/chainer.py
@@ -26,7 +26,6 @@ def run_sequence(
     timeout_per_skill: int = 300,
     capture_between: bool = True,
     snapshot_base_dir: Optional[str] = None,
-    plugin_dir: Optional[str] = None,
 ) -> ChainResult:
     """Invoke skills sequentially in the same working directory.
 
@@ -36,7 +35,6 @@ def run_sequence(
     Args:
         snapshot_base_dir: Parent directory for snapshots. If None, uses
             tempfile.mkdtemp(). Callers control cleanup via snapshot_dirs.
-        plugin_dir: Optional path to plugin directory, forwarded to runner.
     """
     result = ChainResult()
 
@@ -47,7 +45,6 @@ def run_sequence(
             prompt=prompt,
             workdir=workdir,
             timeout=timeout_per_skill,
-            plugin_dir=plugin_dir,
         )
         result.steps.append(run_result)
 

--- a/evals/framework/orchestrator.py
+++ b/evals/framework/orchestrator.py
@@ -163,7 +163,6 @@ def run_single_eval(
     results_dir: str,
     runner,
     timeout: int = 300,
-    plugin_dir: Optional[str] = None,
     suite_dir: Optional[str] = None,
 ) -> None:
     """Run a single eval case trial: setup, execute, grade, write results."""
@@ -218,8 +217,7 @@ def run_single_eval(
                     prompt=resolved_prompt,
                     workdir=workdir,
                     timeout=timeout,
-                    plugin_dir=plugin_dir,
-                )
+                    )
             else:
                 skills = eval_case.get("sequence") or eval_case.get("workflow") or []
                 prompts_dict = _resolve_prompts_layer2(eval_case)
@@ -229,8 +227,7 @@ def run_single_eval(
                     prompts=prompts_dict,
                     workdir=workdir,
                     timeout_per_skill=timeout,
-                    plugin_dir=plugin_dir,
-                )
+                    )
                 snapshots = chain_result.snapshots
 
         except Exception as exc:
@@ -260,7 +257,6 @@ def run_eval_suite(
     timeout: int = 300,
     case_filter: Optional[str] = None,
     dry_run: bool = False,
-    plugin_dir: Optional[str] = None,
     results_dir: Optional[str] = None,
 ) -> str:
     """Load evals.json, iterate cases x trials, aggregate, return results_dir."""
@@ -321,7 +317,6 @@ def run_eval_suite(
                 results_dir=results_dir,
                 runner=runner,
                 timeout=timeout,
-                plugin_dir=plugin_dir,
                 suite_dir=os.path.dirname(os.path.abspath(suite_path)),
             )
 

--- a/evals/framework/runner.py
+++ b/evals/framework/runner.py
@@ -54,7 +54,6 @@ class ToolRunner(ABC):
         prompt: str,
         workdir: Optional[str] = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
-        plugin_dir: Optional[str] = None,
     ) -> RunResult:
         """Run a skill with the given prompt and return a RunResult."""
 
@@ -64,12 +63,11 @@ class ToolRunner(ABC):
 # ---------------------------------------------------------------------------
 
 _VERBOSE_FLAG = "--verbose"
-_PLUGIN_DIR_FLAG = "--plugin-dir"
 
 
-def _build_command(prompt: str, plugin_dir: Optional[str] = None) -> List[str]:
+def _build_command(prompt: str) -> List[str]:
     """Build the claude subprocess command list."""
-    cmd = [
+    return [
         _CLAUDE_BINARY,
         _PROMPT_FLAG,
         prompt,
@@ -77,9 +75,6 @@ def _build_command(prompt: str, plugin_dir: Optional[str] = None) -> List[str]:
         _OUTPUT_FORMAT_VALUE,
         _VERBOSE_FLAG,
     ]
-    if plugin_dir is not None:
-        cmd.extend([_PLUGIN_DIR_FLAG, plugin_dir])
-    return cmd
 
 
 def _build_env() -> Dict[str, str]:
@@ -165,13 +160,12 @@ class ClaudeCodeRunner(ToolRunner):
         prompt: str,
         workdir: Optional[str] = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
-        plugin_dir: Optional[str] = None,
     ) -> RunResult:
         """Invoke the claude binary for the given skill and return a RunResult.
 
         Raises FileNotFoundError if the claude binary is not on PATH.
         """
-        cmd = _build_command(prompt, plugin_dir=plugin_dir)
+        cmd = _build_command(prompt)
         env = _build_env()
 
         try:

--- a/evals/tests/test_orchestrator.py
+++ b/evals/tests/test_orchestrator.py
@@ -125,13 +125,12 @@ class MockRunner(ToolRunner):
         self._result = result or _make_run_result()
         self._side_effect = side_effect
 
-    def run_skill(self, skill, prompt, workdir=None, timeout=300, plugin_dir=None):
+    def run_skill(self, skill, prompt, workdir=None, timeout=300):
         self.calls.append({
             "skill": skill,
             "prompt": prompt,
             "workdir": workdir,
             "timeout": timeout,
-            "plugin_dir": plugin_dir,
         })
         if self._side_effect:
             effect = self._side_effect.pop(0)


### PR DESCRIPTION
## Summary

Remove `plugin_dir` parameter that was threaded through the entire eval stack (runner → chainer → orchestrator → CLI). Plugin loading is handled by the global `~/.claude/settings.json` `enabledPlugins` config — `claude -p` automatically loads enabled plugins without needing `--plugin-dir`.

## Changes

- 19 occurrences removed across 5 files
- `_build_command()` simplified back to fixed arg list
- `ToolRunner.run_skill()` signature simplified
- `--plugin-dir` CLI flag removed
- `MockRunner` in tests simplified

## Test Summary

443 tests passing, 1 skipped, 3 deselected (integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)