### PR TITLE
fix(ci): configure OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -71,7 +71,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
 
       - name: Build opencode adapter
         run: ./build/build.sh opencode


### PR DESCRIPTION
## Summary
- Bump Node from 20.x to 22.x (npm 10.x on Node 20 lacks OIDC support)
- Add `npm install -g npm@latest` to ensure npm 11.5.1+ for OIDC
- Restore `registry-url` in setup-node (npm needs it to know where to publish)
- `NODE_AUTH_TOKEN` remains removed (#124) so OIDC activates instead of token auth

## Context
v0.25.0–v0.25.2 publishes all failed. Root cause was three-fold:
1. npm granular tokens can't bypass 2FA ([npm/cli#8869](https://github.com/npm/cli/issues/8869))
2. `NODE_AUTH_TOKEN` made npm use token auth instead of OIDC (#124 fixed)
3. npm 10.x (Node 20) doesn't support OIDC trusted publishing (#126 partially fixed)

## Test plan
- [ ] Merge this PR
- [ ] Delete `NPM_TOKEN` secret: `gh secret delete NPM_TOKEN --repo Obsidian-Owl/specwright`
- [ ] Cut release and verify publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)