### PR TITLE
fix(ci): pin npm@11 for provenance publish compatibility

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -75,7 +75,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@10
+        run: npm install -g npm@11
 
       - name: Build opencode adapter
         run: ./build/build.sh opencode


### PR DESCRIPTION
## Summary

Changes `npm install -g npm@10` to `npm install -g npm@11` in the release-finalize workflow.

## Root Cause

PR #132 pinned to `npm@10` to fix the Node 22.22.2 `promise-retry` bootstrap bug. However, `npm@10`'s provenance bundle format is rejected by the npm registry (`E404` on PUT) — this is what caused the v0.26.1 publish failure.

v0.25.3 succeeded because `npm@latest` resolved to `npm@11.x` at that time. Pinning to `npm@11` fixes both issues:
- Avoids the broken bundled npm bootstrap (Node 22.22.2)
- Uses the provenance format the registry accepts

## Test plan

- [ ] Merge and cut a release to verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)