### PR TITLE
fix(ci): pin npm@10 to avoid MODULE_NOT_FOUND on Node 22.22.2

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -75,7 +75,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@10
 
       - name: Build opencode adapter
         run: ./build/build.sh opencode


### PR DESCRIPTION
## Summary

- Pins `npm install -g npm@latest` to `npm@10` in the release-finalize workflow
- Fixes `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` error on ubuntu-latest runners with Node 22.22.2

## Root Cause

Node 22.22.2's bundled npm has a broken `promise-retry` dependency. When `npm install -g npm@latest` runs, the bundled npm fails before it can self-upgrade. Pinning to `npm@10` (latest LTS major) avoids the broken bootstrap.

## Test plan

- [x] Verified the workflow file change is a single-line pin
- [ ] Re-run release-finalize workflow after merge to confirm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)