### PR TITLE
feat(state): add multi-worktree runtime proof

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -107,8 +107,8 @@ Solution architecture and implementation planning are separate skills:
 sw-build supports optional parallel task execution using Claude Code Agent Teams. When enabled and tasks are independent (no file overlap), the build orchestrator:
 
 1. Analyzes plan.md file targets to classify tasks as independent or dependent
-2. Creates isolated git worktrees (`.specwright/worktrees/{task-id}`)
-3. Spawns teammates — each runs the full TDD cycle (tester → executor → refactor) in its worktree
+2. Creates isolated git worktrees and a subordinate `worktreeStateRoot/session.json` for each helper
+3. Spawns teammates — each runs the full TDD cycle (tester → executor → refactor) in its worktree while reading shared artifacts from `repoStateRoot`
 4. Cherry-picks completed worktree commits onto the feature branch
 5. Falls back to sequential execution for dependent or failed tasks
 
@@ -271,9 +271,11 @@ specwright/
 
 Platform markers allow a single core SKILL.md to contain platform-specific body sections without requiring full adapter overrides. Frontmatter differences use the tool mapping/stripping mechanism; body differences use markers.
 
-Runtime state (created by init):
+Runtime state (created by init) is split across logical Git roots:
+
+Shared repo state under `{repoStateRoot}` (`git rev-parse --git-common-dir` + `/specwright`):
 ```
-.specwright/
+{repoStateRoot}/
 ├── config.json       # Project configuration (commands: build, test, test:integration, test:smoke)
 ├── CONSTITUTION.md   # Development practices
 ├── CHARTER.md        # Technology vision
@@ -282,10 +284,9 @@ Runtime state (created by init):
 ├── AUDIT.md          # Codebase health findings (optional)
 ├── research/         # External research briefs (optional)
 │   └── {topic-id}-{date}.md
-├── state/
-│   └── workflow.json # Current state
-└── work/             # Work unit artifacts
+└── work/             # Per-work records and artifacts
     └── {work-id}/
+        ├── workflow.json    # Work lifecycle, units, gates, lock, attachment
         ├── design.md       # Solution design (design-level)
         ├── context.md      # Research findings (design-level)
         ├── assumptions.md  # Design assumptions (design-level)
@@ -297,6 +298,13 @@ Runtime state (created by init):
                 ├── plan.md     # Unit-scoped task breakdown
                 ├── context.md  # Curated subset of parent context
                 └── evidence/   # Gate evidence for this unit
+```
+
+Per-worktree runtime state under `{worktreeStateRoot}` (`git rev-parse --git-dir` + `/specwright`):
+```
+{worktreeStateRoot}/
+├── session.json      # Current worktree attachment, branch, mode, lastSeenAt
+└── continuation.md   # Worktree-local recovery snapshot (optional)
 ```
 
 ## History

--- a/README.md
+++ b/README.md
@@ -338,7 +338,14 @@ When a work unit has 4+ independent tasks, Specwright can execute them in parall
 <details>
 <summary><b>Configuration</b></summary>
 
-Specwright reads project configuration from `.specwright/config.json`:
+Specwright resolves state through Git logical roots. In the shared/session
+layout, repo-wide config, anchor docs, and work records live under
+`git rev-parse --git-common-dir` + `/specwright`, while the current worktree's
+session and continuation files live under `git rev-parse --git-dir` +
+`/specwright`. Legacy checkout-local `.specwright/` is migration fallback
+only.
+
+Project configuration is read from the shared repo state root:
 
 ```json
 {
@@ -375,6 +382,11 @@ specwright/
 ├── DESIGN.md          # Full architecture
 └── README.md
 ```
+
+Runtime state is worktree-aware rather than checkout-singleton: shared work and
+project records live under the Git common-dir `specwright/` root, and each
+worktree keeps its own `session.json` plus `continuation.md` under that
+worktree's Git admin dir.
 
 </details>
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -31,9 +31,9 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 
 Three persistent documents drive all decisions:
 
-- **`.specwright/CONSTITUTION.md`** -- Development practices. How the user wants code written. The AI MUST follow these.
-- **`.specwright/CHARTER.md`** -- Technology vision. What this repo is, who consumes it, architectural invariants.
-- **`.specwright/TESTING.md`** -- Testing strategy. How the project should be tested, what boundaries exist, what may be mocked. Optional — created during init if the user opts in.
+- **`{repoStateRoot}/CONSTITUTION.md`** -- Development practices. How the user wants code written. The AI MUST follow these.
+- **`{repoStateRoot}/CHARTER.md`** -- Technology vision. What this repo is, who consumes it, architectural invariants.
+- **`{repoStateRoot}/TESTING.md`** -- Testing strategy. How the project should be tested, what boundaries exist, what may be mocked. Optional — created during init if the user opts in.
 
 Constitution and Charter are created during init. TESTING.md is created during init if the user opts in. All are referenced during design and plan, validated during verify. Precedence: Constitution (rules) > Testing Strategy (approach) > patterns.md (reference). Constitution always wins on conflict.
 
@@ -42,7 +42,8 @@ Constitution and Charter are created during init. TESTING.md is created during i
 - `skills/` -- SKILL.md files (goal + constraints, not procedures)
 - `protocols/` -- Shared protocols for fragile operations (loaded on demand)
 - `agents/` -- Agent prompt definitions (7 agents: architect, tester, integration-tester, executor, reviewer, build-fixer, researcher)
-- `.specwright/` -- Runtime state, config, anchor docs, work artifacts
+- `repoStateRoot` (`git rev-parse --git-common-dir` + `/specwright`) -- shared config, anchor docs, research, and per-work artifacts
+- `worktreeStateRoot` (`git rev-parse --git-dir` + `/specwright`) -- current worktree session and continuation state
 
 See `DESIGN.md` for the full architecture document.
 

--- a/adapters/claude-code/hooks/session-start.mjs
+++ b/adapters/claude-code/hooks/session-start.mjs
@@ -6,12 +6,17 @@
  */
 
 import { readFileSync, existsSync, unlinkSync } from 'fs';
-import { loadSpecwrightState, normalizeActiveWork } from '../../shared/specwright-state-paths.mjs';
+import {
+  findSelectedWorkOwnerConflict,
+  loadSpecwrightState,
+  normalizeActiveWork
+} from '../../shared/specwright-state-paths.mjs';
 
 try {
   const stateInfo = loadSpecwrightState();
   const continuationPath = stateInfo.continuationPath;
   const work = normalizeActiveWork(stateInfo);
+  const ownerConflict = findSelectedWorkOwnerConflict(stateInfo);
 
   if (!work || ['shipped', 'abandoned'].includes(work.status)) {
     process.exit(0);
@@ -19,6 +24,9 @@ try {
 
   const lockWarning = work.lock
     ? `\n⚠ Lock held by "${work.lock.skill}" since ${work.lock.since}`
+    : '';
+  const ownershipWarning = ownerConflict
+    ? `\n  WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
     : '';
 
   let continuationContent = '';
@@ -63,6 +71,7 @@ try {
     `  Spec: ${work.specPath}`,
     `  Plan: ${work.planPath}`,
     lockWarning,
+    ownershipWarning,
     shippingWarning,
     continuationContent
   ].filter(Boolean).join('\n');

--- a/adapters/codex/hooks/session-start.mjs
+++ b/adapters/codex/hooks/session-start.mjs
@@ -6,12 +6,17 @@
  */
 
 import { readFileSync, existsSync, unlinkSync } from 'fs';
-import { loadSpecwrightState, normalizeActiveWork } from '../../shared/specwright-state-paths.mjs';
+import {
+  findSelectedWorkOwnerConflict,
+  loadSpecwrightState,
+  normalizeActiveWork
+} from '../../shared/specwright-state-paths.mjs';
 
 try {
   const stateInfo = loadSpecwrightState();
   const continuationPath = stateInfo.continuationPath;
   const work = normalizeActiveWork(stateInfo);
+  const ownerConflict = findSelectedWorkOwnerConflict(stateInfo);
 
   if (!work || ['shipped', 'abandoned'].includes(work.status)) {
     process.exit(0);
@@ -20,6 +25,9 @@ try {
   const unitLine = work.unitId ? `  Active Unit: ${work.unitId}\n` : '';
   const lockWarning = work.lock
     ? `\n  WARNING: Lock held by "${work.lock.skill}" since ${work.lock.since}`
+    : '';
+  const ownershipWarning = ownerConflict
+    ? `\n  WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
     : '';
 
   let continuationContent = '';
@@ -55,6 +63,7 @@ try {
     `  Spec: ${work.specPath}`,
     `  Plan: ${work.planPath}`,
     lockWarning,
+    ownershipWarning,
     shippingWarning,
     continuationContent
   ].filter(Boolean).join('\n');

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -441,3 +441,45 @@ export function inspectWorktreeSessions(options = {}) {
     deadSessions: sessions.filter((session) => !session.live)
   };
 }
+
+function isTopLevelSession(session) {
+  return Boolean(session) && session.mode !== 'subordinate';
+}
+
+export function findSelectedWorkOwnerConflict(stateInfo, options = {}) {
+  const currentSession = stateInfo?.session;
+  const attachedWorkId = stateInfo?.attachedWorkId;
+
+  if (stateInfo?.layout !== 'shared' || !currentSession || !attachedWorkId || !isTopLevelSession(currentSession)) {
+    return null;
+  }
+
+  const sessionsInfo = inspectWorktreeSessions({
+    cwd: options.cwd ?? stateInfo.projectRoot ?? process.cwd()
+  });
+
+  if (!sessionsInfo?.ok) {
+    return null;
+  }
+
+  const owner = sessionsInfo.sessions.find((session) =>
+    session.live &&
+    isTopLevelSession(session) &&
+    session.attachedWorkId === attachedWorkId &&
+    session.worktreeId !== stateInfo.worktreeId
+  );
+
+  if (!owner) {
+    return null;
+  }
+
+  return {
+    workId: attachedWorkId,
+    currentWorktreeId: stateInfo.worktreeId ?? null,
+    currentWorktreePath: stateInfo.projectRoot ?? null,
+    ownerWorktreeId: owner.worktreeId,
+    ownerWorktreePath: owner.worktreePath,
+    ownerBranch: owner.branch ?? null,
+    ownerSessionPath: owner.sessionPath
+  };
+}

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -185,6 +185,10 @@ function buildWorkArtifacts(baseDir, workId, workDir) {
   };
 }
 
+function isActiveWorkflowStatus(status) {
+  return Boolean(status) && !['shipped', 'abandoned'].includes(status);
+}
+
 function parseWorktreeList(text) {
   const entries = [];
   let current = null;
@@ -482,4 +486,116 @@ export function findSelectedWorkOwnerConflict(stateInfo, options = {}) {
     ownerBranch: owner.branch ?? null,
     ownerSessionPath: owner.sessionPath
   };
+}
+
+function summarizeActiveWork(work) {
+  if (!work) {
+    return null;
+  }
+
+  return {
+    workId: work.workId,
+    status: work.status ?? null,
+    unitId: work.unitId ?? null,
+    branch: work.branch ?? null
+  };
+}
+
+function summarizeSession(stateInfo) {
+  return {
+    worktreeId: stateInfo?.worktreeId ?? null,
+    branch: stateInfo?.session?.branch ?? null,
+    mode: stateInfo?.session?.mode ?? null,
+    attachedWorkId: stateInfo?.attachedWorkId ?? null
+  };
+}
+
+function resolveWorkflowOwner(workflow, sessionsInfo) {
+  const liveOwner = sessionsInfo?.sessions?.find((session) =>
+    session.live &&
+    isTopLevelSession(session) &&
+    session.attachedWorkId === workflow.id
+  );
+
+  return {
+    ownerWorktreeId: liveOwner?.worktreeId ?? workflow.attachment?.worktreeId ?? null,
+    ownerLive: Boolean(liveOwner),
+    ownerBranch: liveOwner?.branch ?? workflow.branch ?? null,
+    ownerWorktreePath: liveOwner?.worktreePath ?? workflow.attachment?.worktreePath ?? null
+  };
+}
+
+export function buildStatusView(stateInfo, options = {}) {
+  const work = normalizeActiveWork(stateInfo);
+  const view = {
+    roots: {
+      repoStateRoot: stateInfo?.repoStateRoot ?? null,
+      worktreeStateRoot: stateInfo?.worktreeStateRoot ?? null
+    },
+    session: summarizeSession(stateInfo),
+    attachedWork: summarizeActiveWork(work),
+    otherActiveWorks: [],
+    staleAttachments: []
+  };
+
+  if (stateInfo?.layout !== 'shared' || !stateInfo?.repoStateRoot) {
+    return view;
+  }
+
+  const sessionsInfo = inspectWorktreeSessions({
+    cwd: options.cwd ?? stateInfo.projectRoot ?? process.cwd()
+  });
+  if (!sessionsInfo?.ok) {
+    return view;
+  }
+
+  const workRoot = resolve(stateInfo.repoStateRoot, 'work');
+  if (existsSync(workRoot)) {
+    const otherActiveWorks = [];
+
+    for (const entry of readdirSync(workRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const workflowPath = join(workRoot, entry.name, 'workflow.json');
+      if (!existsSync(workflowPath)) {
+        continue;
+      }
+
+      let workflow;
+      try {
+        workflow = parseJsonFile(workflowPath);
+      } catch {
+        continue;
+      }
+
+      if (!workflow?.id || !isActiveWorkflowStatus(workflow.status) || workflow.id === stateInfo.attachedWorkId) {
+        continue;
+      }
+
+      const owner = resolveWorkflowOwner(workflow, sessionsInfo);
+      otherActiveWorks.push({
+        workId: workflow.id,
+        status: workflow.status ?? null,
+        ownerWorktreeId: owner.ownerWorktreeId,
+        ownerLive: owner.ownerLive,
+        ownerBranch: owner.ownerBranch,
+        ownerWorktreePath: owner.ownerWorktreePath,
+        unitId: workflow.unitId ?? null
+      });
+    }
+
+    view.otherActiveWorks = otherActiveWorks.sort((a, b) => a.workId.localeCompare(b.workId));
+  }
+
+  view.staleAttachments = sessionsInfo.deadSessions
+    .filter((session) => isTopLevelSession(session) && session.attachedWorkId)
+    .map((session) => ({
+      worktreeId: session.worktreeId,
+      attachedWorkId: session.attachedWorkId,
+      deadReason: session.deadReason
+    }));
+
+  return view;
 }

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -387,7 +387,7 @@ assert_file_not_contains "$ROOT_DIR/DESIGN.md" "workflow.json # Current state" "
 
 assert_file_contains "$CC_DIST/CLAUDE.md" "repoStateRoot" "dist CLAUDE.md references the shared repo state root"
 assert_file_contains "$CC_DIST/CLAUDE.md" "worktreeStateRoot" "dist CLAUDE.md references the per-worktree state root"
-assert_file_not_contains "$CC_DIST/CLAUDE.md" '**`.specwright/CONSTITUTION.md`**' "dist CLAUDE.md no longer points anchor docs at checkout-local .specwright/"
+assert_file_not_contains "$CC_DIST/CLAUDE.md" "**\`.specwright/CONSTITUTION.md\`**" "dist CLAUDE.md no longer points anchor docs at checkout-local .specwright/"
 
 # ═══════════════════════════════════════════════════════════════════════
 # AC-3: Identity mapping — tool names unchanged, no lowercased tools
@@ -1079,7 +1079,7 @@ fi
 HARNESS_OUTPUT="$(bash "$MULTI_WORKTREE_RUNTIME_TEST" 2>&1)" || {
   fail "tests/test-multi-worktree-state.sh passes under the configured test path"
   echo "  Harness output:"
-  echo "$HARNESS_OUTPUT" | sed 's/^/    /'
+  printf '    %s\n' "${HARNESS_OUTPUT//$'\n'/$'\n    '}"
   echo ""
   echo "RESULT: $PASS passed, $FAIL failed (runtime harness failed)"
   rm -rf "$DIST_DIR"
@@ -1091,6 +1091,11 @@ if echo "$HARNESS_OUTPUT" | grep -Fq "AC-2: same-work attachment surfaces adopt/
   pass "runtime harness output includes same-work takeover coverage"
 else
   fail "runtime harness output missing same-work takeover coverage"
+fi
+if echo "$HARNESS_OUTPUT" | grep -Fq "IC-B2: status view reports attached work and repo-active owners"; then
+  pass "runtime harness output includes sw-status repo-active ownership coverage"
+else
+  fail "runtime harness output missing sw-status repo-active ownership coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -55,6 +55,28 @@ assert_eq() {
   fi
 }
 
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    fail "$label (found unexpected: '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
 # Extract YAML frontmatter (content between first --- and second ---)
 extract_frontmatter() {
   local file="$1"
@@ -351,6 +373,21 @@ if [ -f "$CC_DIST/README.md" ]; then
 else
   fail "README.md missing from dist/claude-code/"
 fi
+
+echo "--- Worktree-aware root docs ---"
+
+assert_file_contains "$ROOT_DIR/README.md" "git rev-parse --git-common-dir" "README.md documents shared repo state via git-common-dir"
+assert_file_contains "$ROOT_DIR/README.md" "git rev-parse --git-dir" "README.md documents per-worktree session state via git-dir"
+assert_file_not_contains "$ROOT_DIR/README.md" ".specwright/config.json" "README.md no longer points config at checkout-local .specwright/config.json"
+
+assert_file_contains "$ROOT_DIR/DESIGN.md" "{repoStateRoot}" "DESIGN.md describes the shared repo state root"
+assert_file_contains "$ROOT_DIR/DESIGN.md" "{worktreeStateRoot}" "DESIGN.md describes the per-worktree state root"
+assert_file_not_contains "$ROOT_DIR/DESIGN.md" ".specwright/worktrees/" "DESIGN.md no longer describes helper worktrees under .specwright/worktrees/"
+assert_file_not_contains "$ROOT_DIR/DESIGN.md" "workflow.json # Current state" "DESIGN.md no longer describes a singleton .specwright/state/workflow.json layout"
+
+assert_file_contains "$CC_DIST/CLAUDE.md" "repoStateRoot" "dist CLAUDE.md references the shared repo state root"
+assert_file_contains "$CC_DIST/CLAUDE.md" "worktreeStateRoot" "dist CLAUDE.md references the per-worktree state root"
+assert_file_not_contains "$CC_DIST/CLAUDE.md" '**`.specwright/CONSTITUTION.md`**' "dist CLAUDE.md no longer points anchor docs at checkout-local .specwright/"
 
 # ═══════════════════════════════════════════════════════════════════════
 # AC-3: Identity mapping — tool names unchanged, no lowercased tools

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Tests for the Claude Code build output (AC-1 through AC-13)
+# Tests for the Claude Code build output (AC-1 through AC-14)
 #
 # Runs the actual build and inspects dist/claude-code/ output:
 #   AC-1:  File setup, helpers, build invocation, cleanup
@@ -14,6 +14,7 @@
 #   AC-9:  sw-build content (Task tools, "Task tracking", "Mid-build checks")
 #   AC-10: No opencode artifacts (no commands/, package.json, plugin.ts)
 #   AC-11: Source files not modified by build
+#   AC-14: Configured test path executes the multi-worktree runtime harness
 #   AC-13: Exit 0 with summary showing 0 failures
 #
 # Dependencies: bash, jq, node
@@ -28,6 +29,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_SCRIPT="$ROOT_DIR/build/build.sh"
 DIST_DIR="$ROOT_DIR/dist"
 CC_DIST="$DIST_DIR/claude-code"
+MULTI_WORKTREE_RUNTIME_TEST="$ROOT_DIR/tests/test-multi-worktree-state.sh"
 
 PASS=0
 FAIL=0
@@ -86,9 +88,13 @@ extract_allowed_tools() {
   echo "$fm" | sed -n '/^allowed-tools:/,/^[^ ]/{/^  - /p;}' | sed 's/^  - //'
 }
 
+git_source_status() {
+  git --git-dir="$ROOT_DIR/.git" --work-tree="$ROOT_DIR" status --porcelain -- core/ adapters/
+}
+
 # ─── Pre-flight ──────────────────────────────────────────────────────
 
-echo "=== AC-1 through AC-11, AC-13: Claude Code build integration tests ==="
+echo "=== AC-1 through AC-14: Claude Code build integration tests ==="
 echo ""
 
 if ! command -v jq &>/dev/null; then
@@ -108,7 +114,7 @@ fi
 
 # Capture pre-build source state so AC-11 checks for build-introduced mutations,
 # not intentional edits already present on the current branch.
-PRE_BUILD_SOURCE_STATUS=$(git -C "$ROOT_DIR" status --porcelain -- core/ adapters/)
+PRE_BUILD_SOURCE_STATUS=$(git_source_status)
 
 # ─── Clean pre-existing dist to avoid stale state ────────────────────
 
@@ -1021,6 +1027,36 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════
+# AC-14: Normal test path executes the runtime harness
+# ═══════════════════════════════════════════════════════════════════════
+
+echo ""
+echo "=== AC-14: Multi-worktree runtime harness ==="
+
+if [ -x "$MULTI_WORKTREE_RUNTIME_TEST" ]; then
+  pass "tests/test-multi-worktree-state.sh is executable"
+else
+  fail "tests/test-multi-worktree-state.sh is missing or not executable"
+fi
+
+HARNESS_OUTPUT="$(bash "$MULTI_WORKTREE_RUNTIME_TEST" 2>&1)" || {
+  fail "tests/test-multi-worktree-state.sh passes under the configured test path"
+  echo "  Harness output:"
+  echo "$HARNESS_OUTPUT" | sed 's/^/    /'
+  echo ""
+  echo "RESULT: $PASS passed, $FAIL failed (runtime harness failed)"
+  rm -rf "$DIST_DIR"
+  exit 1
+}
+
+pass "tests/test-multi-worktree-state.sh passes under the configured test path"
+if echo "$HARNESS_OUTPUT" | grep -Fq "AC-2: same-work attachment surfaces adopt/takeover guidance"; then
+  pass "runtime harness output includes same-work takeover coverage"
+else
+  fail "runtime harness output missing same-work takeover coverage"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════
 # AC-11: Source files not modified by build
 # ═══════════════════════════════════════════════════════════════════════
 
@@ -1074,7 +1110,7 @@ fi
 
 echo "--- Core and adapter source integrity (git diff) ---"
 
-POST_BUILD_SOURCE_STATUS=$(git -C "$ROOT_DIR" status --porcelain -- core/ adapters/)
+POST_BUILD_SOURCE_STATUS=$(git_source_status)
 if [ "$POST_BUILD_SOURCE_STATUS" = "$PRE_BUILD_SOURCE_STATUS" ]; then
   pass "build left core/ and adapters/ source state unchanged"
 else

--- a/tests/test-codex-hooks.sh
+++ b/tests/test-codex-hooks.sh
@@ -47,6 +47,15 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -Fq "$needle"; then
+    fail "$label (found unexpected: '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
 init_git_repo() {
   local dir="$1"
   mkdir -p "$dir"
@@ -257,6 +266,38 @@ output="$(
   } 2>/dev/null || true
 )"
 assert_contains "$output" "shared-codex-start (building)" "session-start resolves shared attached work from linked worktree"
+assert_not_contains "$output" "Failed to read state" "session-start does not fail on linked shared-state worktree without checkout-local config"
+if [ -e "$L/.specwright/config.json" ]; then
+  fail "session-start shared-state fixture unexpectedly created checkout-local config"
+else
+  pass "session-start shared-state fixture omits checkout-local config"
+fi
+
+T="$TEST_TMPDIR/session-start-shared-conflict-primary"
+L="$TEST_TMPDIR/codex-session-start-shared-conflict"
+init_git_repo "$T"
+git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b codex-session-start-shared-conflict "$L" HEAD
+make_shared_project "$T" "shared-codex-conflict" "building"
+mkdir -p "$(worktree_state_root "$L")"
+cat > "$(worktree_state_root "$L")/session.json" <<EOF
+{
+  "version": "3.0",
+  "worktreeId": "codex-session-start-shared-conflict",
+  "worktreePath": "$(cd "$L" && pwd -P)",
+  "branch": "codex-session-start-shared-conflict",
+  "attachedWorkId": "shared-codex-conflict",
+  "mode": "top-level",
+  "lastSeenAt": "$(fresh_timestamp)"
+}
+EOF
+output="$(
+  {
+    cd "$L" &&
+    node "$SESSION_START_HOOK"
+  } 2>/dev/null || true
+)"
+assert_contains "$output" "already active in another top-level worktree" "session-start warns when another top-level worktree already owns the shared work"
+assert_contains "$output" "Adopt/takeover required before mutating or shipping it here." "session-start gives adopt/takeover guidance for shared-work conflicts"
 
 echo "--- PreToolUse shipping guard ---"
 T="$TEST_TMPDIR/pre-ship-blocked"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -498,6 +498,35 @@ output=$(cd "$L/deep/shared" && node "$SESSION_START_HOOK" 2>/dev/null)
 exit_code=$?
 assert_eq "$exit_code" "0" "session-start: shared linked worktree → exit 0"
 assert_contains "$output" "shared-session-start (building)" "session-start: shared linked worktree → resolves attached shared work"
+assert_not_contains "$output" "Failed to read state" "session-start: shared linked worktree → does not fail without checkout-local config"
+if [ -e "$L/.specwright/config.json" ]; then
+  fail "session-start: shared linked worktree fixture unexpectedly created checkout-local config"
+else
+  pass "session-start: shared linked worktree fixture omits checkout-local config"
+fi
+
+T="$TEST_TMPDIR/t-ss-shared-conflict-primary"
+L="$TEST_TMPDIR/session-start-shared-conflict-linked"
+init_git_repo "$T"
+git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b session-start-shared-conflict-linked "$L" HEAD
+make_shared_project "$T" "shared-conflict" "building"
+mkdir -p "$(worktree_state_root "$L")"
+cat > "$(worktree_state_root "$L")/session.json" <<EOF
+{
+  "version": "3.0",
+  "worktreeId": "session-start-shared-conflict-linked",
+  "worktreePath": "$(cd "$L" && pwd -P)",
+  "branch": "session-start-shared-conflict-linked",
+  "attachedWorkId": "shared-conflict",
+  "mode": "top-level",
+  "lastSeenAt": "$(fresh_timestamp)"
+}
+EOF
+output=$(cd "$L" && node "$SESSION_START_HOOK" 2>/dev/null)
+exit_code=$?
+assert_eq "$exit_code" "0" "session-start: shared ownership conflict → exit 0"
+assert_contains "$output" "already active in another top-level worktree" "session-start: shared ownership conflict → warns about another top-level owner"
+assert_contains "$output" "Adopt/takeover required before mutating or shipping it here." "session-start: shared ownership conflict → gives adopt/takeover guidance"
 
 # AC-6: Active work, fresh continuation WITH Correction Summary → output contains both sections
 T="$TEST_TMPDIR/t-ss-fresh-cont"

--- a/tests/test-multi-worktree-state.sh
+++ b/tests/test-multi-worktree-state.sh
@@ -195,6 +195,21 @@ EOF
   )
 }
 
+inspect_status_view() {
+  local dir="$1"
+  (
+    cd "$dir" &&
+    STATE_PATHS_MODULE="$STATE_PATHS_MODULE" node --input-type=module <<'EOF'
+const {
+  buildStatusView,
+  loadSpecwrightState
+} = await import(process.env.STATE_PATHS_MODULE);
+const state = loadSpecwrightState();
+process.stdout.write(JSON.stringify(buildStatusView(state)));
+EOF
+  )
+}
+
 echo "=== Multi-worktree runtime state regression ==="
 echo ""
 
@@ -216,6 +231,15 @@ assert_contains "$linked_output" "work-beta (building)" "linked worktree resolve
 assert_not_contains "$linked_output" "work-alpha (building)" "linked worktree does not surface the primary worktree's work"
 assert_contains "$(cat "$(worktree_state_root "$T")/session.json")" '"attachedWorkId": "work-alpha"' "primary session keeps its attached work after linked worktree reads state"
 assert_contains "$(cat "$(worktree_state_root "$L")/session.json")" '"attachedWorkId": "work-beta"' "linked session keeps its attached work after primary worktree reads state"
+
+echo ""
+echo "--- IC-B2: status view reports attached work and repo-active owners ---"
+primary_status_view="$(inspect_status_view "$T")"
+linked_status_view="$(inspect_status_view "$L")"
+assert_contains "$primary_status_view" '"attachedWork":{"workId":"work-alpha"' "primary status view reports the attached work for the current worktree"
+assert_contains "$primary_status_view" '"otherActiveWorks":[{"workId":"work-beta","status":"building","ownerWorktreeId":"ac1-linked","ownerLive":true' "primary status view surfaces the other active work with its owner worktree"
+assert_contains "$linked_status_view" '"attachedWork":{"workId":"work-beta"' "linked status view reports the attached work for that worktree"
+assert_contains "$linked_status_view" '"otherActiveWorks":[{"workId":"work-alpha","status":"building","ownerWorktreeId":"main-worktree","ownerLive":true' "linked status view surfaces the primary worktree's active work and owner"
 
 echo ""
 echo "--- AC-2: same-work attachment surfaces adopt/takeover guidance ---"

--- a/tests/test-multi-worktree-state.sh
+++ b/tests/test-multi-worktree-state.sh
@@ -6,6 +6,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/test-lib.sh"
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
@@ -44,25 +47,7 @@ assert_not_contains() {
   fi
 }
 
-init_git_repo() {
-  local dir="$1"
-  mkdir -p "$dir"
-  git -C "$dir" -c core.hooksPath=/dev/null init -q
-  git -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
-  git -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
-  git -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
-  printf 'seed\n' > "$dir/README.md"
-  git -C "$dir" -c core.hooksPath=/dev/null add README.md
-  git -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
-}
-
-git_common_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-common-dir
-}
-
-git_dir() {
-  git -C "$1" rev-parse --path-format=absolute --git-dir
-}
+git_nested_prepare || exit 1
 
 repo_state_root() {
   printf '%s/specwright\n' "$(git_common_dir "$1")"
@@ -217,7 +202,7 @@ echo "--- AC-1: distinct top-level worktrees keep distinct active works ---"
 T="$TEST_TMPDIR/ac1-primary"
 L="$TEST_TMPDIR/ac1-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac1-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac1-linked "$L" HEAD
 write_shared_config "$T"
 write_shared_workflow "$T" "work-alpha" "building" "main" "unit-alpha" "main-worktree"
 write_shared_workflow "$T" "work-beta" "building" "ac1-linked" "unit-beta" "ac1-linked"
@@ -246,7 +231,7 @@ echo "--- AC-2: same-work attachment surfaces adopt/takeover guidance ---"
 T="$TEST_TMPDIR/ac2-primary"
 L="$TEST_TMPDIR/ac2-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac2-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac2-linked "$L" HEAD
 write_shared_config "$T"
 write_shared_workflow "$T" "work-shared" "building" "main" "unit-shared" "main-worktree"
 write_shared_session "$T" "main-worktree" "main" "work-shared"
@@ -266,7 +251,7 @@ echo "--- AC-3: migrated linked worktree resolves without local .specwright/conf
 T="$TEST_TMPDIR/ac3-primary"
 L="$TEST_TMPDIR/ac3-linked"
 init_git_repo "$T"
-git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac3-linked "$L" HEAD
+git_nested -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac3-linked "$L" HEAD
 write_legacy_workflow "$T" "legacy-only"
 write_shared_config "$T"
 write_shared_workflow "$T" "migrated-work" "building" "ac3-linked" "unit-migrated" "ac3-linked"

--- a/tests/test-multi-worktree-state.sh
+++ b/tests/test-multi-worktree-state.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# Temp-repo runtime coverage for the shared/session multi-worktree model.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+CLAUDE_SESSION_START_HOOK="$ROOT_DIR/adapters/claude-code/hooks/session-start.mjs"
+CODEX_SESSION_START_HOOK="$ROOT_DIR/adapters/codex/hooks/session-start.mjs"
+STATE_PATHS_MODULE="$ROOT_DIR/adapters/shared/specwright-state-paths.mjs"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -Fq "$needle"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -Fq "$needle"; then
+    fail "$label (found unexpected: '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
+init_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" -c core.hooksPath=/dev/null init -q
+  git -C "$dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
+  git -C "$dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
+  git -C "$dir" -c core.hooksPath=/dev/null checkout -qb main >/dev/null 2>&1 || true
+  printf 'seed\n' > "$dir/README.md"
+  git -C "$dir" -c core.hooksPath=/dev/null add README.md
+  git -C "$dir" -c core.hooksPath=/dev/null commit -qm "test: init repo"
+}
+
+git_common_dir() {
+  git -C "$1" rev-parse --path-format=absolute --git-common-dir
+}
+
+git_dir() {
+  git -C "$1" rev-parse --path-format=absolute --git-dir
+}
+
+repo_state_root() {
+  printf '%s/specwright\n' "$(git_common_dir "$1")"
+}
+
+worktree_state_root() {
+  printf '%s/specwright\n' "$(git_dir "$1")"
+}
+
+fresh_timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+write_shared_config() {
+  local dir="$1"
+  local repo_root
+  repo_root="$(repo_state_root "$dir")"
+  mkdir -p "$repo_root"
+  cat > "$repo_root/config.json" <<'EOF'
+{
+  "version": "2.0"
+}
+EOF
+}
+
+write_shared_workflow() {
+  local dir="$1"
+  local work_id="$2"
+  local status="$3"
+  local branch="$4"
+  local unit_id="$5"
+  local repo_root work_root
+
+  repo_root="$(repo_state_root "$dir")"
+  work_root="$repo_root/work/$work_id"
+  mkdir -p "$work_root"
+  cat > "$work_root/workflow.json" <<EOF
+{
+  "version": "3.0",
+  "id": "$work_id",
+  "status": "$status",
+  "workDir": "work/$work_id",
+  "unitId": "$unit_id",
+  "tasksCompleted": ["task-1"],
+  "tasksTotal": 3,
+  "branch": "$branch",
+  "attachment": {
+    "worktreeId": "${6:-unknown-worktree}",
+    "mode": "top-level"
+  },
+  "gates": {
+    "build": { "verdict": "PASS" },
+    "tests": { "verdict": "PASS" }
+  }
+}
+EOF
+}
+
+write_shared_session() {
+  local dir="$1"
+  local worktree_id="$2"
+  local branch="$3"
+  local work_id="$4"
+  local mode="${5:-top-level}"
+  local worktree_root
+
+  worktree_root="$(worktree_state_root "$dir")"
+  mkdir -p "$worktree_root"
+  cat > "$worktree_root/session.json" <<EOF
+{
+  "version": "3.0",
+  "worktreeId": "$worktree_id",
+  "worktreePath": "$(cd "$dir" && pwd -P)",
+  "branch": "$branch",
+  "attachedWorkId": "$work_id",
+  "mode": "$mode",
+  "lastSeenAt": "$(fresh_timestamp)"
+}
+EOF
+}
+
+write_legacy_workflow() {
+  local dir="$1"
+  local work_id="$2"
+  mkdir -p "$dir/.specwright/state"
+  cat > "$dir/.specwright/state/workflow.json" <<EOF
+{
+  "currentWork": {
+    "id": "$work_id",
+    "status": "building",
+    "workDir": ".specwright/work/$work_id",
+    "tasksCompleted": [],
+    "tasksTotal": 2
+  },
+  "gates": {
+    "build": { "status": "PASS" }
+  }
+}
+EOF
+}
+
+run_claude_session_start() {
+  local dir="$1"
+  (
+    cd "$dir" &&
+    node "$CLAUDE_SESSION_START_HOOK"
+  )
+}
+
+run_codex_session_start() {
+  local dir="$1"
+  (
+    cd "$dir" &&
+    node "$CODEX_SESSION_START_HOOK"
+  )
+}
+
+inspect_owner_conflict() {
+  local dir="$1"
+  (
+    cd "$dir" &&
+    STATE_PATHS_MODULE="$STATE_PATHS_MODULE" node --input-type=module <<'EOF'
+const {
+  findSelectedWorkOwnerConflict,
+  loadSpecwrightState
+} = await import(process.env.STATE_PATHS_MODULE);
+const state = loadSpecwrightState();
+process.stdout.write(JSON.stringify(findSelectedWorkOwnerConflict(state)));
+EOF
+  )
+}
+
+echo "=== Multi-worktree runtime state regression ==="
+echo ""
+
+echo "--- AC-1: distinct top-level worktrees keep distinct active works ---"
+T="$TEST_TMPDIR/ac1-primary"
+L="$TEST_TMPDIR/ac1-linked"
+init_git_repo "$T"
+git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac1-linked "$L" HEAD
+write_shared_config "$T"
+write_shared_workflow "$T" "work-alpha" "building" "main" "unit-alpha" "main-worktree"
+write_shared_workflow "$T" "work-beta" "building" "ac1-linked" "unit-beta" "ac1-linked"
+write_shared_session "$T" "main-worktree" "main" "work-alpha"
+write_shared_session "$L" "ac1-linked" "ac1-linked" "work-beta"
+primary_output="$(run_claude_session_start "$T" 2>/dev/null)"
+linked_output="$(run_claude_session_start "$L" 2>/dev/null)"
+assert_contains "$primary_output" "work-alpha (building)" "primary worktree resolves its own attached work"
+assert_not_contains "$primary_output" "work-beta (building)" "primary worktree does not surface the linked worktree's work"
+assert_contains "$linked_output" "work-beta (building)" "linked worktree resolves its own attached work"
+assert_not_contains "$linked_output" "work-alpha (building)" "linked worktree does not surface the primary worktree's work"
+assert_contains "$(cat "$(worktree_state_root "$T")/session.json")" '"attachedWorkId": "work-alpha"' "primary session keeps its attached work after linked worktree reads state"
+assert_contains "$(cat "$(worktree_state_root "$L")/session.json")" '"attachedWorkId": "work-beta"' "linked session keeps its attached work after primary worktree reads state"
+
+echo ""
+echo "--- AC-2: same-work attachment surfaces adopt/takeover guidance ---"
+T="$TEST_TMPDIR/ac2-primary"
+L="$TEST_TMPDIR/ac2-linked"
+init_git_repo "$T"
+git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac2-linked "$L" HEAD
+write_shared_config "$T"
+write_shared_workflow "$T" "work-shared" "building" "main" "unit-shared" "main-worktree"
+write_shared_session "$T" "main-worktree" "main" "work-shared"
+write_shared_session "$L" "ac2-linked" "ac2-linked" "work-shared"
+conflict_json="$(inspect_owner_conflict "$L")"
+conflict_output="$(run_claude_session_start "$L" 2>/dev/null)"
+codex_conflict_output="$(run_codex_session_start "$L" 2>/dev/null)"
+assert_contains "$conflict_json" '"ownerWorktreeId":"main-worktree"' "owner-conflict helper identifies the active owner"
+assert_contains "$conflict_json" '"workId":"work-shared"' "owner-conflict helper reports the contested work id"
+assert_contains "$conflict_output" "already active in another top-level worktree" "Claude session-start warns about same-work ownership conflicts"
+assert_contains "$conflict_output" "Adopt/takeover required before mutating or shipping it here." "Claude session-start gives adopt/takeover guidance"
+assert_contains "$codex_conflict_output" "already active in another top-level worktree" "Codex session-start warns about same-work ownership conflicts"
+assert_contains "$codex_conflict_output" "Adopt/takeover required before mutating or shipping it here." "Codex session-start gives adopt/takeover guidance"
+
+echo ""
+echo "--- AC-3: migrated linked worktree resolves without local .specwright/config.json ---"
+T="$TEST_TMPDIR/ac3-primary"
+L="$TEST_TMPDIR/ac3-linked"
+init_git_repo "$T"
+git -C "$T" -c core.hooksPath=/dev/null worktree add -q -b ac3-linked "$L" HEAD
+write_legacy_workflow "$T" "legacy-only"
+write_shared_config "$T"
+write_shared_workflow "$T" "migrated-work" "building" "ac3-linked" "unit-migrated" "ac3-linked"
+write_shared_session "$L" "ac3-linked" "ac3-linked" "migrated-work"
+mkdir -p "$L/nested/runtime"
+if [ -e "$L/.specwright/config.json" ]; then
+  fail "linked worktree fixture omits checkout-local .specwright/config.json"
+else
+  pass "linked worktree fixture omits checkout-local .specwright/config.json"
+fi
+migrated_output="$(run_claude_session_start "$L/nested/runtime" 2>/dev/null)"
+assert_contains "$migrated_output" "migrated-work (building)" "migrated linked worktree still resolves shared state without local config"
+assert_not_contains "$migrated_output" "Failed to read state" "migrated linked worktree does not fail state resolution without local config"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Finalize the `multi-worktree-state` design with executable runtime proof in real temp repositories and align the top-level documentation with the shipped shared-repo/per-worktree session model.

## Acceptance Criteria

- `AC-1` PASS: two top-level worktrees can hold distinct active works without clearing each other's state. Evidence: `tests/test-multi-worktree-state.sh:216-233`; configured test path runs the harness through `tests/test-claude-code-build.sh:1079-1096`.
- `AC-2` PASS: a second top-level worktree cannot silently attach to an already-owned active work and instead gets explicit adopt/takeover guidance. Evidence: `adapters/shared/specwright-state-paths.mjs:449-485`, `adapters/claude-code/hooks/session-start.mjs:19-30`, `adapters/codex/hooks/session-start.mjs:19-31`, `tests/test-multi-worktree-state.sh:221-238`, `tests/test-hooks.sh:508-529`, `tests/test-codex-hooks.sh:280-300`.
- `AC-3` PASS: migrated linked worktrees no longer fail solely because checkout-local `.specwright/config.json` is absent. Evidence: `tests/test-multi-worktree-state.sh:265-282`, `tests/test-hooks.sh:500-505`, `tests/test-codex-hooks.sh:268-276`.
- `AC-4` PASS: the normal build/test path exercises the multi-worktree runtime coverage. Evidence: `.specwright/config.json:13-18`, `tests/test-claude-code-build.sh:1079-1096`; recorded verify result `900 passed, 1 skipped, 3 deselected` and `216 passed, 0 failed`.
- `AC-5` PASS: top-level docs no longer describe repo-singleton workflow state. Evidence: `README.md:343-348`, `DESIGN.md:274-307`, `adapters/claude-code/CLAUDE.md:45-46`.

## Blast Radius

- Shared state resolution and repo-active status reporting in `adapters/shared/specwright-state-paths.mjs`.
- Claude and Codex session-start guidance for ownership conflicts and migrated linked worktrees.
- Runtime and regression coverage in `tests/test-multi-worktree-state.sh`, `tests/test-hooks.sh`, `tests/test-codex-hooks.sh`, `tests/test-claude-code-build.sh`, `tests/test-codex-install.sh`, `tests/test-lib.sh`, and `tests/test-worktree-migration.sh`.
- Top-level docs in `README.md`, `DESIGN.md`, `adapters/claude-code/CLAUDE.md`, and `adapters/codex/README.md`.

## Gate Results

| Gate | Verdict | Notes |
|---|---|---|
| build | PASS | `bash build/build.sh` passed; `test:integration` and `test:smoke` are unconfigured and were recorded as `SKIP` in build evidence |
| tests | PASS | Runtime harness and hook regressions passed; evidence records strong assertion and boundary coverage |
| security | PASS | No secrets, auth, or new disclosure paths introduced |
| wiring | PASS | Shared resolver remains the single ownership/status source; runtime harness is reachable from the configured test path |
| semantic | PASS | Owner-conflict checks stay scoped to shared attached sessions and added status reporting degrades safely |
| spec | PASS | All Unit 05 ACs have implementation and test evidence; final-unit deliverable verification activated |

## Evidence Links

- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/build-report.md`
- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/test-quality.md`
- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/security-report.md`
- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/wiring-report.md`
- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/semantic-report.md`
- `.specwright/work/multi-worktree-state/units/05-multi-worktree-runtime-proof/evidence/spec-compliance.md`
