### PR TITLE
feat(04-pipeline-skill-cutover): ship unit 04 pipeline skill cutover

### DIFF
--- a/core/skills/gate-build/SKILL.md
+++ b/core/skills/gate-build/SKILL.md
@@ -23,12 +23,12 @@ else matters.
 
 - `.specwright/config.json` -- `commands.build`, `commands.test`,
   `commands.test:integration`, `commands.test:smoke`
-- `.specwright/state/workflow.json` -- current work unit for evidence path
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit for evidence path
 
 ## Outputs
 
-- Evidence file at `{currentWork.workDir}/evidence/build-report.md`
-- Gate status update in workflow.json: PASS, FAIL, WARN, or SKIP
+- Evidence file at `{workDir}/evidence/build-report.md`
+- Gate status update in the selected work's `workflow.json`: PASS, FAIL, WARN, or SKIP
 - Console output showing results inline (users see findings, not just badges)
 
 ## Constraints
@@ -65,7 +65,7 @@ stdout/stderr output, and duration (elapsed wall time). Per-tier sections are
 written regardless of tier outcome.
 
 - Follow `protocols/evidence.md#verdict-rendering` for verdict rendering.
-- Update `workflow.json` gates section per `protocols/state.md`.
+- Update the selected work's `workflow.json` gates section per `protocols/state.md`.
 
 ## Protocol References
 

--- a/core/skills/gate-security/SKILL.md
+++ b/core/skills/gate-security/SKILL.md
@@ -23,13 +23,13 @@ judgment for analysis that tools can't do.
 ## Inputs
 
 - `.specwright/config.json` -- `commands.lint`, SAST tool config if available
-- `.specwright/state/workflow.json` -- current work unit
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Changed files (detected via `git diff`)
 
 ## Outputs
 
-- Evidence file at `{currentWork.workDir}/evidence/security-report.md`
-- Gate status in workflow.json
+- Evidence file at `{workDir}/evidence/security-report.md`
+- Gate status in the selected work's `workflow.json`
 - Findings shown inline with severity, location, and remediation
 
 ## Constraints

--- a/core/skills/gate-semantic/SKILL.md
+++ b/core/skills/gate-semantic/SKILL.md
@@ -23,13 +23,13 @@ premises, claims, and conclusion grounded in file:line evidence.
 ## Inputs
 
 - `config.json` `gates.semantic` — categories, tools, optional `rulesDir`
-- `workflow.json` — current work unit
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` — selected work unit
 - Changed files via `git diff --name-only $(git merge-base HEAD <baseBranch>)`
 
 ## Outputs
 
-- `{currentWork.workDir}/evidence/semantic-report.md`
-- Gate status in workflow.json
+- `{workDir}/evidence/semantic-report.md`
+- Gate status in the selected work's `workflow.json`
 
 ## Constraints
 

--- a/core/skills/gate-spec/SKILL.md
+++ b/core/skills/gate-spec/SKILL.md
@@ -24,15 +24,15 @@ that closes the loop.
 
 ## Inputs
 
-- `{currentWork.workDir}/spec.md` -- acceptance criteria
-- `.specwright/state/workflow.json` -- current work unit
+- `{workDir}/spec.md` -- acceptance criteria
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - The codebase (implementation and tests)
 
 ## Outputs
 
-- Evidence file at `{currentWork.workDir}/evidence/spec-compliance.md`
+- Evidence file at `{workDir}/evidence/spec-compliance.md`
 - Compliance matrix: each criterion → implementation ref + test ref + status
-- Gate status in workflow.json
+- Gate status in the selected work's `workflow.json`
 
 ## Constraints
 

--- a/core/skills/gate-tests/SKILL.md
+++ b/core/skills/gate-tests/SKILL.md
@@ -25,13 +25,13 @@ test quality, not just pass/fail.
 
 - `.specwright/config.json` -- test commands, project language
 - `.specwright/TESTING.md` -- testing strategy with boundary classifications (optional)
-- `.specwright/state/workflow.json` -- current work unit
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Test files in the codebase
 
 ## Outputs
 
-- Evidence file at `{currentWork.workDir}/evidence/test-quality.md`
-- Gate status in workflow.json
+- Evidence file at `{workDir}/evidence/test-quality.md`
+- Gate status in the selected work's `workflow.json`
 - Findings organized by category with specific file:line references
 
 ## Constraints

--- a/core/skills/gate-wiring/SKILL.md
+++ b/core/skills/gate-wiring/SKILL.md
@@ -24,13 +24,13 @@ can still be wired incorrectly.
 ## Inputs
 
 - `.specwright/config.json` -- architecture layers, project structure
-- `.specwright/state/workflow.json` -- current work unit
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Changed files (via `git diff`)
 
 ## Outputs
 
-- Evidence file at `{currentWork.workDir}/evidence/wiring-report.md`
-- Gate status in workflow.json
+- Evidence file at `{workDir}/evidence/wiring-report.md`
+- Gate status in the selected work's `workflow.json`
 - Findings with specific file:line references and remediation
 
 ## Constraints
@@ -63,8 +63,8 @@ invisible to per-unit analysis: missing cross-unit imports, interface mismatches
 disconnected entry points.
 
 *Activation predicate* — all four conditions must be true:
-1. `workUnits` array exists in workflow.json (multi-unit work)
-2. `currentWork.baselineCommit` is non-null
+1. `workUnits` array exists in the selected work's workflow.json (multi-unit work)
+2. `selectedWork.baselineCommit` is non-null
 3. `git cat-file -t {baselineCommit}` exits 0 (commit is reachable)
 4. All `workUnits` entries except the current `unitId` have status `shipped` or
    `abandoned`, AND at least one non-current unit has status `shipped` (if all

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -27,9 +27,10 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 
 ## Inputs
 
-- `.specwright/state/workflow.json`, `{currentWork.workDir}/spec.md`, `{currentWork.workDir}/plan.md`
-- `.specwright/work/{currentWork.id}/design.md`, `{currentWork.workDir}/context.md`
-- `.specwright/CONSTITUTION.md`, `.specwright/config.json`
+- `{worktreeStateRoot}/session.json` -- selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json`, `{workDir}/spec.md`, `{workDir}/plan.md`
+- `{repoStateRoot}/work/{selectedWork.id}/design.md`, `{workDir}/context.md`
+- `{repoStateRoot}/CONSTITUTION.md`, `{repoStateRoot}/config.json`
 
 ## Outputs
 
@@ -42,7 +43,13 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 
 **Stage boundary (LOW freedom):** Follow `protocols/stage-boundary.md`. Implement only the active unit; never create pull requests, run `gh pr create`, or invoke `/sw-ship`. Before the terminal handoff, write `{workDir}/stage-report.md`; the handoff points at it and the Next line is `Next: /sw-verify`.
 
-**Branch setup (LOW freedom):** First action before coding: check out the feature branch from `config.git.branchPrefix` and sync it per `protocols/git.md`. Use `{git.branchPrefix}{currentWork.unitId}` for multi-unit work and never commit to the base branch.
+**Branch setup (LOW freedom):** First action before coding: resolve the
+session-selected work from the current worktree, verify that no other live
+top-level worktree owns it, then check out the feature branch from
+`config.git.branchPrefix` and sync it per `protocols/git.md`. Use
+`{git.branchPrefix}{selectedWork.unitId}` for multi-unit work and never commit
+to the base branch. If the selected work is already owned elsewhere, STOP with
+explicit adopt/takeover guidance instead of mutating it silently.
 
 **Task loop (MEDIUM freedom):** Work one task at a time. Finish it before starting the next and emit a status card after each task commit.
 
@@ -60,9 +67,9 @@ Per-task integration and regression runs do not happen inside this loop.
 
 **After-build (MEDIUM freedom):** Optional end-of-unit phase only. Delegate post-build review, then run `commands.test` and `commands.test:integration` when configured; integration now runs here once per unit, not per task. On failure, use `specwright-build-fixer` (max 2 attempts); if it still fails, surface it to the user in interactive mode and skip with a recorded note in headless mode.
 
-**Task tracking (LOW freedom):** When Claude Code task tools are available, create and update task records, but keep `workflow.json` as the source of truth. Tracking failures never block the build.
+**Task tracking (LOW freedom):** When Claude Code task tools are available, create and update task records, but keep the selected work's `workflow.json` as the source of truth. Tracking failures never block the build.
 
-**State updates (LOW freedom):** Follow `protocols/state.md`: acquire the lock before mutations, update `tasksCompleted` after each committed task, and append as-built notes before handoff.
+**State updates (LOW freedom):** Follow `protocols/state.md`: acquire the per-work lock on the selected work before mutations, update the selected work's `tasksCompleted` after each committed task, refresh `currentTask`, and append as-built notes before handoff. Mutate only the selected work's `workflow.json` and the current worktree's session state.
 
 **Parallel execution (MEDIUM freedom):** Only use `protocols/parallel-build.md` when the experimental config flag enables it; otherwise ignore it and stay sequential.
 
@@ -82,8 +89,9 @@ Per-task integration and regression runs do not happen inside this loop.
 | Condition | Action |
 |-----------|--------|
 | No active work unit | STOP: "Run /sw-design and /sw-plan first" |
+| Selected work owned by another live top-level worktree | STOP with explicit adopt/takeover guidance |
 | Build/test command not configured | STOP: "Configure commands in config.json or run /sw-init" |
 | Tester writes tests that pass immediately | Re-delegate RED with stronger failing cases |
 | Executor reports a pre-existing type/signature mismatch | STOP and surface the plan mismatch |
 | Build-fixer exhausts 2 attempts | STOP and show the failure |
-| Lock held by another skill | STOP with lock info |
+| Per-work lock held by another skill | STOP with lock info |

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -109,6 +109,9 @@ Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:
   worktree:
   `Clearing prior shipped work {unitId}. Run /sw-learn first if pattern capture is desired.`
   The notice is informational only; `sw-learn` remains optional.
+- During legacy fallback migration, if prior `currentWork` has status `shipped`,
+  clear that legacy attachment and reset `workUnits` to null before retargeting
+  this worktree.
 - The new selected work's `workflow.json.status` is `designing`.
 - The new selected work's `baselineCommit` is the SHA of
   `origin/{config.git.baseBranch}` (default `origin/main`). Captures base branch

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -25,15 +25,16 @@ between research and gate handoff, applying `protocols/decision.md` for all deci
 ## Inputs
 
 - The user's request (argument or conversation)
-- `.specwright/CONSTITUTION.md` -- practices to follow
-- `.specwright/CHARTER.md` -- vision and invariants
-- `.specwright/config.json` -- project configuration
-- `.specwright/state/workflow.json` -- current state
+- `{repoStateRoot}/CONSTITUTION.md` -- practices to follow
+- `{repoStateRoot}/CHARTER.md` -- vision and invariants
+- `{repoStateRoot}/config.json` -- project configuration
+- `{worktreeStateRoot}/session.json` -- current worktree attachment, when present
+- `{repoStateRoot}/work/*/workflow.json` -- other active works for collision checks
 - The codebase itself
 
 ## Outputs
 
-When complete, ALL of the following exist in `.specwright/work/{id}/`:
+When complete, ALL of the following exist in `{repoStateRoot}/work/{id}/`:
 
 - `stage-report.md` -- design handoff digest with attention-required at the top
 - `design.md` -- solution overview, approach, integration points, risk assessment
@@ -97,24 +98,23 @@ artifact, `context.md`). The Next line remains machine-parseable: `Next: /sw-pla
 
 **State mutations (LOW freedom):**
 Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:
-- If prior `currentWork` has status `abandoned`: cleared to null, `workUnits` reset to null (prevents stale multi-unit data from triggering cross-unit checks).
-- If prior `currentWork` has status `shipped`:
-  - **With a new-work argument**: clear `currentWork` to null AND reset
-    `workUnits` to null (mirroring the abandoned-path mutation). Before
-    clearing, print exactly one informational notice:
-    `Clearing prior shipped work {unitId}. Run /sw-learn first if pattern capture is desired.`
-    The notice is a print, not a confirmation prompt — the clear proceeds.
-    sw-learn remains optional and may be invoked separately if desired.
-  - **With no argument**: do NOT clear. Shipped work is terminal — the
-    design artifacts are not a change-request surface. Present the shipped
-    status at the gate with the PR URL and the next action (start new
-    work with an argument, or run `/sw-build` for the next queued unit if
-    one exists). Record the interpretation in decisions.md. The Failure
-    Modes "Active work in progress → continue existing" path does NOT
-    apply to shipped work.
-- `currentWork.status` is `designing`. Work directory created at `.specwright/work/{id}/`.
-- `currentWork.baselineCommit` is the SHA of `origin/{config.git.baseBranch}` (default `origin/main`). Captures base branch HEAD before any work begins — used by gate-wiring for cross-unit verification. Never overwritten on re-entry (change request).
-- `baselineCommit` also written to `{workDir}/context.md` for historical reference (persists after sw-learn clears currentWork).
+- New work created at `{repoStateRoot}/work/{id}/`.
+- `{worktreeStateRoot}/session.json.attachedWorkId` is set to the new work ID for
+  the current worktree only.
+- Do not clear or rewrite unrelated active works in other top-level worktrees.
+  Starting a new design in this worktree changes only this worktree's session
+  attachment.
+- If this worktree was previously attached to a shipped work and the user starts
+  a new design, print exactly one informational notice before retargeting this
+  worktree:
+  `Clearing prior shipped work {unitId}. Run /sw-learn first if pattern capture is desired.`
+  The notice is informational only; `sw-learn` remains optional.
+- The new selected work's `workflow.json.status` is `designing`.
+- The new selected work's `baselineCommit` is the SHA of
+  `origin/{config.git.baseBranch}` (default `origin/main`). Captures base branch
+  HEAD before any work begins and is never overwritten on re-entry.
+- `baselineCommit` also written to `{workDir}/context.md` for historical
+  reference.
 
 ## Protocol References
 

--- a/core/skills/sw-learn/SKILL.md
+++ b/core/skills/sw-learn/SKILL.md
@@ -25,10 +25,11 @@ work benefits.
 
 ## Inputs
 
-- `.specwright/state/workflow.json` -- current work unit (should be shipped)
-- `{currentWork.workDir}/evidence/` -- gate evidence files
-- `{currentWork.workDir}/plan.md` -- architecture decisions
-- `.specwright/CONSTITUTION.md` -- existing practices
+- `{worktreeStateRoot}/session.json` -- selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- current work unit (should be shipped)
+- `{workDir}/evidence/` -- gate evidence files
+- `{workDir}/plan.md` -- architecture decisions
+- `{repoStateRoot}/CONSTITUTION.md` -- existing practices
 - `.specwright/learnings/` -- prior work unit learnings (for retrospective)
 - Git log for the work unit's commits
 
@@ -99,15 +100,21 @@ work benefits.
 - Per `protocols/learning-lifecycle.md`. If auto-memory directory doesn't exist or system prompt doesn't mention auto-memory, silently fall back to patterns.md only.
 
 **State cleanup (LOW freedom):**
-- Before clearing, verify `currentWork.status` is `shipped`. If it is anything else (e.g. `building`, `verifying`), STOP with: "State cleanup requires status 'shipped'. Current status: {status}. Complete the current build cycle before running /sw-learn."
-- After ALL persistence steps complete successfully (learnings JSON write, LANDSCAPE.md update, AUDIT.md resolution), clear the workflow state:
-  - Acquire lock per `protocols/state.md` (set `lock: {skill: "sw-learn", since: "<ISO>"}`) before other mutations.
+- Resolve the selected work from the current worktree session. If another live
+  top-level worktree owns it, STOP with explicit adopt/takeover guidance.
+- Before clearing, verify the selected work's status is `shipped`. If it is
+  anything else (e.g. `building`, `verifying`), STOP with:
+  "State cleanup requires status 'shipped'. Current status: {status}. Complete the current build cycle before running /sw-learn."
+- After ALL persistence steps complete successfully (learnings JSON write,
+  LANDSCAPE.md update, AUDIT.md resolution), clear the current worktree session
+  attachment:
+  - Acquire the selected work lock per `protocols/state.md` before other mutations.
   - Follow `protocols/state.md` read-modify-write sequence.
-  - Set `currentWork` to `null`.
-  - Set `gates` to `{}`.
-  - Preserve the `workUnits` array (historical reference for future retrospectives).
-  - Release lock.
-- If ANY persistence step fails (learnings write, landscape update, audit resolution): STOP with error. Do NOT clear `currentWork`. The user must fix the failure and re-run `/sw-learn`.
+  - Set `{worktreeStateRoot}/session.json.attachedWorkId` to `null`.
+  - Clear the selected work's attachment record and release the lock.
+  - Preserve the selected work record, `workUnits`, `gates`, and shipped
+    history for future retrospectives.
+- If ANY persistence step fails (learnings write, landscape update, audit resolution): STOP with error. Do NOT clear the current worktree session attachment. The user must fix the failure and re-run `/sw-learn`.
 - This is the `shipped → (none)` transition defined in `protocols/state.md`.
 
 ## Protocol References

--- a/core/skills/sw-pivot/SKILL.md
+++ b/core/skills/sw-pivot/SKILL.md
@@ -25,25 +25,29 @@ and recorded in decisions.md — the revised plan is the artifact.
 
 ## Inputs
 
-- `.specwright/state/workflow.json` — `tasksCompleted`, `tasksTotal`, `workDir`
-- `{currentWork.workDir}/spec.md` — full spec (completed + remaining)
-- `{currentWork.workDir}/plan.md` — task breakdown
+- `{worktreeStateRoot}/session.json` — selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` — `tasksCompleted`, `tasksTotal`, `workDir`
+- `{workDir}/spec.md` — full spec (completed + remaining)
+- `{workDir}/plan.md` — task breakdown
 - Pivot reason (argument or conversation)
 
 ## Outputs
 
 - `spec.md` — appended with `## Revision` section
 - `plan.md` — appended with `## Pivot Note` section
-- `workflow.json` — remaining tasks updated
+- selected work's `workflow.json` — remaining tasks updated
 - `decisions.md` — pivot decisions recorded
 
 ## Constraints
 
 **Pre-condition (LOW freedom):**
-Status must be `building`. If all tasks done: STOP — "Run /sw-verify."
+Resolve the selected work from the current worktree session. Status must be
+`building`. If all tasks are done: STOP — "Run /sw-verify." If another live
+top-level worktree owns the selected work, STOP with explicit
+adopt/takeover guidance.
 
 **Snapshot (LOW freedom):**
-Read tasksCompleted, present done vs. remaining.
+Read the selected work's `tasksCompleted`, present done vs. remaining.
 
 **Pivot input (MEDIUM freedom):**
 If argument provided, use it as the pivot reason. If no argument, infer from
@@ -56,9 +60,11 @@ completed criteria: reject and re-delegate (max 2 attempts).
 
 **Apply (MEDIUM freedom):**
 Auto-apply revision. Append revision to spec.md and pivot note to plan.md. Update
-workflow.json. Record scope (% tasks changed) and rationale in decisions.md. The
-revised plan is the artifact — sw-build resumes from it, verify validates the result.
-NEVER overwrite existing content — append only.
+the selected work's `workflow.json`. Record scope (% tasks changed) and
+rationale in decisions.md. The revised plan is the artifact — sw-build resumes
+from it, verify validates the result. Mutate only the selected work's
+workflow state; never rewrite unrelated active works. NEVER overwrite existing
+content — append only.
 
 **Stage boundary (LOW freedom):**
 Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
@@ -76,6 +82,7 @@ Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
 | Condition | Action |
 |-----------|--------|
 | Status not `building` | STOP: "sw-pivot only valid during active sw-build" |
+| Selected work owned by another live top-level worktree | STOP with explicit adopt/takeover guidance |
 | All tasks completed | STOP: "Run /sw-verify" |
 | Architect modifies completed criteria | Reject, re-delegate (max 2) |
-| Compaction during pivot | Read workflow.json, check if revision was applied |
+| Compaction during pivot | Read the selected work's workflow.json, check if revision was applied |

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -24,21 +24,22 @@ applying `protocols/decision.md` for all decisions. Gate handoff at the end.
 
 ## Inputs
 
-- `.specwright/state/workflow.json` -- current state (must be `designing` or `planning`)
-- `.specwright/work/{currentWork.id}/design.md` -- approved solution design
-- `.specwright/work/{currentWork.id}/context.md` -- research findings from sw-design
-- `.specwright/work/{currentWork.id}/decisions.md` -- design-phase decisions
+- `{worktreeStateRoot}/session.json` -- selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work state
+- `{repoStateRoot}/work/{selectedWork.id}/design.md` -- approved solution design
+- `{repoStateRoot}/work/{selectedWork.id}/context.md` -- research findings from sw-design
+- `{repoStateRoot}/work/{selectedWork.id}/decisions.md` -- design-phase decisions
 - Conditional design artifacts: `data-model.md`, `contracts.md`, `testing-strategy.md`, `infra.md`, `migrations.md`
-- `.specwright/CONSTITUTION.md` -- practices to follow
-- `.specwright/config.json` -- project configuration
+- `{repoStateRoot}/CONSTITUTION.md` -- practices to follow
+- `{repoStateRoot}/config.json` -- project configuration
 
 ## Outputs
 
-**Single-unit work**: `spec.md` + `plan.md` in `.specwright/work/{id}/` (flat layout).
+**Single-unit work**: `spec.md` + `plan.md` in `{repoStateRoot}/work/{selectedWork.id}/` (flat layout).
 
-**Multi-unit work**: For each unit in `.specwright/work/{id}/units/{unit-id}/`:
+**Multi-unit work**: For each unit in `{repoStateRoot}/work/{selectedWork.id}/units/{unit-id}/`:
 `spec.md` + `plan.md` + `context.md`. `workUnits` array in workflow.json.
-Also: `integration-criteria.md` in the design-level directory (`.specwright/work/{id}/`).
+Also: `integration-criteria.md` in the design-level directory (`{repoStateRoot}/work/{selectedWork.id}/`).
 
 Also: `{workDir}/stage-report.md` for the planning handoff.
 
@@ -51,7 +52,9 @@ Follow `protocols/stage-boundary.md`. Produce specs and plans. NEVER implement, 
 test, or commit. After gate handoff, STOP.
 
 **Pre-condition check (LOW freedom):**
-Check `currentWork.status` is `designing` or `planning` and `design.md` exists.
+Resolve the selected work from the current worktree session. Check that
+`selectedWork.status` is `designing` or `planning` and `design.md` exists.
+`sw-plan` operates on the current worktree's attached work only.
 
 **Decompose (MEDIUM freedom, only if large):**
 - Assess whether the design requires multiple work units. Apply autonomously — use
@@ -63,7 +66,7 @@ Check `currentWork.status` is `designing` or `planning` and `design.md` exists.
 
 **Integration criteria (MEDIUM freedom, multi-unit only):**
 - When decomposing into multiple work units, also write `integration-criteria.md` in
-  the design-level directory (`.specwright/work/{currentWork.id}/`). Not generated for
+  the design-level directory (`{repoStateRoot}/work/{selectedWork.id}/`). Not generated for
   single-unit work.
 - Two IC types coexist in `integration-criteria.md`: structural (IC-{n}) and behavioral
   (IC-B{n}). Both types go to the same file.
@@ -125,9 +128,12 @@ unit, `integration-criteria.md` for multi-unit work). The Next line remains
 machine-parseable: `Next: /sw-build`.
 
 **State mutations (LOW freedom):**
-Follow `protocols/state.md`. Transition `designing` → `planning`. Multi-unit: populate
-workUnits array, set first unit to `building`, transition to `building`, handoff to
-`/sw-build`.
+Follow `protocols/state.md`. Mutate only the selected work's `workflow.json` and
+the current worktree's `session.json`. Transition `designing` → `planning`.
+Multi-unit: populate the selected work's `workUnits` array, set the first unit
+to `building`, transition the selected work to `building`, and hand off to
+`/sw-build`. Do not clear or retarget unrelated active works owned by other
+top-level worktrees.
 
 ## Protocol References
 

--- a/core/skills/sw-ship/SKILL.md
+++ b/core/skills/sw-ship/SKILL.md
@@ -22,16 +22,17 @@ human gate — reviewers verify before merge.
 
 ## Inputs
 
-- `.specwright/state/workflow.json` -- current work unit, gate results
-- `{currentWork.workDir}/spec.md` -- acceptance criteria for PR body
-- `{currentWork.workDir}/evidence/` -- gate evidence files
-- `.specwright/config.json` -- git config (PR tool, branch prefix, main branch)
+- `{worktreeStateRoot}/session.json` -- selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit, gate results
+- `{workDir}/spec.md` -- acceptance criteria for PR body
+- `{workDir}/evidence/` -- gate evidence files
+- `{repoStateRoot}/config.json` -- git config (PR tool, branch prefix, main branch)
 
 ## Outputs
 
-- `{currentWork.workDir}/stage-report.md` -- shipping handoff digest with attention-at-top
+- `{workDir}/stage-report.md` -- shipping handoff digest with attention-at-top
 - Pull request created with evidence-mapped body
-- `workflow.json` currentWork status set to `shipped`
+- Selected work's `workflow.json` status set to `shipped`
 
 ## Constraints
 
@@ -40,9 +41,12 @@ Follow `protocols/stage-boundary.md`. Create PRs and mark shipped. NEVER start n
 work, run builds, or begin next unit. After PR: show URL, suggest `/sw-learn`, handoff.
 
 **Pre-flight checks (LOW freedom):**
-- Verify `currentWork` exists and status is `verifying`. Reject `building` with:
+- Resolve the selected work from the current worktree session. If another live
+  top-level worktree owns it, STOP with explicit adopt/takeover guidance.
+- Verify the selected work exists and status is `verifying`. Reject `building` with:
   "Run /sw-verify first." Reject all other statuses with the standard transition error.
-- All enabled gates in `config.gates` must have a verdict in `workflow.json`. Gates
+- All enabled gates in `config.gates` must have a verdict in the selected work's
+  `workflow.json`. Gates
   without a verdict → STOP: "Gate {name} has no verdict. Run /sw-verify first."
 - No gate verdict may be `FAIL` or `ERROR`. FAIL/ERROR → STOP: "Gate {name} failed.
   Fix and re-run /sw-verify."
@@ -56,10 +60,10 @@ work, run builds, or begin next unit. After PR: show URL, suggest `/sw-learn`, h
 - Follow `protocols/git.md` for push and PR operations.
 - Always create PR (both interactive and headless — PRs are the universal review gate).
 - PR title follows `config.git.commitFormat` style.
-- PR body gate results MUST be sourced from `workflow.json` gate verdicts and
+- PR body gate results MUST be sourced from the selected work's `workflow.json` gate verdicts and
   `{workDir}/evidence/` files. For each enabled gate: read the verdict from
-  `workflow.json`. For non-SKIP gates: read the evidence file. Never infer
-  verdicts from build output — only report what is recorded in `workflow.json`
+  the selected work's `workflow.json`. For non-SKIP gates: read the evidence file. Never infer
+  verdicts from build output — only report what is recorded in the selected work's `workflow.json`
   and backed by an evidence file. SKIP gates show "SKIP".
   (Pre-flight has already verified that all non-SKIP gates have evidence files,
   so this reading step is guaranteed to succeed.)
@@ -69,7 +73,8 @@ work, run builds, or begin next unit. After PR: show URL, suggest `/sw-learn`, h
 
 **State updates (LOW freedom):**
 Follow `protocols/state.md`. State lifecycle for shipping:
-1. After pre-flight passes: set status to `shipping` (write workflow.json).
+1. After pre-flight passes: set the selected work's status to `shipping`
+   (write workflow.json).
 2. Push branch, create PR.
 3. After successful PR creation, write `workUnits[{current unit}].prNumber`
    immediately, inside the same rollback envelope. `prMergedAt` remains null until
@@ -78,7 +83,8 @@ Follow `protocols/state.md`. State lifecycle for shipping:
 5. If push, `gh pr create`, or the `prNumber` write fails: revert status to
    `verifying` (rollback transition) and `prNumber` remains null on failure.
 
-If `workUnits` exists: update entry to `shipped`, advance to next `planned` unit
+If `workUnits` exists: update the selected work's entry to `shipped`, advance to
+next `planned` unit
 (set `building`, reset gates), handoff. If no more units: "All work units complete."
 
 **Gate handoff (LOW freedom):**
@@ -114,5 +120,6 @@ stays machine-parseable). Examples: `Next: /sw-build` or `Next: /sw-learn`.
 | `prNumber` write fails after PR creation | Revert status to `verifying`, keep `prNumber` null, surface rollback failure. |
 | Evidence files missing (pre-flight) | STOP: "Evidence missing for gate {name}. Re-run /sw-verify." |
 | gh CLI not installed | STOP: "Install gh CLI" |
+| Selected work owned elsewhere | STOP with explicit adopt/takeover guidance |
 | Stale shipping state on entry | Status is `shipping` from prior failed attempt. Check `gh pr list --head {branch}` — if PR exists: set `shipped`, show URL. If no PR: revert to `verifying`, suggest re-running /sw-ship. |
 | Compaction during shipping | Recovery reads `shipping` status. Check `gh pr list --head {branch}` — if PR exists: set `shipped`. If no PR: revert to `verifying`. |

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -74,10 +74,32 @@ No fix/skip/abort decisions — the gate handoff presents everything for human r
 Headless: write `headless-result.json`.
 
 **Aggregate report (MEDIUM freedom):**
-After all gates, present: (1) per-finding detail grouped by gate, (2) summary table
-`| Gate | Status | Findings (B/W/I) |`, (3) actionable findings table (WARN → fix
-suggestion, BLOCK → "manual review"). SKIP gates prominently marked. Check escalation
-heuristics per `protocols/evidence.md#verdict-rendering`.
+After all gates, present three tiers:
+1. **Per-finding detail** (first): every BLOCK/WARN grouped by gate — what,
+   why, and recommended action.
+2. **Summary table** (after): `| Gate | Status | Findings (B/W/I) |`
+3. **Actionable Findings** (after summary): only shown when WARN or BLOCK
+   findings exist; omit when all gates PASS. Populate from gate evidence as the
+   source. Include only WARN and BLOCK severity rows, not INFO.
+
+   | # | Gate | Severity | File | Finding | Recommended Fix |
+   |---|------|----------|------|---------|-----------------|
+   | 1 | gate-tests | WARN | src/foo.ts | description | concrete fix suggestion or "manual review" |
+
+   - File column: specific file path from gate evidence, not a vague reference.
+   - Recommended Fix column: WARN rows get concrete, actionable fix suggestions;
+     BLOCK rows that require human judgment get "manual review".
+   - Summary line: state the actionable finding count (`N of M`) and whether any
+     require human judgment before the user proceeds. Wording remains
+     informational — do not imply the skill will perform fixes.
+   - All-manual case: when every actionable finding requires manual review,
+     state that no automated resolution is possible.
+
+SKIP gates prominently marked. Check escalation heuristics per
+`protocols/evidence.md#verdict-rendering`.
+Handoff posture remains three-tiered: BLOCKs → "Fix and re-run `/sw-verify`."
+WARN-only results → "Review, then fix or `/sw-ship`." All PASS →
+"Ready for `/sw-ship`."
 
 **Evidence completeness (LOW freedom):**
 Skip when `--gate=<name>` was used (partial run — only the targeted gate is expected).
@@ -145,6 +167,7 @@ the selected work's `gates` section after each gate completes. Do NOT set
 | Condition | Action |
 |-----------|--------|
 | No active work unit | STOP: "Run /sw-design, /sw-plan, and /sw-build first." |
+| Selected work owned by another live top-level worktree | STOP with explicit adopt/takeover guidance |
 | No gates enabled / all skipped | WARN, proceed to ready-to-ship |
 | Gate skill file not found | ERROR for that gate, continue remaining |
 | Compaction during verification | Read the selected work's workflow.json, resume from next gate without fresh results |

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -23,16 +23,17 @@ gate handoff using `protocols/decision.md` template.
 
 ## Inputs
 
-- `.specwright/state/workflow.json` -- current work unit, previous gate results
-- `.specwright/config.json` -- gate configuration (object or array format)
-- `{currentWork.workDir}/spec.md` -- for spec compliance gate
+- `{worktreeStateRoot}/session.json` -- selected work for this worktree
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit and previous gate results
+- `{repoStateRoot}/config.json` -- gate configuration (object or array format)
+- `{workDir}/spec.md` -- for spec compliance gate
 - Gate skill files in `skills/gate-*/SKILL.md`
 
 ## Outputs
 
-- `{currentWork.workDir}/stage-report.md` -- verify handoff digest with attention-at-top
-- Evidence files in `{currentWork.workDir}/evidence/`, one per gate
-- `workflow.json` gates section updated; status set to `verifying` during run
+- `{workDir}/stage-report.md` -- verify handoff digest with attention-at-top
+- Evidence files in `{workDir}/evidence/`, one per gate
+- Selected work's `workflow.json` gates section updated; status set to `verifying` during run
 - Aggregate report presented at gate handoff
 
 ## Constraints
@@ -40,6 +41,10 @@ gate handoff using `protocols/decision.md` template.
 **Stage boundary (LOW freedom):**
 Follow `protocols/stage-boundary.md`. Run quality gates and show findings. NEVER fix
 code, create PRs, or ship. After gate handoff, STOP.
+
+**Ownership check (LOW freedom):**
+Resolve the selected work from the current worktree session. If another live
+top-level worktree owns that work, STOP with explicit adopt/takeover guidance.
 
 **Assumption re-validation (LOW freedom) — before gate execution:**
 Scan the design assumptions artifact from the design-level directory. Check
@@ -76,7 +81,8 @@ heuristics per `protocols/evidence.md#verdict-rendering`.
 
 **Evidence completeness (LOW freedom):**
 Skip when `--gate=<name>` was used (partial run — only the targeted gate is expected).
-In full mode: check every enabled gate has a status in `workflow.json` `gates.{name}`.
+In full mode: check every enabled gate has a status in the selected work's
+`workflow.json` `gates.{name}`.
 No status and no evidence file → ERROR: "Gate {name} was enabled but produced no
 evidence — gate was not executed."
 
@@ -90,7 +96,7 @@ six gates complete.
 
 When activated:
 - Load `integration-criteria.md` from the design-level directory
-  (`.specwright/work/{currentWork.id}/`). If the file does not exist → SKIP with
+  (`{repoStateRoot}/work/{selectedWork.id}/`). If the file does not exist → SKIP with
   INFO note ("No integration-criteria.md found"). Identify behavioral ICs
   (IC-B{n} entries).
 - For each IC-B, search for test evidence: a test file exercising the described
@@ -119,8 +125,10 @@ The Next: line points to `/sw-build` (on BLOCK) or `/sw-ship` (on PASS
 or WARN). Example: `Next: /sw-ship`.
 
 **State updates (LOW freedom):**
-Follow `protocols/state.md`. Set status to `verifying` at start. Update `gates` section
-after each gate completes. Do NOT set `shipped`.
+Follow `protocols/state.md`. Mutate only the selected work's `workflow.json`
+and the current worktree session. Set status to `verifying` at start. Update
+the selected work's `gates` section after each gate completes. Do NOT set
+`shipped`.
 
 ## Protocol References
 
@@ -139,4 +147,4 @@ after each gate completes. Do NOT set `shipped`.
 | No active work unit | STOP: "Run /sw-design, /sw-plan, and /sw-build first." |
 | No gates enabled / all skipped | WARN, proceed to ready-to-ship |
 | Gate skill file not found | ERROR for that gate, continue remaining |
-| Compaction during verification | Read workflow.json, resume from next gate without fresh results |
+| Compaction during verification | Read the selected work's workflow.json, resume from next gate without fresh results |

--- a/tests/test-multi-worktree-skill-docs.sh
+++ b/tests/test-multi-worktree-skill-docs.sh
@@ -86,6 +86,48 @@ assert_contains "core/skills/sw-pivot/SKILL.md" \
   "sw-pivot documents adopt/takeover guidance for ownership conflicts"
 
 echo ""
+echo "--- Task 3: verify, ship, learn, and gate docs use selected work roots ---"
+assert_contains "core/skills/sw-verify/SKILL.md" \
+  'selected work|session\.json|current worktree session' \
+  "sw-verify references the selected work for this worktree"
+
+assert_contains "core/skills/sw-verify/SKILL.md" \
+  'selected work.?s `?workflow\.json`|selected work.?s evidence directory|workDir' \
+  "sw-verify records evidence and gate updates on the selected work"
+
+assert_contains "core/skills/sw-ship/SKILL.md" \
+  'selected work|session\.json|attached work' \
+  "sw-ship operates on the selected work"
+
+assert_contains "core/skills/sw-ship/SKILL.md" \
+  'adopt/takeover|other live top-level worktree|owned elsewhere' \
+  "sw-ship stops with adopt/takeover guidance for ownership conflicts"
+
+assert_contains "core/skills/sw-learn/SKILL.md" \
+  'selected work|session\.json|attached work' \
+  "sw-learn reads the selected work and current session"
+
+assert_contains "core/skills/sw-learn/SKILL.md" \
+  'clear the current worktree session attachment|attachedWorkId|preserve the work record' \
+  "sw-learn cleanup clears the worktree attachment instead of deleting repo-wide history"
+
+for gate_file in \
+  "core/skills/gate-build/SKILL.md" \
+  "core/skills/gate-tests/SKILL.md" \
+  "core/skills/gate-security/SKILL.md" \
+  "core/skills/gate-wiring/SKILL.md" \
+  "core/skills/gate-semantic/SKILL.md" \
+  "core/skills/gate-spec/SKILL.md"; do
+  assert_contains "$gate_file" \
+    'selected work.?s `?workflow\.json`|{repoStateRoot}/work/{selectedWork\.id}/workflow\.json' \
+    "$gate_file writes gate status to the selected work workflow"
+
+  assert_contains "$gate_file" \
+    '{workDir}/evidence/|selected work.?s evidence' \
+    "$gate_file uses the selected work evidence root"
+done
+
+echo ""
 echo "RESULT: $PASS passed, $FAIL failed"
 
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test-multi-worktree-skill-docs.sh
+++ b/tests/test-multi-worktree-skill-docs.sh
@@ -128,6 +128,35 @@ for gate_file in \
 done
 
 echo ""
+echo "--- Task 4: singleton workflow paths stay gone across touched docs ---"
+for scoped_file in \
+  "core/skills/sw-design/SKILL.md" \
+  "core/skills/sw-plan/SKILL.md" \
+  "core/skills/sw-build/SKILL.md" \
+  "core/skills/sw-pivot/SKILL.md" \
+  "core/skills/sw-verify/SKILL.md" \
+  "core/skills/sw-ship/SKILL.md" \
+  "core/skills/sw-learn/SKILL.md" \
+  "core/skills/gate-build/SKILL.md" \
+  "core/skills/gate-tests/SKILL.md" \
+  "core/skills/gate-security/SKILL.md" \
+  "core/skills/gate-wiring/SKILL.md" \
+  "core/skills/gate-semantic/SKILL.md" \
+  "core/skills/gate-spec/SKILL.md"; do
+  if grep -q '\.specwright/state/workflow\.json' "$scoped_file"; then
+    fail "$scoped_file avoids checkout-local singleton workflow paths"
+  else
+    pass "$scoped_file avoids checkout-local singleton workflow paths"
+  fi
+
+  if grep -q '{currentWork\.workDir}' "$scoped_file"; then
+    fail "$scoped_file avoids currentWork.workDir singleton path templates"
+  else
+    pass "$scoped_file avoids currentWork.workDir singleton path templates"
+  fi
+done
+
+echo ""
 echo "RESULT: $PASS passed, $FAIL failed"
 
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test-multi-worktree-skill-docs.sh
+++ b/tests/test-multi-worktree-skill-docs.sh
@@ -60,6 +60,32 @@ assert_contains "core/skills/sw-plan/SKILL.md" \
   "sw-plan describes logical roots or session-local work selection"
 
 echo ""
+echo "--- Task 2: sw-build and sw-pivot per-work ownership semantics ---"
+assert_contains "core/skills/sw-build/SKILL.md" \
+  'session-selected work|selected work|attached work' \
+  "sw-build resolves the selected work from the current worktree session"
+
+assert_contains "core/skills/sw-build/SKILL.md" \
+  'per-work lock|selected work.?s `?workflow\.json`|mutate only the selected work' \
+  "sw-build describes per-work workflow and lock semantics"
+
+assert_contains "core/skills/sw-build/SKILL.md" \
+  'adopt/takeover|already-owned active work|other live top-level worktree' \
+  "sw-build stops with adopt/takeover guidance for already-owned work"
+
+assert_contains "core/skills/sw-pivot/SKILL.md" \
+  'selected work|attached work|session\.json' \
+  "sw-pivot operates on the selected work for this worktree"
+
+assert_contains "core/skills/sw-pivot/SKILL.md" \
+  'remaining tasks on the selected work|selected work.?s `?workflow\.json`|per-work' \
+  "sw-pivot describes remaining-task updates on the selected work"
+
+assert_contains "core/skills/sw-pivot/SKILL.md" \
+  'adopt/takeover|other live top-level worktree|already-owned active work' \
+  "sw-pivot documents adopt/takeover guidance for ownership conflicts"
+
+echo ""
 echo "RESULT: $PASS passed, $FAIL failed"
 
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test-multi-worktree-skill-docs.sh
+++ b/tests/test-multi-worktree-skill-docs.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+#
+# Tests for Unit 04 — multi-worktree pipeline skill cutover.
+#
+# This suite is extended task-by-task during the build. The opening assertions
+# cover Task 1: sw-design and sw-plan must describe session-selected work and
+# worktree-local attachment semantics instead of repo-global singleton state.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local path="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if grep -qE "$pattern" "$path" 2>/dev/null; then
+    pass "$message"
+  else
+    fail "$message — pattern not found: $pattern"
+  fi
+}
+
+cd "$ROOT_DIR" || exit 1
+
+echo "=== Unit 04: multi-worktree pipeline skill docs ==="
+echo ""
+
+echo "--- Task 1: sw-design and sw-plan session-selected semantics ---"
+assert_contains "core/skills/sw-design/SKILL.md" \
+  'session\.json|attachedWorkId|current worktree session' \
+  "sw-design references current worktree session attachment"
+
+assert_contains "core/skills/sw-design/SKILL.md" \
+  'without clearing unrelated active works|other top-level worktrees|other active works remain' \
+  "sw-design preserves unrelated active works in other top-level worktrees"
+
+assert_contains "core/skills/sw-plan/SKILL.md" \
+  'session-selected work|selected work|attached work' \
+  "sw-plan targets the session-selected work"
+
+assert_contains "core/skills/sw-plan/SKILL.md" \
+  'repoStateRoot|worktreeStateRoot|session\.json' \
+  "sw-plan describes logical roots or session-local work selection"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/test-optional-stage-enforcement.sh
+++ b/tests/test-optional-stage-enforcement.sh
@@ -92,6 +92,10 @@ assert_file_contains "core/skills/sw-design/SKILL.md" \
   'Clearing prior shipped work.*sw-learn first if pattern capture is desired' \
   "sw-design prints clobber notice before clearing prior shipped work"
 
+assert_file_contains "core/skills/sw-design/SKILL.md" \
+  'current worktree only|other top-level worktrees|unrelated active works' \
+  "sw-design limits shipped-work retargeting to the current worktree without clearing unrelated active works"
+
 # AC-5: No core pipeline skill hard-requires an optional skill
 echo ""
 echo "AC-5: core pipeline skills do not hard-require optional skills"

--- a/tests/test-sw-build-inner-loop.sh
+++ b/tests/test-sw-build-inner-loop.sh
@@ -169,6 +169,26 @@ else
 fi
 
 echo ""
+echo "=== Unit 04 compatibility: selected-work semantics preserved ==="
+if grep -qi "selected work\|session-selected work\|attached work" "$SKILL_FILE"; then
+  pass "sw-build body references the selected work for this worktree"
+else
+  fail "sw-build body references the selected work for this worktree"
+fi
+
+if grep -qi "per-work lock" "$SKILL_FILE"; then
+  pass "sw-build body keeps per-work lock language"
+else
+  fail "sw-build body keeps per-work lock language"
+fi
+
+if grep -qi "adopt/takeover\|owned elsewhere" "$SKILL_FILE"; then
+  pass "sw-build body preserves adopt/takeover guidance"
+else
+  fail "sw-build body preserves adopt/takeover guidance"
+fi
+
+echo ""
 echo "==========================================="
 echo "RESULT: $PASS passed, $FAIL failed"
 echo "==========================================="

--- a/tests/test-verify-enriched-handoff.sh
+++ b/tests/test-verify-enriched-handoff.sh
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016
 #
-# Tests for sw-verify enriched handoff enhancement (AC1-AC6)
-#
-#   AC1: Actionable Findings table appears in aggregate report
-#   AC2: Recommended Fix column contains actionable content
-#   AC3: Summary line communicates fix scope
-#   AC4: Existing handoff tiers preserved and extended
-#   AC5: Stage boundary NOT violated
-#   AC6: Token budget maintained
-#
-# Boundary classification: Internal (core skill definition validated via
-# file reads and pattern matching, no mocks).
-#
-# Dependencies: bash
-# Usage: bash tests/test-verify-enriched-handoff.sh
-#   Exit 0 = all pass, exit 1 = any failure
+# Regression checks for sw-verify's handoff and multi-worktree state wording.
 
 set -uo pipefail
 
@@ -36,374 +22,71 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
-# ═══════════════════════════════════════════════════════════════════════
-# Pre-flight: file must exist
-# ═══════════════════════════════════════════════════════════════════════
+assert_contains() {
+  local pattern="$1"
+  local message="$2"
+  if grep -qE "$pattern" "$SKILL_FILE" 2>/dev/null; then
+    pass "$message"
+  else
+    fail "$message — pattern not found: $pattern"
+  fi
+}
 
-echo "=== AC1-AC6: sw-verify enriched handoff tests ==="
+assert_not_contains() {
+  local pattern="$1"
+  local message="$2"
+  if grep -qE "$pattern" "$SKILL_FILE" 2>/dev/null; then
+    fail "$message — unexpected pattern found: $pattern"
+  else
+    pass "$message"
+  fi
+}
+
+echo "=== sw-verify handoff and selected-work semantics ==="
 echo ""
 
 if [ ! -f "$SKILL_FILE" ]; then
-  fail "skills/sw-verify/SKILL.md exists"
+  fail "core/skills/sw-verify/SKILL.md exists"
   echo ""
-  echo "RESULT: $PASS passed, $FAIL failed (file missing, cannot continue)"
+  echo "RESULT: $PASS passed, $FAIL failed"
   exit 1
 fi
 
-FULL_CONTENT=$(cat "$SKILL_FILE")
-
-# Extract body content (everything after the closing --- of frontmatter)
-extract_body() {
-  local file="$1"
-  local closing_line
-  closing_line=$(tail -n +2 "$file" | grep -n '^---$' | head -n 1 | cut -d: -f1)
-  if [ -z "$closing_line" ] || [ "$closing_line" -lt 1 ]; then
-    return 1
-  fi
-  tail -n +"$((closing_line + 2))" "$file"
-}
-
-BODY=$(extract_body "$SKILL_FILE") || {
-  fail "SKILL.md has body content after frontmatter"
-  echo ""
-  echo "RESULT: $PASS passed, $FAIL failed (no body, cannot continue)"
-  exit 1
-}
-
-# (Scoped checks below use BODY directly or AFTER_* slices)
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC1: Actionable Findings table appears in aggregate report
-# ═══════════════════════════════════════════════════════════════════════
-
-echo "=== AC1: Actionable Findings table ==="
-
-# AC1a: Section heading or label for actionable findings
-if echo "$BODY" | grep -qi 'Actionable Findings'; then
-  pass "AC1a: 'Actionable Findings' heading/label present"
-else
-  fail "AC1a: 'Actionable Findings' heading/label present"
-fi
-
-# AC1b: Table columns -- must mention the column names that form the table
-# We check each column individually to prevent a partial implementation
-# that omits one or two columns.
-# Check '#' column inside a table row (grep -qi "#" matches markdown headings, not useful)
-if echo "$BODY" | grep -E '^\s*\|[[:space:]]*#[[:space:]]*\|' | grep -q .; then
-  pass "AC1b: table column '#' mentioned (in table row)"
-else
-  fail "AC1b: table column '#' mentioned (in table row)"
-fi
-
-for col in "Gate" "Severity" "File" "Finding" "Recommended Fix"; do
-  if echo "$BODY" | grep -qi "$col"; then
-    pass "AC1b: table column '$col' mentioned"
-  else
-    fail "AC1b: table column '$col' mentioned"
-  fi
-done
-
-# AC1c: Table must be a pipe-delimited markdown table (not just prose)
-# Check for the actual table row pattern: | something | something |
-if echo "$BODY" | grep -qE '^\s*\|.*\|.*\|.*\|'; then
-  pass "AC1c: pipe-delimited table row pattern present"
-else
-  fail "AC1c: pipe-delimited table row pattern present"
-fi
-
-# AC1d: Table header row specifically for actionable findings
-# Must contain at least 4 of the 6 column names in a single pipe-delimited line
-ACTION_TABLE_HEADER=$(echo "$BODY" | grep -iE '^\s*\|.*#.*\|.*Gate.*\|.*Severity.*\|' || true)
-if [ -n "$ACTION_TABLE_HEADER" ]; then
-  pass "AC1d: actionable findings table header row with #, Gate, Severity columns"
-else
-  fail "AC1d: actionable findings table header row with #, Gate, Severity columns"
-fi
-
-# AC1e: Table includes WARN and BLOCK (not INFO) -- must be in Actionable Findings context
-AFTER_ACTIONABLE_1E=$(echo "$BODY" | sed -n '/Actionable Findings/,$p')
-WARN_IN_AF=$(echo "$AFTER_ACTIONABLE_1E" | grep -ci 'WARN' || true)
-BLOCK_IN_AF=$(echo "$AFTER_ACTIONABLE_1E" | grep -ci 'BLOCK' || true)
-if [ "$WARN_IN_AF" -ge 1 ] && [ "$BLOCK_IN_AF" -ge 1 ]; then
-  pass "AC1e: WARN and BLOCK both referenced in Actionable Findings context"
-else
-  fail "AC1e: WARN and BLOCK both referenced in Actionable Findings context (WARN=$WARN_IN_AF, BLOCK=$BLOCK_IN_AF)"
-fi
-
-# AC1f: INFO findings explicitly excluded from actionable table
-if echo "$BODY" | grep -qi 'not INFO\|exclud.*INFO\|omit.*INFO\|INFO.*excluded\|INFO.*omit\|only WARN.*BLOCK\|only BLOCK.*WARN'; then
-  pass "AC1f: INFO findings excluded from actionable table"
-else
-  fail "AC1f: INFO findings excluded from actionable table"
-fi
-
-# AC1g: Table conditional -- only shown when findings exist
-if echo "$BODY" | grep -qi 'only.*when.*finding\|if.*finding.*exist\|when.*BLOCK\|when.*WARN\|omit.*all PASS\|skip.*all PASS\|not.*shown.*all PASS\|suppress.*when.*PASS'; then
-  pass "AC1g: table shown only when findings exist (not when all PASS)"
-else
-  fail "AC1g: table shown only when findings exist (not when all PASS)"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC2: Recommended Fix column contains actionable content
-# ═══════════════════════════════════════════════════════════════════════
+echo "=== Selected-work roots ==="
+assert_contains 'session\.json|selected work' \
+  "sw-verify references the current worktree session or selected work"
+assert_contains '{repoStateRoot}/work/{selectedWork\.id}/workflow\.json|selected work.?s `?workflow\.json`' \
+  "sw-verify reads the selected work workflow"
+assert_contains '{workDir}/evidence/' \
+  "sw-verify writes evidence into {workDir}/evidence"
+assert_not_contains '\.specwright/state/workflow\.json' \
+  "sw-verify avoids checkout-local singleton workflow paths"
 
 echo ""
-echo "=== AC2: Recommended Fix column is actionable ==="
-
-# AC2a: WARN findings get concrete fix suggestions (not just "fix it")
-# Must appear in the Actionable Findings context, not the existing per-finding detail
-AFTER_ACTIONABLE_2A=$(echo "$BODY" | sed -n '/Actionable Findings/,$p')
-if echo "$AFTER_ACTIONABLE_2A" | grep -qi 'concrete.*fix\|specific.*fix\|actionable.*suggest\|fix.*suggestion\|remediation\|Recommended Fix'; then
-  pass "AC2a: concrete fix suggestions in actionable findings context"
-else
-  fail "AC2a: concrete fix suggestions in actionable findings context"
-fi
-
-# AC2b: BLOCK findings that need human judgment get "manual review" or equivalent
-if echo "$BODY" | grep -qi 'manual review\|human judgment\|manual.*inspection\|requires.*review\|needs.*judgment\|review.*required'; then
-  pass "AC2b: BLOCK findings can indicate manual review needed"
-else
-  fail "AC2b: BLOCK findings can indicate manual review needed"
-fi
-
-# AC2c: File paths must be specific (not vague)
-# Check that the spec mentions specific file paths or rejects "various files"
-if echo "$BODY" | grep -qi 'specific.*file\|file.*path\|exact.*file\|actual.*path\|concrete.*path\|not.*various'; then
-  pass "AC2c: specific file paths required (not vague references)"
-else
-  fail "AC2c: specific file paths required (not vague references)"
-fi
-
-# AC2d: Gate evidence is the source of findings for the actionable table
-AFTER_ACTIONABLE_2D=$(echo "$BODY" | sed -n '/Actionable Findings/,$p')
-if echo "$AFTER_ACTIONABLE_2D" | grep -qi 'evidence.*source\|from.*evidence\|gate.*evidence\|evidence.*finding\|sourced.*from.*gate\|drawn.*from.*evidence\|populate.*from.*evidence'; then
-  pass "AC2d: gate evidence identified as source of actionable findings"
-else
-  fail "AC2d: gate evidence identified as source of actionable findings"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC3: Summary line communicates fix scope
-# ═══════════════════════════════════════════════════════════════════════
+echo "=== Ownership and state updates ==="
+assert_contains 'adopt/takeover|owned that work' \
+  "sw-verify stops with adopt/takeover guidance on ownership conflicts"
+assert_contains 'Mutate only the selected work.?s `?workflow\.json` and the current worktree session|selected work.?s `?workflow\.json`' \
+  "sw-verify state updates target the selected work"
+assert_contains 'gates` section|summary table `\| Gate \| Status \| Findings \(B/W/I\) \|`' \
+  "sw-verify preserves gate-summary reporting"
 
 echo ""
-echo "=== AC3: Summary line with fix scope ==="
-
-# AC3a: Count format like "N of M" or "N/M" or equivalent
-if echo "$BODY" | grep -qi 'N of M\|N/M\|count.*of.*total\|X of Y\|{n}.*of.*{m}\|number.*of.*total\|findings.*count\|tally'; then
-  pass "AC3a: count format (N of M or equivalent) present"
-else
-  fail "AC3a: count format (N of M or equivalent) present"
-fi
-
-# AC3b: Summary line explicitly tells user to resolve/address warns
-# Must be in actionable-findings context, not the existing handoff tier text
-AFTER_ACTIONABLE=$(echo "$BODY" | sed -n '/Actionable Findings/,$p')
-if echo "$AFTER_ACTIONABLE" | grep -qi 'resolve.*warn\|address.*warn\|clear.*warn\|action.*warn\|fix.*warn'; then
-  pass "AC3b: 'resolve the warns' or equivalent user action in actionable findings context"
-else
-  fail "AC3b: 'resolve the warns' or equivalent user action in actionable findings context"
-fi
-
-# AC3c: Handling for all-manual-review case
-if echo "$BODY" | grep -qi 'all.*manual\|every.*manual\|all.*require.*review\|no.*auto.*fix\|none.*auto'; then
-  pass "AC3c: handling for all-manual-review case"
-else
-  fail "AC3c: handling for all-manual-review case"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC4: Existing handoff tiers preserved and extended
-# ═══════════════════════════════════════════════════════════════════════
+echo "=== Stage boundary and handoff ==="
+assert_contains 'NEVER fix|NEVER fix code, create PRs, or ship' \
+  "sw-verify stage boundary still forbids fixing or shipping"
+assert_contains 'Artifacts: \{workDir\}/stage-report\.md|stage-report\.md' \
+  "sw-verify handoff still points at stage-report.md"
+assert_contains 'Next: /sw-build|Next: /sw-ship' \
+  "sw-verify handoff still routes to /sw-build or /sw-ship"
+assert_contains 'Fix and re-run /sw-verify|/sw-build' \
+  "sw-verify still describes the block path"
 
 echo ""
-echo "=== AC4: Existing handoff tiers preserved ==="
-
-# AC4a: BLOCK handoff preserved
-if echo "$BODY" | grep -q 'Fix and re-run.*sw-verify\|Fix and re-run `/sw-verify`'; then
-  pass "AC4a: BLOCK handoff 'Fix and re-run /sw-verify' preserved"
-else
-  fail "AC4a: BLOCK handoff 'Fix and re-run /sw-verify' preserved"
-fi
-
-# AC4b: WARN handoff preserved
-if echo "$BODY" | grep -q 'Review, then fix or.*sw-ship\|Review, then fix or `/sw-ship`'; then
-  pass "AC4b: WARN handoff 'Review, then fix or /sw-ship' preserved"
-else
-  fail "AC4b: WARN handoff 'Review, then fix or /sw-ship' preserved"
-fi
-
-# AC4c: PASS handoff preserved
-if echo "$BODY" | grep -q 'Ready for.*sw-ship\|Ready for `/sw-ship`'; then
-  pass "AC4c: PASS handoff 'Ready for /sw-ship' preserved"
-else
-  fail "AC4c: PASS handoff 'Ready for /sw-ship' preserved"
-fi
-
-# AC4d: All three tiers coexist (not replaced by a single new handoff)
-BLOCK_HANDOFF=$(echo "$BODY" | grep -c 'Fix and re-run' || true)
-WARN_HANDOFF=$(echo "$BODY" | grep -c 'Review, then fix or' || true)
-PASS_HANDOFF=$(echo "$BODY" | grep -c 'Ready for' || true)
-if [ "$BLOCK_HANDOFF" -ge 1 ] && [ "$WARN_HANDOFF" -ge 1 ] && [ "$PASS_HANDOFF" -ge 1 ]; then
-  pass "AC4d: all three handoff tiers coexist"
-else
-  fail "AC4d: all three handoff tiers coexist (BLOCK=$BLOCK_HANDOFF, WARN=$WARN_HANDOFF, PASS=$PASS_HANDOFF)"
-fi
-
-# AC4e: Table is additive -- the existing per-finding detail and summary table
-# must still be present alongside the new actionable findings table
-if echo "$BODY" | grep -qi 'Per-finding detail\|per-finding'; then
-  pass "AC4e: per-finding detail tier still present"
-else
-  fail "AC4e: per-finding detail tier still present"
-fi
-
-if echo "$BODY" | grep -qi 'Summary table\|summary.*table\|Gate.*Status.*Findings'; then
-  pass "AC4f: summary table tier still present"
-else
-  fail "AC4f: summary table tier still present"
-fi
-
-# AC4g: The existing summary table pipe format is preserved
-if echo "$BODY" | grep -qE '\|.*Gate.*\|.*Status.*\|.*Finding'; then
-  pass "AC4g: existing summary table header '| Gate | Status | Findings |' preserved"
-else
-  fail "AC4g: existing summary table header '| Gate | Status | Findings |' preserved"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC5: Stage boundary NOT violated
-# ═══════════════════════════════════════════════════════════════════════
-
-echo ""
-echo "=== AC5: Stage boundary preserved ==="
-
-# AC5a: Core stage boundary statement preserved
-if echo "$BODY" | grep -q 'You NEVER fix code, create PRs, or ship'; then
-  pass "AC5a: 'You NEVER fix code, create PRs, or ship' preserved"
-else
-  fail "AC5a: 'You NEVER fix code, create PRs, or ship' preserved"
-fi
-
-# AC5b: No instructions to fix/modify/write code
-# Search for imperative verbs that would violate stage boundary
-VIOLATION_COUNT=0
-for verb in "fix the code" "modify the file" "write the fix" "apply the fix" "patch the" "edit the file" "update the code" "change the file"; do
-  if echo "$BODY" | grep -qi "$verb"; then
-    VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
-  fi
-done
-if [ "$VIOLATION_COUNT" -eq 0 ]; then
-  pass "AC5b: no imperative code-fixing instructions found"
-else
-  fail "AC5b: found $VIOLATION_COUNT imperative code-fixing instructions"
-fi
-
-# AC5c: No new state transitions added beyond existing ones
-# The existing transitions are: verifying (start), gate updates, no shipped
-# Check that no new status values are introduced
-NEW_STATUS_COUNT=$(echo "$BODY" | grep -oiE 'status.*to.*`[a-z-]+`' | grep -vic 'verifying\|shipped' || true)
-if [ "$NEW_STATUS_COUNT" -eq 0 ]; then
-  pass "AC5c: no new state transitions beyond verifying"
-else
-  fail "AC5c: found $NEW_STATUS_COUNT unexpected state transitions"
-fi
-
-# AC5d: Stage boundary protocol reference preserved
-if echo "$BODY" | grep -q 'protocols/stage-boundary.md'; then
-  pass "AC5d: protocols/stage-boundary.md reference preserved"
-else
-  fail "AC5d: protocols/stage-boundary.md reference preserved"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# AC6: Token budget maintained
-# ═══════════════════════════════════════════════════════════════════════
-
-echo ""
-echo "=== AC6: Token budget ==="
-
-WORD_COUNT=$(echo "$FULL_CONTENT" | wc -w | tr -d ' ')
-
-if [ "$WORD_COUNT" -lt 1500 ]; then
-  pass "AC6a: word count ($WORD_COUNT) is under 1500 ceiling"
-else
-  fail "AC6a: word count ($WORD_COUNT) is under 1500 ceiling"
-fi
-
-if [ "$WORD_COUNT" -gt 200 ]; then
-  pass "AC6b: word count ($WORD_COUNT) is above 200 sanity floor"
-else
-  fail "AC6b: word count ($WORD_COUNT) is above 200 sanity floor"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# Anti-bypass: Guards against sloppy implementations
-# ═══════════════════════════════════════════════════════════════════════
-
-echo ""
-echo "=== Anti-bypass: Implementation guards ==="
-
-# Guard 1: The actionable findings table must be INSIDE the aggregate report
-# constraint (not floating elsewhere). Check that "Actionable Findings" appears
-# after "Aggregate report" heading.
-AFTER_AGG=$(echo "$BODY" | sed -n '/Aggregate report/,$p')
-if echo "$AFTER_AGG" | grep -qi 'Actionable Findings'; then
-  pass "guard: Actionable Findings is within or after Aggregate report section"
-else
-  fail "guard: Actionable Findings is within or after Aggregate report section"
-fi
-
-# Guard 2: The table example must include BOTH the column header AND a separator
-# row (standard markdown table format), not just prose about columns
-TABLE_SEPARATOR=$(echo "$BODY" | grep -cE '^\s*\|[-: ]+\|[-: ]+\|' || true)
-if [ "$TABLE_SEPARATOR" -ge 1 ]; then
-  pass "guard: markdown table separator row present (|---|---|)"
-else
-  fail "guard: markdown table separator row present (|---|---|)"
-fi
-
-# Guard 3: "Recommended Fix" column must appear in actual table header, not just
-# in prose text. Check for it inside a pipe-delimited line.
-if echo "$BODY" | grep -iE '^\s*\|.*Recommended Fix.*\|' | grep -q '.'; then
-  pass "guard: 'Recommended Fix' appears inside a table header row"
-else
-  fail "guard: 'Recommended Fix' appears inside a table header row"
-fi
-
-# Guard 4: The three existing report tiers must now be three or more
-# (per-finding detail, summary table, actionable findings)
-TIER_COUNT=0
-echo "$BODY" | grep -qi 'Per-finding detail\|per-finding' && TIER_COUNT=$((TIER_COUNT + 1))
-echo "$BODY" | grep -qi 'Summary table' && TIER_COUNT=$((TIER_COUNT + 1))
-echo "$BODY" | grep -qi 'Actionable Findings' && TIER_COUNT=$((TIER_COUNT + 1))
-if [ "$TIER_COUNT" -ge 3 ]; then
-  pass "guard: at least 3 report tiers present ($TIER_COUNT found)"
-else
-  fail "guard: at least 3 report tiers present ($TIER_COUNT found)"
-fi
-
-# Guard 5: File column in table must be distinct from Finding column
-# (prevents collapsing two concepts into one column)
-FILE_COL=$(echo "$BODY" | grep -iE '^\s*\|.*File.*\|.*Finding.*\|' || true)
-if [ -n "$FILE_COL" ]; then
-  pass "guard: File and Finding are separate columns in table"
-else
-  fail "guard: File and Finding are separate columns in table"
-fi
-
-# ═══════════════════════════════════════════════════════════════════════
-# Summary
-# ═══════════════════════════════════════════════════════════════════════
-
-echo ""
-echo "═══════════════════════════════════════════"
-TOTAL=$((PASS + FAIL))
-echo "RESULT: $PASS passed, $FAIL failed (of $TOTAL tests)"
-echo "═══════════════════════════════════════════"
+echo "RESULT: $PASS passed, $FAIL failed"
 
 if [ "$FAIL" -gt 0 ]; then
   exit 1
 fi
+
 exit 0

--- a/tests/test-verify-enriched-handoff.sh
+++ b/tests/test-verify-enriched-handoff.sh
@@ -42,7 +42,37 @@ assert_not_contains() {
   fi
 }
 
-echo "=== sw-verify handoff and selected-work semantics ==="
+extract_body() {
+  local file="$1"
+  local closing_line
+  closing_line=$(tail -n +2 "$file" | grep -n '^---$' | head -n 1 | cut -d: -f1)
+  if [ -z "$closing_line" ] || [ "$closing_line" -lt 1 ]; then
+    return 1
+  fi
+  tail -n +"$((closing_line + 2))" "$file"
+}
+
+assert_body_contains() {
+  local pattern="$1"
+  local message="$2"
+  if echo "$BODY" | grep -qE "$pattern"; then
+    pass "$message"
+  else
+    fail "$message — pattern not found in body: $pattern"
+  fi
+}
+
+assert_body_not_contains() {
+  local pattern="$1"
+  local message="$2"
+  if echo "$BODY" | grep -qE "$pattern"; then
+    fail "$message — unexpected pattern found in body: $pattern"
+  else
+    pass "$message"
+  fi
+}
+
+echo "=== sw-verify enriched handoff and selected-work semantics ==="
 echo ""
 
 if [ ! -f "$SKILL_FILE" ]; then
@@ -52,35 +82,84 @@ if [ ! -f "$SKILL_FILE" ]; then
   exit 1
 fi
 
+FULL_CONTENT=$(cat "$SKILL_FILE")
+BODY=$(extract_body "$SKILL_FILE") || {
+  fail "SKILL.md has body content after frontmatter"
+  echo ""
+  echo "RESULT: $PASS passed, $FAIL failed"
+  exit 1
+}
+
 echo "=== Selected-work roots ==="
-assert_contains 'session\.json|selected work' \
+assert_body_contains 'session\.json|selected work' \
   "sw-verify references the current worktree session or selected work"
-assert_contains '{repoStateRoot}/work/{selectedWork\.id}/workflow\.json|selected work.?s `?workflow\.json`' \
+assert_body_contains '{repoStateRoot}/work/{selectedWork\.id}/workflow\.json|selected work.?s `?workflow\.json`' \
   "sw-verify reads the selected work workflow"
-assert_contains '{workDir}/evidence/' \
+assert_body_contains '{workDir}/evidence/' \
   "sw-verify writes evidence into {workDir}/evidence"
-assert_not_contains '\.specwright/state/workflow\.json' \
+assert_body_not_contains '\.specwright/state/workflow\.json' \
   "sw-verify avoids checkout-local singleton workflow paths"
 
 echo ""
 echo "=== Ownership and state updates ==="
-assert_contains 'adopt/takeover|owned that work' \
+assert_body_contains 'adopt/takeover|owned that work' \
   "sw-verify stops with adopt/takeover guidance on ownership conflicts"
-assert_contains 'Mutate only the selected work.?s `?workflow\.json` and the current worktree session|selected work.?s `?workflow\.json`' \
+assert_body_contains 'Mutate only the selected work.?s `?workflow\.json` and the current worktree session|selected work.?s `?workflow\.json`' \
   "sw-verify state updates target the selected work"
-assert_contains 'gates` section|summary table `\| Gate \| Status \| Findings \(B/W/I\) \|`' \
+assert_body_contains 'gates` section|summary table `\| Gate \| Status \| Findings \(B/W/I\) \|`' \
   "sw-verify preserves gate-summary reporting"
 
 echo ""
+echo "=== Enriched handoff contract ==="
+assert_body_contains 'Per-finding detail|per-finding detail' \
+  "sw-verify keeps the per-finding detail tier"
+assert_body_contains '\| Gate \| Status \| Findings \(B/W/I\) \|' \
+  "sw-verify keeps the summary table tier"
+assert_body_contains 'Actionable Findings' \
+  "sw-verify keeps the actionable findings tier"
+assert_body_contains '^\s*\|[[:space:]]*#[[:space:]]*\|.*Gate.*\|.*Severity.*\|.*File.*\|.*Finding.*\|.*Recommended Fix.*\|' \
+  "sw-verify includes the actionable findings table header"
+assert_body_contains '^\s*\|---\|------\|----------\|------\|---------\|-----------------\|' \
+  "sw-verify includes the actionable findings markdown separator row"
+assert_body_contains 'only WARN and BLOCK severity rows, not INFO|Include only WARN and BLOCK severity rows, not INFO' \
+  "sw-verify excludes INFO findings from the actionable findings table"
+assert_body_contains 'specific file path from gate evidence|specific file path' \
+  "sw-verify requires specific file paths in actionable findings"
+assert_body_contains 'manual review' \
+  "sw-verify preserves manual-review guidance for BLOCK findings"
+assert_body_contains 'N of M' \
+  "sw-verify preserves the actionable summary count guidance"
+
+echo ""
 echo "=== Stage boundary and handoff ==="
-assert_contains 'NEVER fix|NEVER fix code, create PRs, or ship' \
+assert_body_contains 'NEVER fix|NEVER fix code, create PRs, or ship' \
   "sw-verify stage boundary still forbids fixing or shipping"
-assert_contains 'Artifacts: \{workDir\}/stage-report\.md|stage-report\.md' \
+assert_body_contains 'Artifacts: \{workDir\}/stage-report\.md|stage-report\.md' \
   "sw-verify handoff still points at stage-report.md"
-assert_contains 'Next: /sw-build|Next: /sw-ship' \
+assert_body_contains 'Next: /sw-build|Next: /sw-ship' \
   "sw-verify handoff still routes to /sw-build or /sw-ship"
-assert_contains 'Fix and re-run /sw-verify|/sw-build' \
-  "sw-verify still describes the block path"
+assert_body_contains 'Fix and re-run `?/sw-verify`?' \
+  "sw-verify keeps the explicit BLOCK handoff"
+assert_body_contains 'Review, then fix or `?/sw-ship`?' \
+  "sw-verify keeps the explicit WARN handoff"
+assert_body_contains 'Ready for `?/sw-ship`?' \
+  "sw-verify keeps the explicit PASS handoff"
+assert_contains 'protocols/stage-boundary\.md' \
+  "sw-verify still references protocols/stage-boundary.md"
+
+echo ""
+echo "=== Budget ==="
+WORD_COUNT=$(echo "$FULL_CONTENT" | wc -w | tr -d ' ')
+if [ "$WORD_COUNT" -lt 1500 ]; then
+  pass "sw-verify word count ($WORD_COUNT) stays under 1500"
+else
+  fail "sw-verify word count ($WORD_COUNT) stays under 1500"
+fi
+if [ "$WORD_COUNT" -gt 200 ]; then
+  pass "sw-verify word count ($WORD_COUNT) stays above 200"
+else
+  fail "sw-verify word count ($WORD_COUNT) stays above 200"
+fi
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- cut the main pipeline skills over from repo-global active-work wording to session-selected work semantics
- align verify, ship, learn, and the gate docs on the selected work's workflow and evidence roots
- add executable regression coverage that rejects singleton workflow-path regressions and preserves adopt/takeover guidance across the touched docs

## Acceptance Criteria
- `AC-1` PASS: `core/skills/sw-design/SKILL.md` now creates and attaches new work only for the current worktree session without clearing unrelated active works. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
- `AC-2` PASS: `core/skills/sw-plan/SKILL.md`, `core/skills/sw-build/SKILL.md`, and `core/skills/sw-pivot/SKILL.md` now resolve the selected work through the current session and describe per-work task/lock semantics consistently. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
- `AC-3` PASS: `core/skills/sw-verify/SKILL.md`, `core/skills/sw-ship/SKILL.md`, and `core/skills/sw-learn/SKILL.md` now describe evidence lookup, status transitions, and cleanup behavior against the selected work rather than a repo-global singleton. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
- `AC-4` PASS: the gate skill docs now describe workflow and evidence updates in terms of the selected work's workflow file and evidence directory. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
- `AC-5` PASS: the touched pipeline docs now stop with explicit adopt/takeover guidance when another top-level worktree already owns the active work. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
- `AC-6` PASS: static regression tests now fail if singleton `workflow.json` assumptions or takeover guidance regress in the touched docs. Evidence: `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`, `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/test-quality.md`

## Blast Radius
- Pipeline skills: `core/skills/sw-design/SKILL.md`, `core/skills/sw-plan/SKILL.md`, `core/skills/sw-build/SKILL.md`, `core/skills/sw-pivot/SKILL.md`, `core/skills/sw-verify/SKILL.md`, `core/skills/sw-ship/SKILL.md`, `core/skills/sw-learn/SKILL.md`
- Gate skills: `core/skills/gate-build/SKILL.md`, `core/skills/gate-tests/SKILL.md`, `core/skills/gate-security/SKILL.md`, `core/skills/gate-wiring/SKILL.md`, `core/skills/gate-semantic/SKILL.md`, `core/skills/gate-spec/SKILL.md`
- Regression coverage: `tests/test-multi-worktree-skill-docs.sh`, `tests/test-optional-stage-enforcement.sh`, `tests/test-sw-build-inner-loop.sh`, `tests/test-verify-enriched-handoff.sh`

## Gate Results
- `build`: PASS (`0/0/2`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/build-report.md`
- `tests`: WARN (`0/1/3`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/test-quality.md`
- `security`: PASS (`0/0/3`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/security-report.md`
- `wiring`: PASS (`0/0/3`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/wiring-report.md`
- `semantic`: PASS (`0/0/2`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/semantic-report.md`
- `spec`: PASS (`0/0/1`) — `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`

## Evidence Links
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/build-report.md`
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/test-quality.md`
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/security-report.md`
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/wiring-report.md`
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/semantic-report.md`
- `.specwright/work/multi-worktree-state/units/04-pipeline-skill-cutover/evidence/spec-compliance.md`
