### PR TITLE
fix(codex): align installer contract and hook context

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ Manual install:
 - Extract it to `~/plugins/specwright` for a user install or `<repo>/plugins/specwright` for a repo install.
 - Add a `specwright` entry to `~/.agents/plugins/marketplace.json` or `<repo>/.agents/plugins/marketplace.json` with `source.path` set to `./plugins/specwright`.
 
+Packaged Codex installs use the prebuilt plugin bundle and its bundled
+slash-command contract. If you are developing Specwright itself and only need
+repo-local skills-only mode, use the source tree directly instead of the
+packaged installer above.
+
 This enables:
 - `/sw-*` slash commands
 - Session hooks (resume context + shipping guard + continuation snapshots)

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -10,6 +10,9 @@ point Codex directly at `adapters/codex`. The distributable bundle is built to
 - `commands/`, `hooks/`, `hooks.json`
 - `.codex-plugin/plugin.json`
 
+Packaged Codex slash commands invoke the installed `specwright:sw-*` skills
+from that bundle.
+
 ## User Install
 
 ```sh
@@ -38,3 +41,6 @@ If you are working on Specwright itself:
 1. Build the distributable with `./build/build.sh codex`.
 2. Install the resulting `dist/codex` bundle into a user or repo marketplace.
 3. Use `.agents/skills` directly if you only need skills-only mode.
+
+That `.agents/skills` path is a repo-local development shortcut, not part of
+the packaged Codex install contract.

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -7,10 +7,40 @@ const FAILURE_CODE = 'GIT_RESOLUTION_FAILED';
 const PRIMARY_WORKTREE_ID = 'main-worktree';
 const LEGACY_STATE_SEGMENTS = ['.specwright', 'state'];
 const SHARED_CONFIG_FILE = 'config.json';
+const REPO_LOCAL_GIT_ENV_VARS = new Set([
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_DIR',
+  'GIT_GRAFT_FILE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_PREFIX',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+  'GIT_WORK_TREE'
+]);
+
+function sanitizedGitEnv(extra = {}) {
+  const env = { ...process.env };
+  for (const key of REPO_LOCAL_GIT_ENV_VARS) {
+    delete env[key];
+  }
+
+  return {
+    ...env,
+    ...extra
+  };
+}
 
 function runGit(args, cwd) {
   return execFileSync('git', args, {
     cwd,
+    env: sanitizedGitEnv(),
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe']
   }).trim();

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -7,7 +7,10 @@ const FAILURE_CODE = 'GIT_RESOLUTION_FAILED';
 const PRIMARY_WORKTREE_ID = 'main-worktree';
 const LEGACY_STATE_SEGMENTS = ['.specwright', 'state'];
 const SHARED_CONFIG_FILE = 'config.json';
-const REPO_LOCAL_GIT_ENV_VARS = new Set([
+const FALLBACK_REPO_LOCAL_GIT_ENV_VARS = new Set([
+  // Tracks `git rev-parse --local-env-vars` plus config-injection vars that
+  // Git does not report but are still unsafe to inherit across repositories.
+  // Re-check this fallback when the minimum supported Git version changes.
   'GIT_ALTERNATE_OBJECT_DIRECTORIES',
   'GIT_COMMON_DIR',
   'GIT_CONFIG',
@@ -17,6 +20,7 @@ const REPO_LOCAL_GIT_ENV_VARS = new Set([
   'GIT_GRAFT_FILE',
   'GIT_IMPLICIT_WORK_TREE',
   'GIT_INDEX_FILE',
+  'GIT_NAMESPACE',
   'GIT_NO_REPLACE_OBJECTS',
   'GIT_OBJECT_DIRECTORY',
   'GIT_PREFIX',
@@ -25,9 +29,9 @@ const REPO_LOCAL_GIT_ENV_VARS = new Set([
   'GIT_WORK_TREE'
 ]);
 
-function sanitizedGitEnv(extra = {}) {
+function sanitizedGitEnv(extra = {}, keys = REPO_LOCAL_GIT_ENV_VARS) {
   const env = { ...process.env };
-  for (const key of REPO_LOCAL_GIT_ENV_VARS) {
+  for (const key of keys) {
     delete env[key];
   }
 
@@ -36,6 +40,30 @@ function sanitizedGitEnv(extra = {}) {
     ...extra
   };
 }
+
+function loadRepoLocalGitEnvVars() {
+  const keys = new Set(FALLBACK_REPO_LOCAL_GIT_ENV_VARS);
+
+  try {
+    const output = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+      env: sanitizedGitEnv({}, FALLBACK_REPO_LOCAL_GIT_ENV_VARS),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+
+    for (const key of output.split(/\r?\n/u)) {
+      if (key) {
+        keys.add(key);
+      }
+    }
+  } catch {
+    // Keep the static fallback when Git cannot provide a dynamic env list.
+  }
+
+  return keys;
+}
+
+const REPO_LOCAL_GIT_ENV_VARS = loadRepoLocalGitEnvVars();
 
 function runGit(args, cwd) {
   return execFileSync('git', args, {

--- a/tests/test-codex-hooks.sh
+++ b/tests/test-codex-hooks.sh
@@ -47,16 +47,39 @@ assert_contains() {
   fi
 }
 
+git_nested() {
+  local env_cmd=(env)
+  local git_var
+  while IFS= read -r git_var; do
+    env_cmd+=(-u "$git_var")
+  done < <(git rev-parse --local-env-vars)
+  "${env_cmd[@]}" git "$@"
+}
+
 init_git_repo() {
   local dir="$1"
   mkdir -p "$dir"
-  git -C "$dir" -c core.hooksPath=/dev/null init -q
-  git -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
+  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
   printf 'seed\n' > "$dir/README.md"
-  git -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
+  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+}
+
+run_with_outer_git_context() {
+  local outer="$1"
+  shift
+  local outer_git_dir outer_common_dir outer_root
+  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
+  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
+  outer_root="$(cd "$outer" && pwd -P)"
+  GIT_DIR="$outer_git_dir" \
+  GIT_WORK_TREE="$outer_root" \
+  GIT_COMMON_DIR="$outer_common_dir" \
+  GIT_PREFIX="" \
+  "$@"
 }
 
 make_project() {
@@ -65,15 +88,24 @@ make_project() {
 }
 
 git_common_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-common-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
 }
 
 git_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
 }
 
 repo_state_root() {
   printf '%s/specwright\n' "$(git_common_dir "$1")"
+}
+
+run_in_dir() {
+  local dir="$1"
+  shift
+  (
+    cd "$dir" &&
+    "$@"
+  )
 }
 
 worktree_state_root() {
@@ -88,7 +120,7 @@ make_shared_project() {
   local dir="$1"
   local work_id="$2"
   local status="$3"
-  local branch="${4:-$(git -C "$dir" branch --show-current)}"
+  local branch="${4:-$(git_nested -C "$dir" branch --show-current)}"
   local repo_root worktree_root work_dir
 
   repo_root="$(repo_state_root "$dir")"
@@ -163,6 +195,30 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
+echo "--- Nested git context isolation ---"
+T="$TEST_TMPDIR/hook-env-outer"
+U="$TEST_TMPDIR/hook-env-target"
+V="$TEST_TMPDIR/hook-env-fresh"
+init_git_repo "$T"
+init_git_repo "$U"
+U_REAL="$(cd "$U" && pwd -P)"
+output="$(run_with_outer_git_context "$T" git_common_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "codex hooks: git_common_dir ignores inherited outer git context"
+output="$(run_with_outer_git_context "$T" git_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "codex hooks: git_dir ignores inherited outer git context"
+run_with_outer_git_context "$T" init_git_repo "$V" >/dev/null 2>&1
+if git_nested -C "$V" rev-parse HEAD >/dev/null 2>&1; then
+  pass "codex hooks: init_git_repo creates a temp repo under inherited outer git context"
+else
+  fail "codex hooks: init_git_repo creates a temp repo under inherited outer git context"
+fi
+make_shared_project "$U" "outer-codex-start" "building"
+mkdir -p "$U/deep/start"
+output="$(
+  run_with_outer_git_context "$T" run_in_dir "$U/deep/start" node "$SESSION_START_HOOK" 2>/dev/null || true
+)"
+assert_contains "$output" "outer-codex-start (building)" "codex hooks: session-start ignores inherited outer git context"
+
 echo "--- SessionStart ---"
 T="$TEST_TMPDIR/session-start-none"
 mkdir -p "$T"
@@ -232,7 +288,7 @@ assert_contains "$output" "Specwright: Work in progress" "session-start resolves
 T="$TEST_TMPDIR/session-start-linked-primary"
 L="$TEST_TMPDIR/codex-session-start-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b codex-session-start-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b codex-session-start-linked "$L" HEAD
 make_project "$L"
 mkdir -p "$L/.specwright/work/WU-001" "$L/deep/start"
 write_workflow "$L" "building"
@@ -247,7 +303,7 @@ assert_contains "$output" "Specwright: Work in progress" "session-start resolves
 T="$TEST_TMPDIR/session-start-shared-primary"
 L="$TEST_TMPDIR/codex-session-start-shared-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b codex-session-start-shared-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b codex-session-start-shared-linked "$L" HEAD
 make_shared_project "$L" "shared-codex-start" "building"
 mkdir -p "$L/deep/shared"
 output="$(

--- a/tests/test-codex-hooks.sh
+++ b/tests/test-codex-hooks.sh
@@ -16,6 +16,8 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+. "$SCRIPT_DIR/test-lib.sh"
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
@@ -47,52 +49,11 @@ assert_contains() {
   fi
 }
 
-git_nested() {
-  local env_cmd=(env)
-  local git_var
-  while IFS= read -r git_var; do
-    env_cmd+=(-u "$git_var")
-  done < <(git rev-parse --local-env-vars)
-  "${env_cmd[@]}" git "$@"
-}
-
-init_git_repo() {
-  local dir="$1"
-  mkdir -p "$dir"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
-  printf 'seed\n' > "$dir/README.md"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
-}
-
-run_with_outer_git_context() {
-  local outer="$1"
-  shift
-  local outer_git_dir outer_common_dir outer_root
-  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
-  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
-  outer_root="$(cd "$outer" && pwd -P)"
-  GIT_DIR="$outer_git_dir" \
-  GIT_WORK_TREE="$outer_root" \
-  GIT_COMMON_DIR="$outer_common_dir" \
-  GIT_PREFIX="" \
-  "$@"
-}
+git_nested_prepare || exit 1
 
 make_project() {
   local dir="$1"
   mkdir -p "$dir/.specwright/state"
-}
-
-git_common_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
-}
-
-git_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
 }
 
 repo_state_root() {

--- a/tests/test-codex-install.sh
+++ b/tests/test-codex-install.sh
@@ -53,6 +53,79 @@ assert_eq() {
   fi
 }
 
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    pass "$label"
+  else
+    fail "$label (missing '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$label (unexpected '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
+extract_details_block() {
+  python3 - "$1" "$2" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+summary = f"<summary><b>{sys.argv[2]}</b></summary>"
+start = text.find(summary)
+if start == -1:
+    raise SystemExit(1)
+end = text.find("</details>", start)
+if end == -1:
+    end = len(text)
+print(text[start:end])
+PY
+}
+
+extract_before_heading() {
+  python3 - "$1" "$2" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+heading = f"## {sys.argv[2]}\n"
+index = text.find(heading)
+if index == -1:
+    print(text)
+else:
+    print(text[:index])
+PY
+}
+
+extract_heading_section() {
+  python3 - "$1" "$2" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+heading = f"## {sys.argv[2]}\n"
+start = text.find(heading)
+if start == -1:
+    raise SystemExit(1)
+remainder = text[start:]
+next_index = remainder.find("\n## ", len(heading))
+if next_index == -1:
+    print(remainder)
+else:
+    print(remainder[:next_index + 1])
+PY
+}
+
 cleanup() {
   if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
     rm -rf "$TMP_DIR"
@@ -75,6 +148,13 @@ if [ ! -x "$BUILD_SCRIPT" ]; then
   echo "ABORT: build script not executable at $BUILD_SCRIPT"
   exit 1
 fi
+
+assert_file "$INSTALLER" "installer script exists"
+INSTALLER_HELP="$(bash "$INSTALLER" --help)"
+assert_contains "$INSTALLER_HELP" "--user" "installer help documents --user"
+assert_contains "$INSTALLER_HELP" "--repo" "installer help documents --repo"
+assert_contains "$INSTALLER_HELP" "--version" "installer help documents --version"
+assert_contains "$INSTALLER_HELP" "--update" "installer help documents --update"
 
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t specwright-codex-test)"
 ASSET_DIR="$TMP_DIR/asset"
@@ -176,6 +256,17 @@ assert_file "$REPO_DIR/.agents/plugins/marketplace.json" "repo install writes ma
 assert_eq "$(jq -r '.plugins[] | select(.name == "specwright") | .source.path' "$REPO_DIR/.agents/plugins/marketplace.json")" "./plugins/specwright" "repo marketplace path points at bundled plugin"
 assert_eq "$(jq -r '.plugins[] | select(.name == "specwright") | .version' "$REPO_DIR/.agents/plugins/marketplace.json")" "latest" "repo marketplace records installed version"
 assert_eq "$(jq '[.plugins[] | select(.name == "specwright")] | length' "$REPO_DIR/.agents/plugins/marketplace.json")" "1" "repo install adds one specwright marketplace entry"
+
+echo "--- Documentation contract ---"
+README_CODEX_SECTION="$(extract_details_block "$ROOT_DIR/README.md" "Codex CLI")"
+ADAPTER_PACKAGED_SECTION="$(extract_before_heading "$ROOT_DIR/adapters/codex/README.md" "Local Development")"
+ADAPTER_LOCAL_DEV_SECTION="$(extract_heading_section "$ROOT_DIR/adapters/codex/README.md" "Local Development")"
+
+assert_contains "$README_CODEX_SECTION" "skills-only mode" "README distinguishes packaged install from skills-only mode"
+assert_not_contains "$README_CODEX_SECTION" ".agents/skills" "README packaged Codex section does not require .agents/skills"
+assert_contains "$ADAPTER_PACKAGED_SECTION" "specwright:sw-*" "adapter README documents specwright:sw-* command contract"
+assert_not_contains "$ADAPTER_PACKAGED_SECTION" ".agents/skills" "adapter README packaged sections do not require .agents/skills"
+assert_contains "$ADAPTER_LOCAL_DEV_SECTION" ".agents/skills" "adapter README scopes .agents/skills to local development"
 
 echo ""
 TOTAL=$((PASS + FAIL))

--- a/tests/test-codex-install.sh
+++ b/tests/test-codex-install.sh
@@ -84,7 +84,8 @@ text = Path(sys.argv[1]).read_text()
 summary = f"<summary><b>{sys.argv[2]}</b></summary>"
 start = text.find(summary)
 if start == -1:
-    raise SystemExit(1)
+    print("")
+    raise SystemExit(0)
 end = text.find("</details>", start)
 if end == -1:
     end = len(text)
@@ -101,7 +102,7 @@ text = Path(sys.argv[1]).read_text()
 heading = f"## {sys.argv[2]}\n"
 index = text.find(heading)
 if index == -1:
-    print(text)
+    print("")
 else:
     print(text[:index])
 PY
@@ -116,7 +117,8 @@ text = Path(sys.argv[1]).read_text()
 heading = f"## {sys.argv[2]}\n"
 start = text.find(heading)
 if start == -1:
-    raise SystemExit(1)
+    print("")
+    raise SystemExit(0)
 remainder = text[start:]
 next_index = remainder.find("\n## ", len(heading))
 if next_index == -1:

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -17,6 +17,8 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+. "$SCRIPT_DIR/test-lib.sh"
 # Use a non-reserved variable name — TMPDIR is POSIX/macOS system env
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
@@ -62,14 +64,7 @@ assert_not_contains() {
   fi
 }
 
-git_nested() {
-  local env_cmd=(env)
-  local git_var
-  while IFS= read -r git_var; do
-    env_cmd+=(-u "$git_var")
-  done < <(git rev-parse --local-env-vars)
-  "${env_cmd[@]}" git "$@"
-}
+git_nested_prepare || exit 1
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -79,32 +74,6 @@ git_nested() {
 make_project() {
   local dir="$1"
   mkdir -p "$dir/.specwright/state"
-}
-
-init_git_repo() {
-  local dir="$1"
-  mkdir -p "$dir"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
-  printf 'seed\n' > "$dir/README.md"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
-}
-
-run_with_outer_git_context() {
-  local outer="$1"
-  shift
-  local outer_git_dir outer_common_dir outer_root
-  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
-  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
-  outer_root="$(cd "$outer" && pwd -P)"
-  GIT_DIR="$outer_git_dir" \
-  GIT_WORK_TREE="$outer_root" \
-  GIT_COMMON_DIR="$outer_common_dir" \
-  GIT_PREFIX="" \
-  "$@"
 }
 
 run_resolver_json() {
@@ -132,14 +101,6 @@ write_workflow() {
   "gates": {}
 }
 EOF
-}
-
-git_common_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
-}
-
-git_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
 }
 
 repo_state_root() {

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -62,6 +62,15 @@ assert_not_contains() {
   fi
 }
 
+git_nested() {
+  local env_cmd=(env)
+  local git_var
+  while IFS= read -r git_var; do
+    env_cmd+=(-u "$git_var")
+  done < <(git rev-parse --local-env-vars)
+  "${env_cmd[@]}" git "$@"
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -75,13 +84,27 @@ make_project() {
 init_git_repo() {
   local dir="$1"
   mkdir -p "$dir"
-  git -C "$dir" -c core.hooksPath=/dev/null init -q
-  git -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
+  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
   printf 'seed\n' > "$dir/README.md"
-  git -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
+  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+}
+
+run_with_outer_git_context() {
+  local outer="$1"
+  shift
+  local outer_git_dir outer_common_dir outer_root
+  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
+  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
+  outer_root="$(cd "$outer" && pwd -P)"
+  GIT_DIR="$outer_git_dir" \
+  GIT_WORK_TREE="$outer_root" \
+  GIT_COMMON_DIR="$outer_common_dir" \
+  GIT_PREFIX="" \
+  "$@"
 }
 
 run_resolver_json() {
@@ -112,11 +135,11 @@ EOF
 }
 
 git_common_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-common-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
 }
 
 git_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
 }
 
 repo_state_root() {
@@ -135,7 +158,7 @@ make_shared_project() {
   local dir="$1"
   local work_id="$2"
   local status="${3:-building}"
-  local branch="${4:-$(git -C "$dir" branch --show-current)}"
+  local branch="${4:-$(git_nested -C "$dir" branch --show-current)}"
   local repo_root worktree_root work_dir
 
   repo_root="$(repo_state_root "$dir")"
@@ -184,6 +207,26 @@ EOF
 echo ""
 echo "=== Section 0: specwright-state-paths.mjs ==="
 
+T="$TEST_TMPDIR/t-hook-env-outer"
+U="$TEST_TMPDIR/t-hook-env-target"
+V="$TEST_TMPDIR/t-hook-env-fresh"
+init_git_repo "$T"
+init_git_repo "$U"
+U_REAL="$(cd "$U" && pwd -P)"
+output="$(run_with_outer_git_context "$T" git_common_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "nested git helpers: git_common_dir ignores inherited outer git context"
+output="$(run_with_outer_git_context "$T" git_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "nested git helpers: git_dir ignores inherited outer git context"
+run_with_outer_git_context "$T" init_git_repo "$V" >/dev/null 2>&1
+if git_nested -C "$V" rev-parse HEAD >/dev/null 2>&1; then
+  pass "nested git helpers: init_git_repo creates a temp repo under inherited outer git context"
+else
+  fail "nested git helpers: init_git_repo creates a temp repo under inherited outer git context"
+fi
+output="$(run_with_outer_git_context "$T" run_resolver_json "$U" 2>/dev/null)"
+assert_contains "$output" "\"projectRoot\":\"$U_REAL\"" "state-paths: shared resolver ignores inherited outer git context"
+assert_contains "$output" "\"gitDir\":\"$U_REAL/.git\"" "state-paths: shared resolver keeps the target gitDir under inherited outer git context"
+
 T="$TEST_TMPDIR/t-resolver-primary"
 init_git_repo "$T"
 T_REAL="$(cd "$T" && pwd -P)"
@@ -201,7 +244,7 @@ assert_contains "$output" '"worktreeId":"main-worktree"' "state-paths: primary w
 T="$TEST_TMPDIR/t-resolver-linked-primary"
 L="$TEST_TMPDIR/linked-worktree"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b linked-worktree "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b linked-worktree "$L" HEAD
 T_REAL="$(cd "$T" && pwd -P)"
 L_REAL="$(cd "$L" && pwd -P)"
 output=$(run_resolver_json "$L" 2>/dev/null)
@@ -336,7 +379,7 @@ assert_eq "$output" "" "subagent-context: missing agent_type → no output"
 T="$TEST_TMPDIR/t-subagent-linked-primary"
 L="$TEST_TMPDIR/subagent-linked-worktree"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b subagent-linked-worktree "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b subagent-linked-worktree "$L" HEAD
 make_project "$L"
 mkdir -p "$L/.specwright/work/WU-001" "$L/nested/context"
 write_workflow "$L" ".specwright/work/WU-001"
@@ -350,7 +393,7 @@ assert_contains "$output" "additionalContext" "subagent-context: nested linked w
 T="$TEST_TMPDIR/t-subagent-shared-primary"
 L="$TEST_TMPDIR/subagent-shared-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b subagent-shared-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b subagent-shared-linked "$L" HEAD
 make_shared_project "$L" "shared-subagent"
 mkdir -p "$(repo_state_root "$L")/work/shared-subagent" "$L/nested/shared"
 printf '# Repo Map\nshared session content\n' > "$(repo_state_root "$L")/work/shared-subagent/repo-map.md"
@@ -478,7 +521,7 @@ assert_contains "$output" "Work in progress" "session-start: nested primary work
 T="$TEST_TMPDIR/t-ss-linked-primary"
 L="$TEST_TMPDIR/session-start-linked-worktree"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b session-start-linked-worktree "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b session-start-linked-worktree "$L" HEAD
 make_project "$L"
 write_workflow "$L" ".specwright/work/WU-001" "building"
 mkdir -p "$L/deep/nested"
@@ -491,7 +534,7 @@ assert_contains "$output" "Work in progress" "session-start: nested linked workt
 T="$TEST_TMPDIR/t-ss-shared-primary"
 L="$TEST_TMPDIR/session-start-shared-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b session-start-shared-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b session-start-shared-linked "$L" HEAD
 make_shared_project "$L" "shared-session-start" "building"
 mkdir -p "$L/deep/shared"
 output=$(cd "$L/deep/shared" && node "$SESSION_START_HOOK" 2>/dev/null)

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+git_nested_prepare() {
+  if [ "${GIT_NESTED_LOCAL_ENV_VARS_READY:-0}" = "1" ]; then
+    return 0
+  fi
+
+  if ! GIT_NESTED_LOCAL_ENV_VARS="$(git rev-parse --local-env-vars 2>/dev/null)"; then
+    echo "ERROR: git rev-parse --local-env-vars is required for nested git isolation helpers" >&2
+    return 1
+  fi
+
+  GIT_NESTED_LOCAL_ENV_VARS_READY=1
+}
+
+git_nested() {
+  git_nested_prepare || return 1
+
+  local env_cmd=(env)
+  local git_var
+  while IFS= read -r git_var; do
+    [ -n "$git_var" ] || continue
+    env_cmd+=(-u "$git_var")
+  done <<< "$(printf '%s\n%s\n%s\n' "$GIT_NESTED_LOCAL_ENV_VARS" "GIT_CONFIG_COUNT" "GIT_CONFIG_PARAMETERS")"
+
+  "${env_cmd[@]}" git "$@"
+}
+
+init_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q || return 1
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests" || return 1
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com" || return 1
+  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
+  printf 'seed\n' > "$dir/README.md"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md || return 1
+  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo" || return 1
+}
+
+run_with_outer_git_context() {
+  local outer="$1"
+  shift
+  local outer_git_dir outer_common_dir outer_root
+  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)" || return 1
+  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)" || return 1
+  outer_root="$(cd "$outer" && pwd -P)"
+  GIT_DIR="$outer_git_dir" \
+  GIT_WORK_TREE="$outer_root" \
+  GIT_COMMON_DIR="$outer_common_dir" \
+  GIT_PREFIX="" \
+  "$@"
+}
+
+git_common_dir() {
+  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
+}
+
+git_dir() {
+  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
+}

--- a/tests/test-worktree-migration.sh
+++ b/tests/test-worktree-migration.sh
@@ -6,6 +6,8 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+. "$SCRIPT_DIR/test-lib.sh"
 STATE_PATHS_MODULE="$ROOT_DIR/adapters/shared/specwright-state-paths.mjs"
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
@@ -41,48 +43,7 @@ assert_contains() {
   fi
 }
 
-git_nested() {
-  local env_cmd=(env)
-  local git_var
-  while IFS= read -r git_var; do
-    env_cmd+=(-u "$git_var")
-  done < <(git rev-parse --local-env-vars)
-  "${env_cmd[@]}" git "$@"
-}
-
-init_git_repo() {
-  local dir="$1"
-  mkdir -p "$dir"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
-  printf 'seed\n' > "$dir/README.md"
-  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
-}
-
-run_with_outer_git_context() {
-  local outer="$1"
-  shift
-  local outer_git_dir outer_common_dir outer_root
-  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
-  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
-  outer_root="$(cd "$outer" && pwd -P)"
-  GIT_DIR="$outer_git_dir" \
-  GIT_WORK_TREE="$outer_root" \
-  GIT_COMMON_DIR="$outer_common_dir" \
-  GIT_PREFIX="" \
-  "$@"
-}
-
-git_common_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
-}
-
-git_dir() {
-  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
-}
+git_nested_prepare || exit 1
 
 repo_state_root() {
   printf '%s/specwright\n' "$(git_common_dir "$1")"

--- a/tests/test-worktree-migration.sh
+++ b/tests/test-worktree-migration.sh
@@ -41,24 +41,47 @@ assert_contains() {
   fi
 }
 
+git_nested() {
+  local env_cmd=(env)
+  local git_var
+  while IFS= read -r git_var; do
+    env_cmd+=(-u "$git_var")
+  done < <(git rev-parse --local-env-vars)
+  "${env_cmd[@]}" git "$@"
+}
+
 init_git_repo() {
   local dir="$1"
   mkdir -p "$dir"
-  git -C "$dir" -c core.hooksPath=/dev/null init -q
-  git -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
+  git_nested -C "$dir" -c core.hooksPath=/dev/null init -q
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
   printf 'seed\n' > "$dir/README.md"
-  git -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+  git_nested -C "$dir" -c core.hooksPath=/dev/null add README.md
+  git_nested -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+}
+
+run_with_outer_git_context() {
+  local outer="$1"
+  shift
+  local outer_git_dir outer_common_dir outer_root
+  outer_git_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-dir)"
+  outer_common_dir="$(git_nested -C "$outer" rev-parse --path-format=absolute --git-common-dir)"
+  outer_root="$(cd "$outer" && pwd -P)"
+  GIT_DIR="$outer_git_dir" \
+  GIT_WORK_TREE="$outer_root" \
+  GIT_COMMON_DIR="$outer_common_dir" \
+  GIT_PREFIX="" \
+  "$@"
 }
 
 git_common_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-common-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-common-dir
 }
 
 git_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-dir
+  git_nested -C "$1" rev-parse --path-format=absolute --git-dir
 }
 
 repo_state_root() {
@@ -77,7 +100,7 @@ make_shared_project() {
   local dir="$1"
   local work_id="$2"
   local status="${3:-building}"
-  local branch="${4:-$(git -C "$dir" branch --show-current)}"
+  local branch="${4:-$(git_nested -C "$dir" branch --show-current)}"
   local repo_root worktree_root work_dir
 
   repo_root="$(repo_state_root "$dir")"
@@ -172,11 +195,33 @@ EOF
 echo "=== worktree migration regression ==="
 echo ""
 
+echo "--- Nested git context isolation ---"
+T="$TEST_TMPDIR/hook-env-outer"
+U="$TEST_TMPDIR/hook-env-target"
+V="$TEST_TMPDIR/hook-env-fresh"
+init_git_repo "$T"
+init_git_repo "$U"
+U_REAL="$(cd "$U" && pwd -P)"
+output="$(run_with_outer_git_context "$T" git_common_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "worktree migration: git_common_dir ignores inherited outer git context"
+output="$(run_with_outer_git_context "$T" git_dir "$U" 2>/dev/null)"
+assert_eq "$output" "$U_REAL/.git" "worktree migration: git_dir ignores inherited outer git context"
+run_with_outer_git_context "$T" init_git_repo "$V" >/dev/null 2>&1
+if git_nested -C "$V" rev-parse HEAD >/dev/null 2>&1; then
+  pass "worktree migration: init_git_repo creates a temp repo under inherited outer git context"
+else
+  fail "worktree migration: init_git_repo creates a temp repo under inherited outer git context"
+fi
+make_shared_project "$U" "outer-shared-install"
+mkdir -p "$U/nested/path"
+output="$(run_with_outer_git_context "$T" load_state_json "$U/nested/path" 2>/dev/null)"
+assert_contains "$output" '"workId":"outer-shared-install"' "worktree migration: shared state loading ignores inherited outer git context"
+
 echo "--- Shared new install ---"
 T="$TEST_TMPDIR/shared-primary"
 L="$TEST_TMPDIR/shared-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b shared-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b shared-linked "$L" HEAD
 make_shared_project "$L" "shared-install"
 mkdir -p "$L/nested/path"
 output="$(load_state_json "$L/nested/path")"
@@ -221,7 +266,7 @@ cat > "$(worktree_state_root "$T")/session.json" <<EOF
   "version": "3.0",
   "worktreeId": "test-worktree",
   "worktreePath": "$(cd "$T" && pwd -P)",
-  "branch": "$(git -C "$T" branch --show-current)",
+  "branch": "$(git_nested -C "$T" branch --show-current)",
   "attachedWorkId": "../escape",
   "mode": "top-level",
   "lastSeenAt": "$(fresh_timestamp)"
@@ -250,7 +295,7 @@ cat > "$(repo_state_root "$T")/work/shared-dispatch/workflow.json" <<EOF
   "unitId": "unit-shared-dispatch",
   "tasksCompleted": ["t1"],
   "tasksTotal": 3,
-  "branch": "$(git -C "$T" branch --show-current)",
+  "branch": "$(git_nested -C "$T" branch --show-current)",
   "gates": {
     "build": { "verdict": "PASS" }
   },
@@ -286,7 +331,7 @@ echo "--- Dead session detection ---"
 T="$TEST_TMPDIR/dead-session-primary"
 L="$TEST_TMPDIR/dead-session-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b dead-session-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b dead-session-linked "$L" HEAD
 make_shared_project "$L" "dead-session-work"
 rm -rf "$L"
 output="$(inspect_sessions_json "$T")"


### PR DESCRIPTION
## Summary

This PR ships the `installer-docs` unit for `codex-path-contract`.

It:
- aligns the Codex install docs with the packaged plugin contract and the `specwright:sw-*` slash-command surface
- keeps installer/doc regression coverage on the packaged marketplace path and doc contract
- hardens shared Git state resolution and hook/worktree shell regressions against inherited outer `GIT_*` hook context that previously tainted temp repos during shipping

Advisory warnings carried from verify:
- `AC-2` still lacks explicit negative assertions that packaged installs do **not** create `.agents/skills`, `protocols`, or `agents` compatibility paths
- `.specwright/config.json` still leaves `commands.test:e2e` unconfigured

## Acceptance Criteria

- `AC-1` `PASS`  
  Evidence: `scripts/install-codex.sh:14-28`, `scripts/install-codex.sh:67-84`, `scripts/install-codex.sh:218-271`; tests `tests/test-codex-install.sh:152-157`, `tests/test-codex-install.sh:203-258`
- `AC-2` `WARN`  
  Evidence: `scripts/install-codex.sh:67-84`, `scripts/install-codex.sh:125-193`, `scripts/install-codex.sh:270-271`; tests `tests/test-codex-install.sh:208-220`, `tests/test-codex-install.sh:254-258`  
  Warning: the suite proves marketplace wiring, but it does not yet assert absence of legacy compatibility directories after packaged install.
- `AC-3` `PASS`  
  Evidence: `README.md:170-189`; tests `tests/test-codex-install.sh:260-266`
- `AC-4` `PASS`  
  Evidence: `adapters/codex/README.md:5-14`, `adapters/codex/README.md:38-46`; tests `tests/test-codex-install.sh:262-269`
- `AC-5` `PASS`  
  Evidence: `tests/test-codex-install.sh:152-157`, `tests/test-codex-install.sh:210`, `tests/test-codex-install.sh:256`, `tests/test-codex-install.sh:260-269`

Behavioral integration checks:
- `IC-B1` `PASS` via `tests/test-codex-install.sh` installer-path verification and `tests/test-codex-build.sh:145-180` command-contract verification
- `IC-B2` `PASS` via `tests/test-codex-install.sh:260-269` and `tests/test-codex-build.sh:145-180`

## Blast Radius

Files changed on this branch:
- `README.md`
- `adapters/codex/README.md`
- `adapters/shared/specwright-state-paths.mjs`
- `tests/test-codex-hooks.sh`
- `tests/test-codex-install.sh`
- `tests/test-hooks.sh`
- `tests/test-worktree-migration.sh`

Operational impact:
- Codex installer/docs contract and packaged-command guidance
- shared Git-root resolution for hook/runtime state discovery
- shell regression coverage for hook/worktree temp-repo behavior

## Gate Results

| Gate | Verdict | Evidence | Notes |
|---|---|---|---|
| build | `PASS` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/build-report.md` | build, eval, and Codex integration tiers passed; smoke unconfigured |
| tests | `WARN` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/test-quality.md` | installer suite still misses legacy-path absence assertions |
| security | `PASS` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/security-report.md` | no secret, injection, or destructive-path regression |
| wiring | `PASS` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/wiring-report.md` | final-unit cross-check stayed structurally clean |
| semantic | `PASS` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/semantic-report.md` | shared resolver and shell regressions are fail-closed |
| spec | `WARN` | `.specwright/work/codex-path-contract/units/installer-docs/evidence/spec-compliance.md` | `AC-2` still has partial test evidence only |

Deliverable verification:
- `IC-B1` `PASS`
- `IC-B2` `PASS`
- `commands.test:integration` `PASS`
- `commands.test:e2e` `WARN` because it is not configured

## Evidence Links

- Spec: `.specwright/work/codex-path-contract/units/installer-docs/spec.md`
- Plan: `.specwright/work/codex-path-contract/units/installer-docs/plan.md`
- Design: `.specwright/work/codex-path-contract/design.md`
- Integration criteria: `.specwright/work/codex-path-contract/integration-criteria.md`
- Verify digest: `.specwright/work/codex-path-contract/units/installer-docs/stage-report.md`
- Build evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/build-report.md`
- Test-quality evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/test-quality.md`
- Security evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/security-report.md`
- Wiring evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/wiring-report.md`
- Semantic evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/semantic-report.md`
- Spec evidence: `.specwright/work/codex-path-contract/units/installer-docs/evidence/spec-compliance.md`
