### PR TITLE
feat(01-target-model-foundation): ship unit 01 target model foundation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,6 +110,8 @@ jobs:
         run: tests/test-hooks.sh
       - name: Run stage enforcement tests
         run: tests/test-stage-enforcement.sh
+      - name: Run branch freshness target-model regression
+        run: tests/test-branch-freshness-target-model-docs.sh
 
   test-codex:
     runs-on: ubuntu-latest

--- a/core/protocols/git.md
+++ b/core/protocols/git.md
@@ -65,6 +65,11 @@ targeting and checkpoint policy.
 - `roles.{role}.branch` sets a concrete default branch such as `main` or `develop`
 - `roles.{role}.pattern` allows constrained families such as `release/*`
 
+Pattern-based defaults are templates, not autonomous selectors. `sw-design`
+may resolve a `roles.{role}.pattern` entry automatically only when exactly one
+remote branch matches. Zero or multiple matches require an explicit user choice
+so the work records a concrete `targetRef.branch` instead of guessing.
+
 `git.baseBranch` remains supported as a compatibility alias for the default
 integration branch. Writers should prefer `git.targets.roles.integration.branch`
 when the expanded shape exists, but readers must keep honoring `baseBranch`
@@ -113,14 +118,18 @@ but they must not push, verify, or ship the parent work directly.
 
 ## Branch Lifecycle
 
-If the selected work already records `targetRef`, branch setup uses that concrete target before falling back to `git.targets` defaults or the `baseBranch` compatibility alias.
+If the selected work already records `targetRef`, branch setup uses that
+concrete target before falling back to `git.targets` defaults or the
+`baseBranch` compatibility alias.
 
 **Create** (at build start):
 
 ```bash
-git checkout {config.git.baseBranch}
-git fetch origin
-git pull --ff-only origin {config.git.baseBranch}
+TARGET_REMOTE="{resolved target remote}"
+TARGET_BRANCH="{resolved target branch}"
+git fetch "$TARGET_REMOTE"
+git checkout "$TARGET_BRANCH"
+git pull --ff-only "$TARGET_REMOTE" "$TARGET_BRANCH"
 git checkout -b {config.git.branchPrefix}{work-or-unit-id}
 ```
 
@@ -139,10 +148,10 @@ single remote, or a single unit naming scheme outside the config contract.
 
 At build start, after branch setup:
 
-- compare the local base branch with `origin/{baseBranch}`
-- warn if the base branch is behind
+- compare the resolved local target branch with `{target remote}/{target branch}`
+- warn if the resolved target branch is behind
 - if the feature branch already exists, also check upstream drift for the
-  session-attached branch
+  session-attached branch relative to that same resolved target
 
 This is advisory only unless a skill adds a stricter policy.
 

--- a/core/protocols/git.md
+++ b/core/protocols/git.md
@@ -10,6 +10,23 @@ hardcoded.
   "git": {
     "strategy": "trunk-based",
     "baseBranch": "main",
+    "targets": {
+      "defaultRole": "integration",
+      "roles": {
+        "integration": { "branch": "main" },
+        "release": { "branch": "main" },
+        "maintenance": { "pattern": "release/*" }
+      }
+    },
+    "freshness": {
+      "validation": "branch-head",
+      "reconcile": "manual",
+      "checkpoints": {
+        "build": "require",
+        "verify": "require",
+        "ship": "require"
+      }
+    },
     "branchPrefix": "feat/",
     "mergeStrategy": "squash",
     "prRequired": true,
@@ -25,7 +42,9 @@ hardcoded.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `strategy` | enum | `trunk-based` | `trunk-based`, `github-flow`, `gitflow`, `custom` |
-| `baseBranch` | string | `main` | primary integration branch |
+| `baseBranch` | string | `main` | compatibility alias for the default integration branch |
+| `targets` | object | see above | canonical branch-role defaults used to resolve work-level target refs |
+| `freshness` | object | see above | canonical checkpoint policy for build, verify, and ship freshness checks |
 | `branchPrefix` | string | `feat/` | prefix for feature branches |
 | `mergeStrategy` | enum | `squash` | `squash`, `rebase`, `merge` |
 | `prRequired` | boolean | `true` | whether PRs are required for shipping |
@@ -34,6 +53,32 @@ hardcoded.
 | `branchPerWorkUnit` | boolean | `true` | create a branch per work unit |
 | `cleanupBranch` | boolean | `true` | delete branch after merge |
 | `prTool` | string | `gh` | CLI tool for PR creation |
+
+## Branch Role Defaults And Freshness Policy
+
+`git.targets` and `git.freshness` are the canonical config surfaces for branch
+targeting and checkpoint policy.
+
+`git.targets` stays intentionally small:
+
+- `defaultRole` selects the role used when the work does not specify one
+- `roles.{role}.branch` sets a concrete default branch such as `main` or `develop`
+- `roles.{role}.pattern` allows constrained families such as `release/*`
+
+`git.baseBranch` remains supported as a compatibility alias for the default
+integration branch. Writers should prefer `git.targets.roles.integration.branch`
+when the expanded shape exists, but readers must keep honoring `baseBranch`
+during migration.
+
+`git.freshness` defines the lifecycle policy that later stages resolve onto the
+selected work:
+
+- `validation`: `branch-head` or `queue`
+- `reconcile`: `manual`, `rebase`, or `merge`
+- `checkpoints.build|verify|ship`: `ignore`, `warn`, or `require`
+
+This keeps the branch-target model explicit without introducing a custom branch
+DSL.
 
 ## Logical Roots And Selected Work
 
@@ -112,6 +157,11 @@ Read `config.git.strategy`:
 
 For `custom` strategy: prompt the user for operations that are not derivable
 from config.
+
+`sw-init` and `sw-guard` seed or migrate `git.targets` and `git.freshness`
+from the detected workflow strategy. `sw-design` then resolves the selected
+work's concrete `targetRef` from those defaults instead of inferring a target
+from the current checkout alone.
 
 ## Staging Rules
 

--- a/core/protocols/git.md
+++ b/core/protocols/git.md
@@ -113,6 +113,8 @@ but they must not push, verify, or ship the parent work directly.
 
 ## Branch Lifecycle
 
+If the selected work already records `targetRef`, branch setup uses that concrete target before falling back to `git.targets` defaults or the `baseBranch` compatibility alias.
+
 **Create** (at build start):
 
 ```bash

--- a/core/protocols/state.md
+++ b/core/protocols/state.md
@@ -60,6 +60,10 @@ Per-worktree runtime data lives under the active Git admin directory:
 
 Each top-level work owns its own workflow file.
 
+The schema below shows the populated v3 shape. Legacy workflow files may omit
+`targetRef`, `freshness`, `prNumber`, or `prMergedAt` until migration or later
+stages populate them.
+
 ```json
 {
   "version": "3.0",
@@ -136,6 +140,9 @@ Each top-level work owns its own workflow file.
 - `targetRef` is work-level state for the selected work, not a repo-global
   singleton. `sw-design` records the concrete remote, branch, role, and
   resolution source once so later stages stop guessing what the work targets.
+- `targetRef.resolvedBy` is descriptive provenance such as a config path or
+  user override marker. Readers must treat it as explanatory metadata, not as a
+  stable enum or branching primitive.
 - `baselineCommit` remains the design-time HEAD of the recorded target branch.
   `targetRef` is the live branch target for the work and may stay stable even
   after the remote head advances.
@@ -148,7 +155,7 @@ Each top-level work owns its own workflow file.
   omissions as backward-compatible legacy state.
 - Older workflow files may also omit `targetRef` and `freshness`; readers must
   treat both omissions as backward-compatible legacy state until the new model
-  is populated.
+  is populated, even though the schema block above shows the populated shape.
 - `workDir` remains the unit-local artifact path for the selected unit. Skills
   still resolve unit-local files through `workflow.workDir`, never by guessing
   from IDs.

--- a/core/protocols/state.md
+++ b/core/protocols/state.md
@@ -72,6 +72,24 @@ Each top-level work owns its own workflow file.
   "tasksCompleted": ["task-id strings"],
   "currentTask": "string | null",
   "baselineCommit": "string | null",
+  "targetRef": {
+    "remote": "string",
+    "branch": "string",
+    "role": "string",
+    "resolvedBy": "string",
+    "resolvedAt": "ISO timestamp"
+  },
+  "freshness": {
+    "validation": "branch-head | queue",
+    "reconcile": "manual | rebase | merge",
+    "checkpoints": {
+      "build": "ignore | warn | require",
+      "verify": "ignore | warn | require",
+      "ship": "ignore | warn | require"
+    },
+    "status": "unknown | fresh | stale | diverged | blocked | queue-managed",
+    "lastCheckedAt": "ISO timestamp | null"
+  },
   "branch": "string | null",
   "lastCommit": "string | null",
   "workUnits": [
@@ -115,10 +133,22 @@ Each top-level work owns its own workflow file.
   to the current terminal session.
 - `attachment` records the current owner of the work. It replaces the old
   repo-global `currentWork`.
+- `targetRef` is work-level state for the selected work, not a repo-global
+  singleton. `sw-design` records the concrete remote, branch, role, and
+  resolution source once so later stages stop guessing what the work targets.
+- `baselineCommit` remains the design-time HEAD of the recorded target branch.
+  `targetRef` is the live branch target for the work and may stay stable even
+  after the remote head advances.
+- `freshness` stores the selected work's resolved validation mode, reconcile
+  policy, checkpoint severities, and latest known checkpoint result. It belongs
+  to the selected work alongside `targetRef`, not to repo-global state.
 - `workUnits[{n}].prNumber` is an optional, nullable, backward-compatible `number | null` field.
 - `workUnits[{n}].prMergedAt` is an optional, nullable, backward-compatible `ISO timestamp | null` field.
 - Older workflow files may omit either field; readers must treat both
   omissions as backward-compatible legacy state.
+- Older workflow files may also omit `targetRef` and `freshness`; readers must
+  treat both omissions as backward-compatible legacy state until the new model
+  is populated.
 - `workDir` remains the unit-local artifact path for the selected unit. Skills
   still resolve unit-local files through `workflow.workDir`, never by guessing
   from IDs.

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -46,7 +46,10 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 **Branch setup (LOW freedom):** First action before coding: resolve the
 session-selected work from the current worktree, verify that no other live
 top-level worktree owns it, then check out the feature branch from
-`config.git.branchPrefix` and sync it per `protocols/git.md`. Use
+`config.git.branchPrefix` and sync it per `protocols/git.md`. The selected
+work's recorded `targetRef`, when present, is the first branch-resolution
+input via `protocols/git.md`; repo config defaults and the `baseBranch`
+compatibility alias are fallbacks only. Use
 `{git.branchPrefix}{selectedWork.unitId}` for multi-unit work and never commit
 to the base branch. If the selected work is already owned elsewhere, STOP with
 explicit adopt/takeover guidance instead of mutating it silently.

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -113,9 +113,8 @@ Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:
   clear that legacy attachment and reset `workUnits` to null before retargeting
   this worktree.
 - The new selected work's `workflow.json.status` is `designing`.
-- The new selected work's `baselineCommit` is the SHA of
-  `origin/{config.git.baseBranch}` (default `origin/main`). Captures base branch
-  HEAD before any work begins and is never overwritten on re-entry.
+- The new selected work's `targetRef` records the concrete remote, branch, role, resolution source, and resolution time for the selected work.
+- The new selected work's `baselineCommit` is the SHA of the resolved target branch HEAD captured before any work begins and is never overwritten on re-entry.
 - `baselineCommit` also written to `{workDir}/context.md` for historical
   reference.
 

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -115,6 +115,7 @@ Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:
 - The new selected work's `workflow.json.status` is `designing`.
 - The new selected work's `targetRef` records the concrete remote, branch, role, resolution source, and resolution time for the selected work.
 - The new selected work's `baselineCommit` is the SHA of the resolved target branch HEAD captured before any work begins and is never overwritten on re-entry.
+- `targetRef` also written to `{workDir}/context.md` for historical reference.
 - `baselineCommit` also written to `{workDir}/context.md` for historical
   reference.
 

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -114,6 +114,7 @@ Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:
   this worktree.
 - The new selected work's `workflow.json.status` is `designing`.
 - The new selected work's `targetRef` records the concrete remote, branch, role, resolution source, and resolution time for the selected work.
+- The new selected work's `freshness` is seeded from the resolved `git.freshness` config at design time, carrying `validation`, `reconcile`, and `checkpoints`, with `status: "unknown"` and `lastCheckedAt: null`.
 - The new selected work's `baselineCommit` is the SHA of the resolved target branch HEAD captured before any work begins and is never overwritten on re-entry.
 - `targetRef` also written to `{workDir}/context.md` for historical reference.
 - `baselineCommit` also written to `{workDir}/context.md` for historical

--- a/core/skills/sw-guard/SKILL.md
+++ b/core/skills/sw-guard/SKILL.md
@@ -64,6 +64,7 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
 - If `.specwright/config.json` does not exist, rely entirely on detection.
   Validate detected tools by running them (e.g., `--version` check). Present
   standalone recommendations with explicit "detected via heuristics" labeling.
+- When Git workflow config is present or inferred, seed or migrate `git.targets` and `git.freshness` from the detected Git workflow strategy without requiring users to define a custom branch DSL.
 - For unfamiliar stacks or niche tools, use WebSearch to identify tooling conventions.
 - Detect existing guardrails before recommending. Show delta on re-runs.
 

--- a/core/skills/sw-init/SKILL.md
+++ b/core/skills/sw-init/SKILL.md
@@ -114,9 +114,8 @@ Quality gates are configured in config (all six default to enabled; user may dis
 **Git workflow configuration (MEDIUM freedom):**
 - Detect workflow by scanning branch names, remotes, CI files. Present detected strategy with confidence.
 - Confirm via AskUserQuestion: strategy (trunk-based/github-flow/gitflow/custom), branch prefix, merge strategy, PR required, commit format.
-- Store `git.targets` and `git.freshness` in `config.json`.
-- Seed branch-role defaults and freshness checkpoints from the detected workflow strategy while preserving `baseBranch` as a compatibility alias and without requiring users to define a custom branch DSL.
-- Store in `config.json` `git` section per `protocols/git.md`.
+- Store `git.targets` and `git.freshness` in `config.json`, seeding branch-role defaults and freshness checkpoints from the detected workflow strategy while preserving `baseBranch` as a compatibility alias and without requiring users to define a custom branch DSL.
+- Store the resulting settings in the `config.json` `git` section per `protocols/git.md`.
 - If old git schema detected: offer migration with sensible defaults.
 
 **Configuration (LOW freedom):**

--- a/core/skills/sw-init/SKILL.md
+++ b/core/skills/sw-init/SKILL.md
@@ -114,6 +114,8 @@ Quality gates are configured in config (all six default to enabled; user may dis
 **Git workflow configuration (MEDIUM freedom):**
 - Detect workflow by scanning branch names, remotes, CI files. Present detected strategy with confidence.
 - Confirm via AskUserQuestion: strategy (trunk-based/github-flow/gitflow/custom), branch prefix, merge strategy, PR required, commit format.
+- Store `git.targets` and `git.freshness` in `config.json`.
+- Seed branch-role defaults and freshness checkpoints from the detected workflow strategy while preserving `baseBranch` as a compatibility alias and without requiring users to define a custom branch DSL.
 - Store in `config.json` `git` section per `protocols/git.md`.
 - If old git schema detected: offer migration with sensible defaults.
 

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -130,6 +130,8 @@ machine-parseable: `Next: /sw-build`.
 **State mutations (LOW freedom):**
 Follow `protocols/state.md`. Mutate only the selected work's `workflow.json` and
 the current worktree's `session.json`. Transition `designing` → `planning`.
+- preserve the selected work's recorded `targetRef` and freshness metadata in the selected work state and any generated unit context that depends on them.
+- Planning must not collapse back to inferring a single `baseBranch` target.
 Multi-unit: populate the selected work's `workUnits` array, set the first unit
 to `building`, transition the selected work to `building`, and hand off to
 `/sw-build`. Do not clear or retarget unrelated active works owned by other

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -130,8 +130,9 @@ machine-parseable: `Next: /sw-build`.
 **State mutations (LOW freedom):**
 Follow `protocols/state.md`. Mutate only the selected work's `workflow.json` and
 the current worktree's `session.json`. Transition `designing` → `planning`.
-- preserve the selected work's recorded `targetRef` and freshness metadata in the selected work state and any generated unit context that depends on them.
-- Planning must not collapse back to inferring a single `baseBranch` target.
+- Preserve the selected work's recorded `targetRef` and freshness metadata in the selected work state and any generated unit context that depends on them.
+- Do not collapse back to inferring a single `baseBranch` target.
+
 Multi-unit: populate the selected work's `workUnits` array, set the first unit
 to `building`, transition the selected work to `building`, and hand off to
 `/sw-build`. Do not clear or retarget unrelated active works owned by other

--- a/tests/test-branch-freshness-target-model-docs.sh
+++ b/tests/test-branch-freshness-target-model-docs.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Regression checks for the target-branch and freshness model introduced by
+# branch-freshness-policy Unit 01.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+STATE_PROTOCOL="$ROOT_DIR/core/protocols/state.md"
+GIT_PROTOCOL="$ROOT_DIR/core/protocols/git.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+echo "=== branch freshness target model docs ==="
+echo ""
+
+for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- State protocol ---"
+assert_contains "$STATE_PROTOCOL" '"targetRef": {' "workflow schema adds targetRef object"
+assert_contains "$STATE_PROTOCOL" '"remote": "string"' "targetRef records remote"
+assert_contains "$STATE_PROTOCOL" '"branch": "string"' "targetRef records branch"
+assert_contains "$STATE_PROTOCOL" '"role": "string"' "targetRef records role"
+assert_contains "$STATE_PROTOCOL" '"resolvedBy": "string"' "targetRef records resolution source"
+assert_contains "$STATE_PROTOCOL" '"freshness": {' "workflow schema adds freshness metadata"
+
+echo ""
+echo "--- Git protocol ---"
+assert_contains "$GIT_PROTOCOL" '"targets": {' "git config schema adds targets"
+assert_contains "$GIT_PROTOCOL" '"freshness": {' "git config schema adds freshness"
+assert_contains "$GIT_PROTOCOL" 'compatibility alias for the default integration branch' "baseBranch remains a compatibility alias"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/test-branch-freshness-target-model-docs.sh
+++ b/tests/test-branch-freshness-target-model-docs.sh
@@ -10,6 +10,10 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 STATE_PROTOCOL="$ROOT_DIR/core/protocols/state.md"
 GIT_PROTOCOL="$ROOT_DIR/core/protocols/git.md"
+DESIGN_SKILL="$ROOT_DIR/core/skills/sw-design/SKILL.md"
+PLAN_SKILL="$ROOT_DIR/core/skills/sw-plan/SKILL.md"
+INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
+GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
 
 PASS=0
 FAIL=0
@@ -38,7 +42,7 @@ assert_contains() {
 echo "=== branch freshness target model docs ==="
 echo ""
 
-for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL"; do
+for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL"; do
   if [ -f "$file" ]; then
     pass "exists: ${file#"$ROOT_DIR"/}"
   else
@@ -60,6 +64,17 @@ echo "--- Git protocol ---"
 assert_contains "$GIT_PROTOCOL" '"targets": {' "git config schema adds targets"
 assert_contains "$GIT_PROTOCOL" '"freshness": {' "git config schema adds freshness"
 assert_contains "$GIT_PROTOCOL" 'compatibility alias for the default integration branch' "baseBranch remains a compatibility alias"
+
+echo ""
+echo "--- Skill surfaces ---"
+assert_contains "$DESIGN_SKILL" "selected work's \`targetRef\` records the concrete remote, branch, role, resolution source, and resolution time" "sw-design records the concrete targetRef at design time"
+assert_contains "$DESIGN_SKILL" "baselineCommit\` is the SHA of the resolved target branch HEAD" "sw-design ties baselineCommit to the resolved target branch head"
+assert_contains "$PLAN_SKILL" "preserve the selected work's recorded \`targetRef\` and freshness metadata" "sw-plan preserves the recorded target model"
+assert_contains "$PLAN_SKILL" "must not collapse back to inferring a single \`baseBranch\` target" "sw-plan rejects single-base inference drift"
+assert_contains "$INIT_SKILL" "Store \`git.targets\` and \`git.freshness\` in \`config.json\`" "sw-init writes the new git config surfaces"
+assert_contains "$INIT_SKILL" 'without requiring users to define a custom branch DSL' "sw-init avoids a custom branch DSL"
+assert_contains "$GUARD_SKILL" "seed or migrate \`git.targets\` and \`git.freshness\` from the detected Git workflow strategy" "sw-guard seeds or migrates the new git model"
+assert_contains "$GUARD_SKILL" 'without requiring users to define a custom branch DSL' "sw-guard keeps the git model intentionally small"
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-branch-freshness-target-model-docs.sh
+++ b/tests/test-branch-freshness-target-model-docs.sh
@@ -39,6 +39,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    fail "$label"
+  else
+    pass "$label"
+  fi
+}
+
 echo "=== branch freshness target model docs ==="
 echo ""
 
@@ -75,6 +86,14 @@ assert_contains "$INIT_SKILL" "Store \`git.targets\` and \`git.freshness\` in \`
 assert_contains "$INIT_SKILL" 'without requiring users to define a custom branch DSL' "sw-init avoids a custom branch DSL"
 assert_contains "$GUARD_SKILL" "seed or migrate \`git.targets\` and \`git.freshness\` from the detected Git workflow strategy" "sw-guard seeds or migrates the new git model"
 assert_contains "$GUARD_SKILL" 'without requiring users to define a custom branch DSL' "sw-guard keeps the git model intentionally small"
+
+echo ""
+echo "--- Consistency guards ---"
+assert_contains "$DESIGN_SKILL" "\`targetRef\` also written to \`{workDir}/context.md\` for historical reference." "sw-design writes targetRef to context"
+assert_contains "$GIT_PROTOCOL" "If the selected work already records \`targetRef\`, branch setup uses that concrete target before falling back to \`git.targets\` defaults or the \`baseBranch\` compatibility alias." "git branch setup prefers targetRef before compatibility fallbacks"
+for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL"; do
+  assert_not_contains "$file" "\`targetBranch\`" "${file#"$ROOT_DIR"/} avoids targetBranch drift"
+done
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-branch-freshness-target-model-docs.sh
+++ b/tests/test-branch-freshness-target-model-docs.sh
@@ -3,7 +3,7 @@
 # Regression checks for the target-branch and freshness model introduced by
 # branch-freshness-policy Unit 01.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -14,6 +14,7 @@ DESIGN_SKILL="$ROOT_DIR/core/skills/sw-design/SKILL.md"
 PLAN_SKILL="$ROOT_DIR/core/skills/sw-plan/SKILL.md"
 INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
 GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
+BUILD_SKILL="$ROOT_DIR/core/skills/sw-build/SKILL.md"
 
 PASS=0
 FAIL=0
@@ -53,7 +54,7 @@ assert_not_contains() {
 echo "=== branch freshness target model docs ==="
 echo ""
 
-for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL"; do
+for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL" "$BUILD_SKILL"; do
   if [ -f "$file" ]; then
     pass "exists: ${file#"$ROOT_DIR"/}"
   else
@@ -68,6 +69,7 @@ assert_contains "$STATE_PROTOCOL" '"remote": "string"' "targetRef records remote
 assert_contains "$STATE_PROTOCOL" '"branch": "string"' "targetRef records branch"
 assert_contains "$STATE_PROTOCOL" '"role": "string"' "targetRef records role"
 assert_contains "$STATE_PROTOCOL" '"resolvedBy": "string"' "targetRef records resolution source"
+assert_contains "$STATE_PROTOCOL" '"resolvedAt": "ISO timestamp"' "targetRef records resolution timestamp"
 assert_contains "$STATE_PROTOCOL" '"freshness": {' "workflow schema adds freshness metadata"
 
 echo ""
@@ -75,24 +77,27 @@ echo "--- Git protocol ---"
 assert_contains "$GIT_PROTOCOL" '"targets": {' "git config schema adds targets"
 assert_contains "$GIT_PROTOCOL" '"freshness": {' "git config schema adds freshness"
 assert_contains "$GIT_PROTOCOL" 'compatibility alias for the default integration branch' "baseBranch remains a compatibility alias"
+assert_contains "$GIT_PROTOCOL" 'Zero or multiple matches require an explicit user choice' "git protocol defines the safe pattern-resolution rule"
 
 echo ""
 echo "--- Skill surfaces ---"
 assert_contains "$DESIGN_SKILL" "selected work's \`targetRef\` records the concrete remote, branch, role, resolution source, and resolution time" "sw-design records the concrete targetRef at design time"
+assert_contains "$DESIGN_SKILL" "selected work's \`freshness\` is seeded from the resolved \`git.freshness\` config" "sw-design seeds freshness at design time"
 assert_contains "$DESIGN_SKILL" "baselineCommit\` is the SHA of the resolved target branch HEAD" "sw-design ties baselineCommit to the resolved target branch head"
-assert_contains "$PLAN_SKILL" "preserve the selected work's recorded \`targetRef\` and freshness metadata" "sw-plan preserves the recorded target model"
-assert_contains "$PLAN_SKILL" "must not collapse back to inferring a single \`baseBranch\` target" "sw-plan rejects single-base inference drift"
+assert_contains "$PLAN_SKILL" "Preserve the selected work's recorded \`targetRef\` and freshness metadata" "sw-plan preserves the recorded target model"
+assert_contains "$PLAN_SKILL" "Do not collapse back to inferring a single \`baseBranch\` target" "sw-plan rejects single-base inference drift"
 assert_contains "$INIT_SKILL" "Store \`git.targets\` and \`git.freshness\` in \`config.json\`" "sw-init writes the new git config surfaces"
 assert_contains "$INIT_SKILL" 'without requiring users to define a custom branch DSL' "sw-init avoids a custom branch DSL"
 assert_contains "$GUARD_SKILL" "seed or migrate \`git.targets\` and \`git.freshness\` from the detected Git workflow strategy" "sw-guard seeds or migrates the new git model"
 assert_contains "$GUARD_SKILL" 'without requiring users to define a custom branch DSL' "sw-guard keeps the git model intentionally small"
+assert_contains "$BUILD_SKILL" "work's recorded \`targetRef\`, when present, is the first branch-resolution" "sw-build acknowledges targetRef-first branch setup"
 
 echo ""
 echo "--- Consistency guards ---"
 assert_contains "$DESIGN_SKILL" "\`targetRef\` also written to \`{workDir}/context.md\` for historical reference." "sw-design writes targetRef to context"
-assert_contains "$GIT_PROTOCOL" "If the selected work already records \`targetRef\`, branch setup uses that concrete target before falling back to \`git.targets\` defaults or the \`baseBranch\` compatibility alias." "git branch setup prefers targetRef before compatibility fallbacks"
-for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL"; do
-  assert_not_contains "$file" "\`targetBranch\`" "${file#"$ROOT_DIR"/} avoids targetBranch drift"
+assert_contains "$GIT_PROTOCOL" "If the selected work already records \`targetRef\`, branch setup uses that" "git branch setup prefers targetRef before compatibility fallbacks"
+for file in "$STATE_PROTOCOL" "$GIT_PROTOCOL" "$DESIGN_SKILL" "$PLAN_SKILL" "$INIT_SKILL" "$GUARD_SKILL" "$BUILD_SKILL"; do
+  assert_not_contains "$file" "targetBranch" "${file#"$ROOT_DIR"/} avoids targetBranch drift"
 done
 
 echo ""

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -30,6 +30,7 @@ BUILD_SCRIPT="$ROOT_DIR/build/build.sh"
 DIST_DIR="$ROOT_DIR/dist"
 CC_DIST="$DIST_DIR/claude-code"
 MULTI_WORKTREE_RUNTIME_TEST="$ROOT_DIR/tests/test-multi-worktree-state.sh"
+TARGET_MODEL_DOCS_TEST="$ROOT_DIR/tests/test-branch-freshness-target-model-docs.sh"
 
 PASS=0
 FAIL=0
@@ -1095,6 +1096,31 @@ if echo "$HARNESS_OUTPUT" | grep -Fq "IC-B2: status view reports attached work a
   pass "runtime harness output includes sw-status repo-active ownership coverage"
 else
   fail "runtime harness output missing sw-status repo-active ownership coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Branch freshness target-model docs ==="
+
+if [ -x "$TARGET_MODEL_DOCS_TEST" ]; then
+  pass "tests/test-branch-freshness-target-model-docs.sh is executable"
+else
+  fail "tests/test-branch-freshness-target-model-docs.sh is missing or not executable"
+fi
+
+TARGET_MODEL_EXIT=0
+TARGET_MODEL_OUTPUT="$(bash "$TARGET_MODEL_DOCS_TEST" 2>&1)" || TARGET_MODEL_EXIT=$?
+
+if [ "$TARGET_MODEL_EXIT" -ne 0 ]; then
+  fail "tests/test-branch-freshness-target-model-docs.sh passes under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${TARGET_MODEL_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-branch-freshness-target-model-docs.sh passes under the configured test path"
+fi
+if echo "$TARGET_MODEL_OUTPUT" | grep -Fq "workflow schema adds targetRef object"; then
+  pass "target-model regression output includes targetRef schema coverage"
+else
+  fail "target-model regression output missing targetRef schema coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- document work-level `targetRef` and `freshness` metadata so later stages stop guessing which remote branch a work actually targets
- define `git.targets` and `git.freshness` as the canonical branch-role and checkpoint-policy config surfaces while preserving `baseBranch` compatibility
- align `sw-design`, `sw-plan`, `sw-init`, and `sw-guard` with design-time target capture and add a regression guard for terminology drift
- wire `tests/test-branch-freshness-target-model-docs.sh` into the tracked default test path via `tests/test-claude-code-build.sh` and into PR CI via `.github/workflows/validate.yml`

## Acceptance Criteria
- `AC-1` PASS: `core/protocols/state.md` now documents a work-level `targetRef` structure plus companion freshness metadata as selected-work state. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
- `AC-2` PASS: `core/protocols/git.md` now documents `git.targets` and `git.freshness` as canonical config surfaces while preserving `baseBranch` compatibility. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
- `AC-3` PASS: `core/skills/sw-design/SKILL.md` now states that design resolves and records the work's concrete target branch and baseline before later stages begin. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
- `AC-4` PASS: `core/skills/sw-plan/SKILL.md` now preserves the recorded target model instead of reintroducing a single inferred `baseBranch` assumption. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
- `AC-5` PASS: `core/skills/sw-init/SKILL.md` and `core/skills/sw-guard/SKILL.md` now describe seeding or migrating the target-branch policy from detected workflow strategy without introducing a custom branch DSL. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
- `AC-6` PASS: `tests/test-branch-freshness-target-model-docs.sh` now fails on terminology drift or dropped compatibility wording. Evidence: `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`, `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/test-quality.md`

## Blast Radius
- Protocols: `core/protocols/state.md`, `core/protocols/git.md`
- Skill surfaces: `core/skills/sw-design/SKILL.md`, `core/skills/sw-plan/SKILL.md`, `core/skills/sw-init/SKILL.md`, `core/skills/sw-guard/SKILL.md`
- Default test path / CI: `tests/test-claude-code-build.sh`, `.github/workflows/validate.yml`
- Regression coverage: `tests/test-branch-freshness-target-model-docs.sh`

## Gate Results
- `build`: PASS (`0/0/2`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/build-report.md`
- `tests`: WARN (`0/1/1`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/test-quality.md`. This warning was recorded by the original `sw-verify` artifact before the follow-up commit wired the regression into the tracked default test path and PR CI. Current PR head targeted validation passed with `python -m pytest evals/tests/ -v && bash tests/test-claude-code-build.sh`.
- `security`: PASS (`0/0/0`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/security-report.md`
- `wiring`: PASS (`0/0/1`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/wiring-report.md`
- `semantic`: PASS (`0/0/1`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/semantic-report.md`
- `spec`: PASS (`0/0/1`) — `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`

## Evidence Links
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/build-report.md`
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/test-quality.md`
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/security-report.md`
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/wiring-report.md`
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/semantic-report.md`
- `.specwright/work/branch-freshness-policy/units/01-target-model-foundation/evidence/spec-compliance.md`
