### PR TITLE
fix(ci): use OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -89,5 +89,3 @@ jobs:
       - name: Publish to npm
         if: env.SKIP_PUBLISH != 'true'
         run: cd dist/opencode && npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` from the npm publish step so npm uses OIDC trusted publishing instead of token auth
- The package has trusted publishing configured on npmjs.com, but the `NODE_AUTH_TOKEN` env var was causing npm to use token auth, which hit the 2FA requirement wall (E403)
- The `id-token: write` permission is already configured on the job

## Context
v0.25.0 publish failed ([run #23779560374](https://github.com/Obsidian-Owl/specwright/actions/runs/23779560374)) because npm's granular access tokens have a [known bug](https://github.com/npm/cli/issues/8869) where the "Bypass 2FA" checkbox doesn't take effect.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the v0.25.0 release finalize workflow (`gh run rerun 23779560374 --failed`)
- [ ] Verify `@obsidian-owl/opencode-specwright@0.25.0` appears on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)