### PR TITLE
fix(ci): remove registry-url to enable OIDC publish

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Build opencode adapter
         run: ./build/build.sh opencode


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `actions/setup-node` — it creates an `.npmrc` with `NODE_AUTH_TOKEN` reference that causes npm to use token auth instead of OIDC
- Follow-up to #124 which removed the explicit `NODE_AUTH_TOKEN` env var but didn't address the `.npmrc` created by `setup-node`

## Context
v0.25.1 publish failed with E404 because the `.npmrc` from `setup-node` was still injecting the `NPM_TOKEN` secret as token auth, preventing OIDC trusted publishing from activating.

## Test plan
- [ ] Merge this PR
- [ ] Delete `NPM_TOKEN` secret from repo settings
- [ ] Cut v0.25.2 release and verify publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)