### PR TITLE
fix(ci): make release workflow idempotent on re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,10 +119,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Clean up stale branch/PR from previous failed runs
-          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
           if [ -n "$EXISTING_PR" ]; then
-            gh pr close "$EXISTING_PR" --delete-branch || true
-          elif git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            gh pr close "$EXISTING_PR" --comment "Superseded by release workflow re-run" || true
+          fi
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
             git push origin --delete "$BRANCH" || true
           fi
 


### PR DESCRIPTION
## Summary
- Adds cleanup logic to the release workflow so re-runs don't fail with non-fast-forward rejection
- If a stale PR exists from a previous failed run, it's closed and its branch deleted
- If only a stale branch exists (no PR), the branch is deleted before re-creation

## Context
The release workflow (`release.yml`) pushes a `release/v{VERSION}` branch and then creates a PR. If the PR creation fails (e.g., due to a permissions issue), re-running the workflow fails at `git push` because the stale branch already exists with a different commit SHA.

## Test plan
- [ ] Re-run the release workflow after a simulated failure — should succeed
- [ ] Run the release workflow fresh — should behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)