### PR TITLE
feat(02-git-freshness-engine): ship unit 02 git freshness engine

### DIFF
--- a/adapters/shared/specwright-git-freshness.mjs
+++ b/adapters/shared/specwright-git-freshness.mjs
@@ -86,7 +86,11 @@ function tryGit(args, cwd) {
 }
 
 function parseJsonFile(path) {
-  return JSON.parse(readFileSync(path, 'utf8'));
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 function normalizeString(value) {
@@ -125,7 +129,8 @@ function loadConfig(stateInfo) {
       continue;
     }
 
-    return parseJsonFile(candidate);
+    const raw = parseJsonFile(candidate);
+    return raw ?? {};
   }
 
   return {};
@@ -436,6 +441,7 @@ export function assessGitFreshness(stateInfo, options = {}) {
     return buildResult(context, {
       status: 'blocked',
       currentHead: null,
+      fetched: false,
       reason: `Unable to resolve HEAD: ${currentHeadResult.message}`
     });
   }
@@ -449,7 +455,7 @@ export function assessGitFreshness(stateInfo, options = {}) {
       return buildResult(context, {
         status: 'blocked',
         currentHead,
-        fetched: true,
+        fetched: false,
         reason: `Unable to fetch ${context.targetRef.remote}/${context.targetRef.branch}: ${fetchResult.message}`
       });
     }

--- a/adapters/shared/specwright-git-freshness.mjs
+++ b/adapters/shared/specwright-git-freshness.mjs
@@ -1,0 +1,507 @@
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { loadSpecwrightState } from './specwright-state-paths.mjs';
+
+const FALLBACK_REPO_LOCAL_GIT_ENV_VARS = new Set([
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_DIR',
+  'GIT_GRAFT_FILE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_NAMESPACE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_PREFIX',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+  'GIT_WORK_TREE'
+]);
+
+function sanitizedGitEnv(extra = {}, keys = REPO_LOCAL_GIT_ENV_VARS) {
+  const env = { ...process.env };
+  for (const key of keys) {
+    delete env[key];
+  }
+
+  return {
+    ...env,
+    ...extra
+  };
+}
+
+function loadRepoLocalGitEnvVars() {
+  const keys = new Set(FALLBACK_REPO_LOCAL_GIT_ENV_VARS);
+
+  try {
+    const output = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+      env: sanitizedGitEnv({}, FALLBACK_REPO_LOCAL_GIT_ENV_VARS),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+
+    for (const key of output.split(/\r?\n/u)) {
+      if (key) {
+        keys.add(key);
+      }
+    }
+  } catch {
+    // Fall back to the static list when Git cannot provide the dynamic one.
+  }
+
+  return keys;
+}
+
+const REPO_LOCAL_GIT_ENV_VARS = loadRepoLocalGitEnvVars();
+
+function runGit(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    env: sanitizedGitEnv(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function tryGit(args, cwd) {
+  try {
+    return {
+      ok: true,
+      value: runGit(args, cwd)
+    };
+  } catch (error) {
+    const stderr = error?.stderr?.toString?.().trim();
+    const stdout = error?.stdout?.toString?.().trim();
+    return {
+      ok: false,
+      command: ['git', ...args],
+      message: stderr || stdout || (error instanceof Error ? error.message : String(error))
+    };
+  }
+}
+
+function parseJsonFile(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function normalizeString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizePhase(value) {
+  return ['build', 'verify', 'ship'].includes(value) ? value : 'build';
+}
+
+function normalizeValidation(value) {
+  return value === 'queue' ? 'queue' : 'branch-head';
+}
+
+function normalizeReconcile(value) {
+  return ['manual', 'rebase', 'merge'].includes(value) ? value : 'manual';
+}
+
+function normalizeCheckpoint(value) {
+  return ['ignore', 'warn', 'require'].includes(value) ? value : 'ignore';
+}
+
+function loadConfig(stateInfo) {
+  const candidates = [
+    stateInfo?.sharedConfigPath ?? null,
+    stateInfo?.projectRoot ? join(stateInfo.projectRoot, '.specwright', 'config.json') : null
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate || !existsSync(candidate)) {
+      continue;
+    }
+
+    return parseJsonFile(candidate);
+  }
+
+  return {};
+}
+
+function resolveCurrentBranch(stateInfo, cwd) {
+  const detected = tryGit(['branch', '--show-current'], cwd);
+  if (detected.ok && detected.value) {
+    return detected.value;
+  }
+
+  return normalizeString(stateInfo?.session?.branch) ?? normalizeString(stateInfo?.workflow?.branch);
+}
+
+function listPatternMatches(cwd, remote, pattern) {
+  const refs = tryGit(
+    ['for-each-ref', `refs/remotes/${remote}/${pattern}`, '--format=%(refname:strip=3)'],
+    cwd
+  );
+
+  if (!refs.ok) {
+    return {
+      ok: false,
+      reason: refs.message
+    };
+  }
+
+  return {
+    ok: true,
+    matches: refs.value
+      ? refs.value.split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean)
+      : []
+  };
+}
+
+function resolveTargetRef(stateInfo, config, cwd, options = {}) {
+  const workflowTarget = stateInfo?.workflow?.targetRef;
+  const workflowBranch = normalizeString(workflowTarget?.branch);
+  const workflowRemote = normalizeString(workflowTarget?.remote) ?? normalizeString(options.remote) ?? 'origin';
+
+  if (workflowBranch) {
+    return {
+      ok: true,
+      targetRef: {
+        remote: workflowRemote,
+        branch: workflowBranch,
+        role: normalizeString(workflowTarget?.role),
+        resolvedBy: normalizeString(workflowTarget?.resolvedBy) ?? 'workflow.targetRef',
+        resolvedAt: normalizeString(workflowTarget?.resolvedAt)
+      }
+    };
+  }
+
+  const gitConfig = config?.git ?? {};
+  const targets = gitConfig.targets ?? {};
+  const role = normalizeString(options.role) ?? normalizeString(targets.defaultRole) ?? 'integration';
+  const remote = normalizeString(options.remote) ?? 'origin';
+  const roleConfig = targets.roles?.[role];
+  const branch = normalizeString(roleConfig?.branch);
+  if (branch) {
+    return {
+      ok: true,
+      targetRef: {
+        remote,
+        branch,
+        role,
+        resolvedBy: `config.git.targets.roles.${role}.branch`,
+        resolvedAt: null
+      }
+    };
+  }
+
+  const pattern = normalizeString(roleConfig?.pattern);
+  if (pattern) {
+    const matches = listPatternMatches(cwd, remote, pattern);
+    if (!matches.ok) {
+      return {
+        ok: false,
+        reason: `Unable to resolve target pattern ${pattern} on ${remote}: ${matches.reason}`
+      };
+    }
+
+    if (matches.matches.length === 1) {
+      return {
+        ok: true,
+        targetRef: {
+          remote,
+          branch: matches.matches[0],
+          role,
+          resolvedBy: `config.git.targets.roles.${role}.pattern`,
+          resolvedAt: null
+        }
+      };
+    }
+
+    if (matches.matches.length === 0) {
+      return {
+        ok: false,
+        reason: `No remote branches matched ${remote}/${pattern}.`
+      };
+    }
+
+    return {
+      ok: false,
+      reason: `Multiple remote branches matched ${remote}/${pattern}; resolve a concrete targetRef before assessing freshness.`
+    };
+  }
+
+  const baseBranch = normalizeString(gitConfig.baseBranch);
+  if (baseBranch) {
+    return {
+      ok: true,
+      targetRef: {
+        remote,
+        branch: baseBranch,
+        role,
+        resolvedBy: 'config.git.baseBranch',
+        resolvedAt: null
+      }
+    };
+  }
+
+  return {
+    ok: false,
+    reason: 'No recorded targetRef or compatible git target defaults were available.'
+  };
+}
+
+function resolveFreshnessSettings(stateInfo, config, phase) {
+  const workflowFreshness = stateInfo?.workflow?.freshness ?? {};
+  const configFreshness = config?.git?.freshness ?? {};
+
+  return {
+    validation: normalizeValidation(
+      normalizeString(workflowFreshness.validation) ?? normalizeString(configFreshness.validation)
+    ),
+    reconcile: normalizeReconcile(
+      normalizeString(workflowFreshness.reconcile) ?? normalizeString(configFreshness.reconcile)
+    ),
+    checkpoint: normalizeCheckpoint(
+      normalizeString(workflowFreshness.checkpoints?.[phase]) ??
+      normalizeString(configFreshness.checkpoints?.[phase])
+    )
+  };
+}
+
+function recommendedAction(status, checkpoint) {
+  if (status === 'fresh') {
+    return 'continue';
+  }
+
+  if (status === 'queue-managed') {
+    return 'delegate-to-queue';
+  }
+
+  if (checkpoint === 'ignore') {
+    return 'continue';
+  }
+
+  if (checkpoint === 'warn') {
+    return 'warn';
+  }
+
+  return 'stop';
+}
+
+function guidanceFor(status, details) {
+  const targetLabel = details?.targetRef
+    ? `${details.targetRef.remote}/${details.targetRef.branch}`
+    : 'the configured target branch';
+  const branchLabel = details?.currentBranch ?? 'the current branch';
+
+  switch (status) {
+    case 'fresh':
+      return `${branchLabel} already contains ${targetLabel}.`;
+    case 'stale':
+      return `${branchLabel} is behind ${targetLabel} by ${details.behind} commit(s).`;
+    case 'diverged':
+      return `${branchLabel} and ${targetLabel} both have unique commits (ahead ${details.ahead}, behind ${details.behind}).`;
+    case 'queue-managed':
+      return `${targetLabel} freshness is managed by queue validation; local branch-head drift is advisory only.`;
+    case 'blocked':
+    default:
+      return details?.reason ?? 'Freshness could not be assessed from the available Git state.';
+  }
+}
+
+function buildResult(context, overrides = {}) {
+  const status = overrides.status ?? 'blocked';
+  const checkpoint = overrides.checkpoint ?? context.checkpoint ?? 'ignore';
+  const ahead = overrides.ahead ?? 0;
+  const behind = overrides.behind ?? 0;
+
+  return {
+    phase: context.phase ?? 'build',
+    targetRef: overrides.targetRef ?? context.targetRef ?? null,
+    validation: overrides.validation ?? context.validation ?? 'branch-head',
+    reconcile: overrides.reconcile ?? context.reconcile ?? 'manual',
+    checkpoint,
+    currentBranch: overrides.currentBranch ?? context.currentBranch ?? null,
+    status,
+    ahead,
+    behind,
+    targetHead: overrides.targetHead ?? null,
+    currentHead: overrides.currentHead ?? null,
+    recommendedAction: overrides.recommendedAction ?? recommendedAction(status, checkpoint),
+    guidance: overrides.guidance ?? guidanceFor(status, {
+      targetRef: overrides.targetRef ?? context.targetRef ?? null,
+      currentBranch: overrides.currentBranch ?? context.currentBranch ?? null,
+      ahead,
+      behind,
+      reason: overrides.reason ?? context.reason ?? null
+    }),
+    ...('fetched' in overrides ? { fetched: overrides.fetched } : {})
+  };
+}
+
+export function resolveGitFreshnessContext(stateInfo, options = {}) {
+  const info = stateInfo ?? loadSpecwrightState({ cwd: options.cwd });
+  const phase = normalizePhase(options.phase);
+
+  if (!info || info.ok === false) {
+    return {
+      ok: false,
+      phase,
+      validation: 'branch-head',
+      reconcile: 'manual',
+      checkpoint: 'ignore',
+      targetRef: null,
+      currentBranch: null,
+      reason: 'Specwright state roots could not be resolved for freshness assessment.'
+    };
+  }
+
+  const config = loadConfig(info);
+  const settings = resolveFreshnessSettings(info, config, phase);
+  const projectRoot = info.projectRoot ?? options.cwd ?? process.cwd();
+
+  if (!info.workflow) {
+    return {
+      ok: false,
+      phase,
+      projectRoot,
+      ...settings,
+      targetRef: null,
+      currentBranch: null,
+      reason: 'No selected work is attached for freshness assessment.'
+    };
+  }
+
+  const targetResolution = resolveTargetRef(info, config, projectRoot, options);
+  if (!targetResolution.ok) {
+    return {
+      ok: false,
+      phase,
+      projectRoot,
+      ...settings,
+      targetRef: null,
+      currentBranch: null,
+      reason: targetResolution.reason
+    };
+  }
+
+  const currentBranch = resolveCurrentBranch(info, projectRoot);
+  if (!currentBranch) {
+    return {
+      ok: false,
+      phase,
+      projectRoot,
+      ...settings,
+      targetRef: targetResolution.targetRef,
+      currentBranch: null,
+      reason: 'The current branch could not be resolved.'
+    };
+  }
+
+  return {
+    ok: true,
+    stateInfo: info,
+    config,
+    projectRoot,
+    phase,
+    ...settings,
+    targetRef: targetResolution.targetRef,
+    currentBranch,
+    fetch: options.fetch === true
+  };
+}
+
+export function assessGitFreshness(stateInfo, options = {}) {
+  const context = resolveGitFreshnessContext(stateInfo, options);
+  if (!context.ok) {
+    return buildResult(context, { status: 'blocked' });
+  }
+
+  const currentHeadResult = tryGit(['rev-parse', 'HEAD'], context.projectRoot);
+  const currentHead = currentHeadResult.ok ? currentHeadResult.value : null;
+
+  if (context.validation === 'queue') {
+    return buildResult(context, {
+      status: 'queue-managed',
+      currentHead,
+      fetched: false
+    });
+  }
+
+  if (!currentHeadResult.ok) {
+    return buildResult(context, {
+      status: 'blocked',
+      currentHead: null,
+      reason: `Unable to resolve HEAD: ${currentHeadResult.message}`
+    });
+  }
+
+  if (context.fetch) {
+    const fetchResult = tryGit(
+      ['fetch', '--prune', context.targetRef.remote, context.targetRef.branch],
+      context.projectRoot
+    );
+    if (!fetchResult.ok) {
+      return buildResult(context, {
+        status: 'blocked',
+        currentHead,
+        fetched: true,
+        reason: `Unable to fetch ${context.targetRef.remote}/${context.targetRef.branch}: ${fetchResult.message}`
+      });
+    }
+  }
+
+  const targetRefName = `refs/remotes/${context.targetRef.remote}/${context.targetRef.branch}`;
+  const targetHeadResult = tryGit(['rev-parse', targetRefName], context.projectRoot);
+  if (!targetHeadResult.ok) {
+    return buildResult(context, {
+      status: 'blocked',
+      currentHead,
+      fetched: context.fetch,
+      reason: `Unable to resolve ${context.targetRef.remote}/${context.targetRef.branch}: ${targetHeadResult.message}`
+    });
+  }
+
+  const countResult = tryGit(['rev-list', '--left-right', '--count', `HEAD...${targetRefName}`], context.projectRoot);
+  if (!countResult.ok) {
+    return buildResult(context, {
+      status: 'blocked',
+      currentHead,
+      targetHead: targetHeadResult.value,
+      fetched: context.fetch,
+      reason: `Unable to compare HEAD with ${context.targetRef.remote}/${context.targetRef.branch}: ${countResult.message}`
+    });
+  }
+
+  const [aheadRaw, behindRaw] = countResult.value.split(/\s+/u);
+  const ahead = Number.parseInt(aheadRaw, 10);
+  const behind = Number.parseInt(behindRaw, 10);
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) {
+    return buildResult(context, {
+      status: 'blocked',
+      currentHead,
+      targetHead: targetHeadResult.value,
+      fetched: context.fetch,
+      reason: `Unexpected ancestry counts from git rev-list: ${countResult.value}`
+    });
+  }
+
+  const status = behind === 0 ? 'fresh' : (ahead === 0 ? 'stale' : 'diverged');
+
+  return buildResult(context, {
+    status,
+    ahead,
+    behind,
+    currentHead,
+    targetHead: targetHeadResult.value,
+    fetched: context.fetch
+  });
+}
+
+export function assessGitFreshnessFromCwd(options = {}) {
+  return assessGitFreshness(loadSpecwrightState({ cwd: options.cwd }), options);
+}

--- a/core/protocols/git-freshness.md
+++ b/core/protocols/git-freshness.md
@@ -1,0 +1,172 @@
+# Git Freshness Protocol
+
+Shared contract for assessing branch freshness against a work's recorded target
+branch.
+
+## Purpose
+
+`git-freshness` exists so `sw-build`, `sw-verify`, `sw-ship`, and support
+surfaces can consume one deterministic checkpoint contract instead of
+re-deriving Git ancestry rules independently.
+
+This protocol defines:
+
+- the storage boundary model the helper must respect
+- the inputs and result shape for freshness assessment
+- the supported validation backends and reconcile policies
+- the explicit side-effect boundary for helper code
+
+It does not define user-facing lifecycle policy on its own. Later skills apply
+their checkpoint severity rules to the helper result.
+
+## Storage Boundary Model
+
+Freshness assessment must distinguish three storage classes.
+
+### 1. Clone-local runtime state
+
+This state is local to one clone or one worktree session. It includes:
+
+- `session.json`
+- `continuation.md`
+- work attachment ownership
+- per-work locks
+- `lastSeenAt` style liveness timestamps
+- absolute worktree paths and other machine-local diagnostics
+
+This clone-local runtime state is never treated as a publishable audit trail.
+
+### 2. Project-level artifacts
+
+These project-level artifacts describe how the project is supposed to work and
+may need to be reviewed or pushed with normal Git history. They include:
+
+- `CONSTITUTION.md`
+- `CHARTER.md`
+- `TESTING.md`
+- the project's effective Git policy/config surface
+
+### 3. Optional auditable work artifacts
+
+Some work artifacts may need a remote audit trail, but that is a separate
+publication decision from runtime orchestration. Examples include:
+
+- `design.md`
+- `context.md`
+- `decisions.md`
+- `assumptions.md`
+- `spec.md`
+- `plan.md`
+- `stage-report.md`
+- evidence artifacts
+
+These optional auditable work artifacts may remain clone-local in one mode and
+be published in another. The helper contract must not assume one universal
+storage backend for them.
+
+## Resolution Rules
+
+The helper operates from recorded work state and resolved roots.
+
+- Inputs come from recorded work state and resolved roots, not from one
+  hardcoded `.git/specwright` path.
+- The selected work's `targetRef`, when present, is the first branch target.
+- If `targetRef` is absent, the helper falls back to `config.git.targets`, then
+  the `baseBranch` compatibility alias.
+- The helper consumes the resolved `git.freshness` policy from config or the
+  work-level `freshness` snapshot when later skills materialize it.
+- The helper must not depend on symlinked mirrors between runtime roots and
+  tracked artifact roots.
+
+## Supported Validation Backends
+
+- `branch-head`: compare the current branch with the resolved target branch
+- `queue`: treat provider-managed merge freshness as the final authority
+
+## Supported Reconcile Modes
+
+- `manual`
+- `rebase`
+- `merge`
+
+The helper reports which mode is configured. It does not execute the
+reconciliation itself.
+
+## Result Categories
+
+The helper returns one of these statuses:
+
+- `fresh`
+- `stale`
+- `diverged`
+- `blocked`
+- `queue-managed`
+
+Recommended meanings:
+
+- `fresh`: the current branch already contains the target head
+- `stale`: the target advanced and the current branch does not include it
+- `diverged`: both current and target have unique commits
+- `blocked`: inputs or Git state are insufficient for a reliable assessment
+- `queue-managed`: local branch-head freshness is not the deciding authority
+
+## Result Shape
+
+Minimum machine-readable shape:
+
+```json
+{
+  "phase": "build | verify | ship",
+  "targetRef": {
+    "remote": "origin",
+    "branch": "main",
+    "role": "integration"
+  },
+  "validation": "branch-head | queue",
+  "reconcile": "manual | rebase | merge",
+  "checkpoint": "ignore | warn | require",
+  "status": "fresh | stale | diverged | blocked | queue-managed",
+  "ahead": 0,
+  "behind": 0,
+  "targetHead": "sha | null",
+  "currentHead": "sha | null",
+  "recommendedAction": "continue | stop | warn | delegate-to-queue",
+  "guidance": "short human-readable summary"
+}
+```
+
+Callers may add extra diagnostics, but they must preserve the stable fields
+above.
+
+## Explicit Side-Effect Boundary
+
+Allowed:
+
+- read Git refs and ancestry data
+- fetch the resolved target remote when the caller requests an explicit fetch
+
+Not allowed:
+
+- checkout
+- merge
+- rebase
+- commit
+- push
+- create or update PRs
+- rewrite session or workflow ownership state as part of assessment
+
+The helper is an assessor, not a mutator.
+
+## Caller Responsibilities
+
+- lifecycle skills decide whether a result blocks, warns, or proceeds
+- publication mode for optional auditable work artifacts is configured outside
+  this helper
+- redaction or safe publication of evidence is handled by the surfaces that
+  expose or commit those artifacts
+
+## Non-Goals
+
+- defining merge-queue provider playbooks inline
+- using symlinks as the contract between runtime-local and tracked artifacts
+- turning runtime ownership state into committed repo truth

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -334,6 +334,12 @@ else
   fail "dist/shared/specwright-state-paths.mjs missing"
 fi
 
+if [ -f "$DIST_DIR/shared/specwright-git-freshness.mjs" ]; then
+  pass "dist/shared/specwright-git-freshness.mjs exists"
+else
+  fail "dist/shared/specwright-git-freshness.mjs missing"
+fi
+
 # ─── .claude-plugin/ directory ────────────────────────────────────────
 
 echo "--- .claude-plugin/ directory ---"

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -31,6 +31,7 @@ DIST_DIR="$ROOT_DIR/dist"
 CC_DIST="$DIST_DIR/claude-code"
 MULTI_WORKTREE_RUNTIME_TEST="$ROOT_DIR/tests/test-multi-worktree-state.sh"
 TARGET_MODEL_DOCS_TEST="$ROOT_DIR/tests/test-branch-freshness-target-model-docs.sh"
+GIT_FRESHNESS_ENGINE_TEST="$ROOT_DIR/tests/test-git-freshness-engine.sh"
 
 PASS=0
 FAIL=0
@@ -267,11 +268,11 @@ if [ -d "$CC_DIST/agents" ]; then
   done
 fi
 
-# ─── protocols/ directory: exactly 23 .md files ──────────────────────
+# ─── protocols/ directory: exactly 24 .md files ──────────────────────
 
 echo "--- protocols/ directory ---"
 
-EXPECTED_PROTO_COUNT=23
+EXPECTED_PROTO_COUNT=24
 
 if [ -d "$CC_DIST/protocols" ]; then
   pass "protocols/ directory exists"
@@ -284,7 +285,7 @@ if [ -d "$CC_DIST/protocols" ]; then
   assert_eq "$PROTO_COUNT" "$EXPECTED_PROTO_COUNT" "protocols/ has exactly $EXPECTED_PROTO_COUNT .md files"
 
   # Spot-check specific protocol files
-  for proto in state.md git.md delegation.md recovery.md evidence.md stage-boundary.md context.md repo-map.md; do
+  for proto in state.md git.md git-freshness.md delegation.md recovery.md evidence.md stage-boundary.md context.md repo-map.md; do
     if [ -f "$CC_DIST/protocols/$proto" ]; then
       pass "protocols/$proto exists"
     else
@@ -1121,6 +1122,31 @@ if echo "$TARGET_MODEL_OUTPUT" | grep -Fq "workflow schema adds targetRef object
   pass "target-model regression output includes targetRef schema coverage"
 else
   fail "target-model regression output missing targetRef schema coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Git freshness engine ==="
+
+if [ -x "$GIT_FRESHNESS_ENGINE_TEST" ]; then
+  pass "tests/test-git-freshness-engine.sh is executable"
+else
+  fail "tests/test-git-freshness-engine.sh is missing or not executable"
+fi
+
+GIT_FRESHNESS_EXIT=0
+GIT_FRESHNESS_OUTPUT="$(bash "$GIT_FRESHNESS_ENGINE_TEST" 2>&1)" || GIT_FRESHNESS_EXIT=$?
+
+if [ "$GIT_FRESHNESS_EXIT" -ne 0 ]; then
+  fail "tests/test-git-freshness-engine.sh passes under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${GIT_FRESHNESS_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-git-freshness-engine.sh passes under the configured test path"
+fi
+if echo "$GIT_FRESHNESS_OUTPUT" | grep -Fq "protocol names clone-local runtime state explicitly"; then
+  pass "git-freshness regression output includes storage-boundary coverage"
+else
+  fail "git-freshness regression output missing storage-boundary coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test-git-freshness-engine.sh
+++ b/tests/test-git-freshness-engine.sh
@@ -82,6 +82,7 @@ fresh_timestamp() {
 write_shared_config() {
   local dir="$1"
   local validation="${2:-branch-head}"
+  local checkpoint="${3:-require}"
   local repo_root
   repo_root="$(repo_state_root "$dir")"
   mkdir -p "$repo_root"
@@ -100,9 +101,9 @@ write_shared_config() {
       "validation": "$validation",
       "reconcile": "manual",
       "checkpoints": {
-        "build": "require",
-        "verify": "require",
-        "ship": "require"
+        "build": "$checkpoint",
+        "verify": "$checkpoint",
+        "ship": "$checkpoint"
       }
     }
   }
@@ -117,6 +118,7 @@ write_shared_workflow() {
   local validation="${4:-branch-head}"
   local target_branch="${5:-main}"
   local target_remote="${6:-origin}"
+  local checkpoint="${7:-require}"
   local repo_root work_root
 
   repo_root="$(repo_state_root "$dir")"
@@ -143,9 +145,9 @@ write_shared_workflow() {
     "validation": "$validation",
     "reconcile": "manual",
     "checkpoints": {
-      "build": "require",
-      "verify": "require",
-      "ship": "require"
+      "build": "$checkpoint",
+      "verify": "$checkpoint",
+      "ship": "$checkpoint"
     },
     "status": "unknown",
     "lastCheckedAt": null
@@ -179,7 +181,7 @@ EOF
 init_bare_remote() {
   local remote_dir="$1"
   mkdir -p "$remote_dir"
-  git_nested -C "$remote_dir" -c core.hooksPath=/dev/null init --bare -q
+  git_nested -C "$remote_dir" -c core.hooksPath=/dev/null init --bare --initial-branch=main -q
 }
 
 clone_repo() {
@@ -195,10 +197,11 @@ setup_assessed_repo() {
   local repo_dir="$2"
   local work_id="$3"
   local validation="${4:-branch-head}"
+  local checkpoint="${5:-require}"
   clone_repo "$remote_dir" "$repo_dir"
   git_nested -C "$repo_dir" checkout -qb feature origin/main
-  write_shared_config "$repo_dir" "$validation"
-  write_shared_workflow "$repo_dir" "$work_id" "feature" "$validation"
+  write_shared_config "$repo_dir" "$validation" "$checkpoint"
+  write_shared_workflow "$repo_dir" "$work_id" "feature" "$validation" "main" "origin" "$checkpoint"
   write_shared_session "$repo_dir" "feature" "$work_id"
 }
 
@@ -322,6 +325,7 @@ setup_assessed_repo "$REMOTE" "$BLOCKED_REPO" "blocked-work"
 write_shared_workflow "$BLOCKED_REPO" "blocked-work" "feature" "branch-head" "release/missing"
 if blocked_output="$(assess_freshness "$BLOCKED_REPO" true)"; then
   assert_output_contains "$blocked_output" '"status":"blocked"' "helper reports missing target refs as blocked"
+  assert_output_contains "$blocked_output" '"fetched":false' "failed fetches do not claim the target was refreshed"
   assert_output_contains "$blocked_output" '"recommendedAction":"stop"' "blocked result recommends stop for require checkpoints"
 else
   fail "helper returns JSON for a blocked assessment"
@@ -333,10 +337,39 @@ QUEUE_REPO="$TEST_TMPDIR/queue-repo"
 setup_assessed_repo "$REMOTE" "$QUEUE_REPO" "queue-work" "queue"
 if queue_output="$(assess_freshness "$QUEUE_REPO" false)"; then
   assert_output_contains "$queue_output" '"status":"queue-managed"' "helper reports queue-managed validation distinctly"
+  assert_output_contains "$queue_output" '"fetched":false' "queue-managed assessment reports that no fetch was needed"
   assert_output_contains "$queue_output" '"recommendedAction":"delegate-to-queue"' "queue-managed result delegates authority to the queue"
   assert_output_contains "$queue_output" '"validation":"queue"' "queue-managed result preserves queue validation mode"
 else
   fail "helper returns JSON for a queue-managed assessment"
+fi
+
+echo ""
+echo "--- Helper warn checkpoint assessment ---"
+WARN_REPO="$TEST_TMPDIR/warn-repo"
+WARN_PUSHER="$TEST_TMPDIR/warn-pusher"
+setup_assessed_repo "$REMOTE" "$WARN_REPO" "warn-work" "branch-head" "warn"
+clone_repo "$REMOTE" "$WARN_PUSHER"
+advance_main_and_push "$WARN_PUSHER" "test: warn checkpoint sees drift"
+if warn_output="$(assess_freshness "$WARN_REPO" true)"; then
+  assert_output_contains "$warn_output" '"status":"stale"' "helper still reports stale under warn checkpoints"
+  assert_output_contains "$warn_output" '"recommendedAction":"warn"' "warn checkpoints downgrade stale guidance to warn"
+else
+  fail "helper returns JSON for a warn checkpoint assessment"
+fi
+
+echo ""
+echo "--- Helper malformed config assessment ---"
+INVALID_CONFIG_REPO="$TEST_TMPDIR/invalid-config-repo"
+setup_assessed_repo "$REMOTE" "$INVALID_CONFIG_REPO" "invalid-config-work"
+cat > "$(repo_state_root "$INVALID_CONFIG_REPO")/config.json" <<'EOF'
+{ invalid json
+EOF
+if malformed_config_output="$(assess_freshness "$INVALID_CONFIG_REPO" false)"; then
+  assert_output_contains "$malformed_config_output" '"status":"fresh"' "malformed config degrades cleanly to workflow-backed assessment"
+  assert_output_contains "$malformed_config_output" '"validation":"branch-head"' "malformed config does not drop workflow freshness settings"
+else
+  fail "helper tolerates malformed shared config"
 fi
 
 echo ""

--- a/tests/test-git-freshness-engine.sh
+++ b/tests/test-git-freshness-engine.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Regression checks for the shared git-freshness contract introduced by
+# branch-freshness-policy Unit 02.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROTOCOL_FILE="$ROOT_DIR/core/protocols/git-freshness.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_file_exists() {
+  local path="$1" label="$2"
+  if [ -f "$path" ]; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+assert_contains() {
+  local path="$1" needle="$2" label="$3"
+  if grep -Fq "$needle" "$path"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+echo "=== git freshness engine ==="
+echo ""
+
+echo "--- Protocol contract ---"
+assert_file_exists "$PROTOCOL_FILE" "core/protocols/git-freshness.md exists"
+assert_contains "$PROTOCOL_FILE" "clone-local runtime state" "protocol names clone-local runtime state explicitly"
+assert_contains "$PROTOCOL_FILE" "project-level artifacts" "protocol names project-level artifacts explicitly"
+assert_contains "$PROTOCOL_FILE" "optional auditable work artifacts" "protocol names optional auditable work artifacts explicitly"
+assert_contains "$PROTOCOL_FILE" "must not depend on symlinked mirrors" "protocol rejects symlink-based artifact assumptions"
+assert_contains "$PROTOCOL_FILE" "session.json" "protocol keeps session.json in the local-only runtime set"
+assert_contains "$PROTOCOL_FILE" "CONSTITUTION.md" "protocol keeps anchor docs in the project artifact set"
+assert_contains "$PROTOCOL_FILE" "recorded work state and resolved roots" "protocol roots helper behavior in resolved state instead of one hardcoded path"
+
+echo ""
+TOTAL=$((PASS + FAIL))
+echo "RESULT: $PASS passed, $FAIL failed (of $TOTAL tests)"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/test-git-freshness-engine.sh
+++ b/tests/test-git-freshness-engine.sh
@@ -7,7 +7,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/test-lib.sh"
 PROTOCOL_FILE="$ROOT_DIR/core/protocols/git-freshness.md"
+STATE_PATHS_MODULE="$ROOT_DIR/adapters/shared/specwright-state-paths.mjs"
+GIT_FRESHNESS_MODULE="$ROOT_DIR/adapters/shared/specwright-git-freshness.mjs"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 PASS=0
 FAIL=0
@@ -40,6 +47,203 @@ assert_contains() {
   fi
 }
 
+assert_output_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -Fq "$needle"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (expected '$expected', got '$actual')"
+  fi
+}
+
+git_nested_prepare || exit 1
+
+repo_state_root() {
+  printf '%s/specwright\n' "$(git_common_dir "$1")"
+}
+
+worktree_state_root() {
+  printf '%s/specwright\n' "$(git_dir "$1")"
+}
+
+fresh_timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+write_shared_config() {
+  local dir="$1"
+  local validation="${2:-branch-head}"
+  local repo_root
+  repo_root="$(repo_state_root "$dir")"
+  mkdir -p "$repo_root"
+  cat > "$repo_root/config.json" <<EOF
+{
+  "version": "2.0",
+  "git": {
+    "baseBranch": "main",
+    "targets": {
+      "defaultRole": "integration",
+      "roles": {
+        "integration": { "branch": "main" }
+      }
+    },
+    "freshness": {
+      "validation": "$validation",
+      "reconcile": "manual",
+      "checkpoints": {
+        "build": "require",
+        "verify": "require",
+        "ship": "require"
+      }
+    }
+  }
+}
+EOF
+}
+
+write_shared_workflow() {
+  local dir="$1"
+  local work_id="$2"
+  local branch="$3"
+  local validation="${4:-branch-head}"
+  local target_branch="${5:-main}"
+  local target_remote="${6:-origin}"
+  local repo_root work_root
+
+  repo_root="$(repo_state_root "$dir")"
+  work_root="$repo_root/work/$work_id"
+  mkdir -p "$work_root"
+  cat > "$work_root/workflow.json" <<EOF
+{
+  "version": "3.0",
+  "id": "$work_id",
+  "status": "building",
+  "workDir": "work/$work_id",
+  "unitId": "unit-$work_id",
+  "tasksCompleted": [],
+  "tasksTotal": 3,
+  "currentTask": "task-1",
+  "targetRef": {
+    "remote": "$target_remote",
+    "branch": "$target_branch",
+    "role": "integration",
+    "resolvedBy": "config.git.targets.roles.integration.branch",
+    "resolvedAt": "$(fresh_timestamp)"
+  },
+  "freshness": {
+    "validation": "$validation",
+    "reconcile": "manual",
+    "checkpoints": {
+      "build": "require",
+      "verify": "require",
+      "ship": "require"
+    },
+    "status": "unknown",
+    "lastCheckedAt": null
+  },
+  "branch": "$branch"
+}
+EOF
+}
+
+write_shared_session() {
+  local dir="$1"
+  local branch="$2"
+  local work_id="$3"
+  local worktree_root
+
+  worktree_root="$(worktree_state_root "$dir")"
+  mkdir -p "$worktree_root"
+  cat > "$worktree_root/session.json" <<EOF
+{
+  "version": "3.0",
+  "worktreeId": "test-worktree",
+  "worktreePath": "$(cd "$dir" && pwd -P)",
+  "branch": "$branch",
+  "attachedWorkId": "$work_id",
+  "mode": "top-level",
+  "lastSeenAt": "$(fresh_timestamp)"
+}
+EOF
+}
+
+init_bare_remote() {
+  local remote_dir="$1"
+  mkdir -p "$remote_dir"
+  git_nested -C "$remote_dir" -c core.hooksPath=/dev/null init --bare -q
+}
+
+clone_repo() {
+  local remote_dir="$1"
+  local clone_dir="$2"
+  git_nested -c core.hooksPath=/dev/null clone -q "$remote_dir" "$clone_dir"
+  git_nested -C "$clone_dir" -c core.hooksPath=/dev/null config user.name "Specwright Tests"
+  git_nested -C "$clone_dir" -c core.hooksPath=/dev/null config user.email "specwright-tests@example.com"
+}
+
+setup_assessed_repo() {
+  local remote_dir="$1"
+  local repo_dir="$2"
+  local work_id="$3"
+  local validation="${4:-branch-head}"
+  clone_repo "$remote_dir" "$repo_dir"
+  git_nested -C "$repo_dir" checkout -qb feature origin/main
+  write_shared_config "$repo_dir" "$validation"
+  write_shared_workflow "$repo_dir" "$work_id" "feature" "$validation"
+  write_shared_session "$repo_dir" "feature" "$work_id"
+}
+
+advance_main_and_push() {
+  local clone_dir="$1"
+  local message="$2"
+  printf '%s\n' "$message" >> "$clone_dir/README.md"
+  git_nested -C "$clone_dir" -c core.hooksPath=/dev/null add README.md
+  git_nested -C "$clone_dir" -c core.hooksPath=/dev/null commit -qm "$message"
+  git_nested -C "$clone_dir" -c core.hooksPath=/dev/null push -q origin main
+}
+
+commit_on_feature() {
+  local repo_dir="$1"
+  local message="$2"
+  printf '%s\n' "$message" > "$repo_dir/feature.txt"
+  git_nested -C "$repo_dir" -c core.hooksPath=/dev/null add feature.txt
+  git_nested -C "$repo_dir" -c core.hooksPath=/dev/null commit -qm "$message"
+}
+
+assess_freshness() {
+  local dir="$1"
+  local fetch_mode="${2:-false}"
+  local phase="${3:-build}"
+  (
+    cd "$dir" &&
+    STATE_PATHS_MODULE="$STATE_PATHS_MODULE" \
+    GIT_FRESHNESS_MODULE="$GIT_FRESHNESS_MODULE" \
+    FETCH_MODE="$fetch_mode" \
+    PHASE="$phase" \
+    node --input-type=module <<'EOF'
+const { loadSpecwrightState } = await import(process.env.STATE_PATHS_MODULE);
+const { assessGitFreshness } = await import(process.env.GIT_FRESHNESS_MODULE);
+
+const state = loadSpecwrightState();
+const result = assessGitFreshness(state, {
+  fetch: process.env.FETCH_MODE === 'true',
+  phase: process.env.PHASE
+});
+
+process.stdout.write(JSON.stringify(result));
+EOF
+  )
+}
+
 echo "=== git freshness engine ==="
 echo ""
 
@@ -52,6 +256,88 @@ assert_contains "$PROTOCOL_FILE" "must not depend on symlinked mirrors" "protoco
 assert_contains "$PROTOCOL_FILE" "session.json" "protocol keeps session.json in the local-only runtime set"
 assert_contains "$PROTOCOL_FILE" "CONSTITUTION.md" "protocol keeps anchor docs in the project artifact set"
 assert_contains "$PROTOCOL_FILE" "recorded work state and resolved roots" "protocol roots helper behavior in resolved state instead of one hardcoded path"
+
+echo ""
+echo "--- Helper fresh assessment ---"
+SEED="$TEST_TMPDIR/fresh-seed"
+REMOTE="$TEST_TMPDIR/fresh-remote.git"
+REPO="$TEST_TMPDIR/fresh-repo"
+init_git_repo "$SEED"
+init_bare_remote "$REMOTE"
+git_nested -C "$SEED" remote add origin "$REMOTE"
+git_nested -C "$SEED" -c core.hooksPath=/dev/null push -q -u origin main
+setup_assessed_repo "$REMOTE" "$REPO" "fresh-work"
+if fresh_output="$(assess_freshness "$REPO" false)"; then
+  assert_output_contains "$fresh_output" '"status":"fresh"' "helper reports a branch aligned with target as fresh"
+  assert_output_contains "$fresh_output" '"recommendedAction":"continue"' "fresh result recommends continue"
+  assert_output_contains "$fresh_output" '"validation":"branch-head"' "fresh result preserves branch-head validation mode"
+else
+  fail "helper returns JSON for a fresh assessment"
+fi
+
+echo ""
+echo "--- Helper stale assessment with explicit fetch ---"
+PUSHER="$TEST_TMPDIR/stale-pusher"
+clone_repo "$REMOTE" "$PUSHER"
+before_branch="$(git_nested -C "$REPO" branch --show-current)"
+before_head="$(git_nested -C "$REPO" rev-parse HEAD)"
+advance_main_and_push "$PUSHER" "test: remote main advances"
+if stale_without_fetch="$(assess_freshness "$REPO" false)"; then
+  assert_output_contains "$stale_without_fetch" '"status":"fresh"' "helper does not invent remote drift without an explicit fetch"
+else
+  fail "helper returns JSON before explicit fetch"
+fi
+if stale_with_fetch="$(assess_freshness "$REPO" true)"; then
+  assert_output_contains "$stale_with_fetch" '"status":"stale"' "helper reports stale once explicit fetch refreshes target refs"
+  assert_output_contains "$stale_with_fetch" '"behind":1' "stale result reports target-only commits"
+  assert_output_contains "$stale_with_fetch" '"recommendedAction":"stop"' "require checkpoint turns stale into a stop recommendation"
+else
+  fail "helper returns JSON for a stale assessment after fetch"
+fi
+after_branch="$(git_nested -C "$REPO" branch --show-current)"
+after_head="$(git_nested -C "$REPO" rev-parse HEAD)"
+assert_eq "$after_branch" "$before_branch" "explicit fetch keeps the current branch checked out"
+assert_eq "$after_head" "$before_head" "explicit fetch does not mutate HEAD"
+
+echo ""
+echo "--- Helper diverged assessment ---"
+DIVERGED_REPO="$TEST_TMPDIR/diverged-repo"
+DIVERGED_PUSHER="$TEST_TMPDIR/diverged-pusher"
+setup_assessed_repo "$REMOTE" "$DIVERGED_REPO" "diverged-work"
+clone_repo "$REMOTE" "$DIVERGED_PUSHER"
+commit_on_feature "$DIVERGED_REPO" "test: feature diverges"
+advance_main_and_push "$DIVERGED_PUSHER" "test: target diverges"
+if diverged_output="$(assess_freshness "$DIVERGED_REPO" true)"; then
+  assert_output_contains "$diverged_output" '"status":"diverged"' "helper reports unique commits on both branches as diverged"
+  assert_output_contains "$diverged_output" '"ahead":1' "diverged result reports current-only commits"
+  assert_output_contains "$diverged_output" '"behind":1' "diverged result reports target-only commits"
+else
+  fail "helper returns JSON for a diverged assessment"
+fi
+
+echo ""
+echo "--- Helper blocked assessment ---"
+BLOCKED_REPO="$TEST_TMPDIR/blocked-repo"
+setup_assessed_repo "$REMOTE" "$BLOCKED_REPO" "blocked-work"
+write_shared_workflow "$BLOCKED_REPO" "blocked-work" "feature" "branch-head" "release/missing"
+if blocked_output="$(assess_freshness "$BLOCKED_REPO" true)"; then
+  assert_output_contains "$blocked_output" '"status":"blocked"' "helper reports missing target refs as blocked"
+  assert_output_contains "$blocked_output" '"recommendedAction":"stop"' "blocked result recommends stop for require checkpoints"
+else
+  fail "helper returns JSON for a blocked assessment"
+fi
+
+echo ""
+echo "--- Helper queue-managed assessment ---"
+QUEUE_REPO="$TEST_TMPDIR/queue-repo"
+setup_assessed_repo "$REMOTE" "$QUEUE_REPO" "queue-work" "queue"
+if queue_output="$(assess_freshness "$QUEUE_REPO" false)"; then
+  assert_output_contains "$queue_output" '"status":"queue-managed"' "helper reports queue-managed validation distinctly"
+  assert_output_contains "$queue_output" '"recommendedAction":"delegate-to-queue"' "queue-managed result delegates authority to the queue"
+  assert_output_contains "$queue_output" '"validation":"queue"' "queue-managed result preserves queue validation mode"
+else
+  fail "helper returns JSON for a queue-managed assessment"
+fi
 
 echo ""
 TOTAL=$((PASS + FAIL))

--- a/tests/test-opencode-build.sh
+++ b/tests/test-opencode-build.sh
@@ -196,10 +196,11 @@ else
   fail "commands/ directory missing from dist/opencode/"
 fi
 
-# Exactly 14 command files
+# Command files mirror the adapter
 if [ -d "$OC_DIST/commands" ]; then
+  EXPECTED_CMD_COUNT=$(find "$ROOT_DIR/adapters/opencode/commands" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
   CMD_COUNT=$(find "$OC_DIST/commands" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
-  assert_eq "$CMD_COUNT" "14" "commands/ has exactly 14 .md files"
+  assert_eq "$CMD_COUNT" "$EXPECTED_CMD_COUNT" "commands/ mirrors the adapter command set"
 
   # Spot-check specific command files exist
   for cmd in sw-init sw-build sw-verify sw-ship sw-guard; do
@@ -229,22 +230,27 @@ else
 fi
 
 if [ -d "$OC_DIST/skills" ]; then
-  # 19 skill directories
+  EXPECTED_SKILL_DIR_COUNT=$(find "$ROOT_DIR/core/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  EXPECTED_SKILL_FILE_COUNT=$(find "$ROOT_DIR/core/skills" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -type f | wc -l | tr -d ' ')
   SKILL_DIR_COUNT=$(find "$OC_DIST/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-  assert_eq "$SKILL_DIR_COUNT" "19" "skills/ has exactly 19 subdirectories"
+  assert_eq "$SKILL_DIR_COUNT" "$EXPECTED_SKILL_DIR_COUNT" "skills/ mirrors the core skill directory set"
 
-  # Each has SKILL.md
+  # Each distributable skill has SKILL.md
   SKILL_FILE_COUNT=0
   MISSING_SKILLS=""
   for skill_dir in "$OC_DIST"/skills/*/; do
     skill_name=$(basename "$skill_dir")
+    if [ ! -f "$ROOT_DIR/core/skills/$skill_name/SKILL.md" ]; then
+      continue
+    fi
+
     if [ -f "$skill_dir/SKILL.md" ]; then
       SKILL_FILE_COUNT=$((SKILL_FILE_COUNT + 1))
     else
       MISSING_SKILLS="$MISSING_SKILLS $skill_name"
     fi
   done
-  assert_eq "$SKILL_FILE_COUNT" "19" "all 19 skill directories contain SKILL.md"
+  assert_eq "$SKILL_FILE_COUNT" "$EXPECTED_SKILL_FILE_COUNT" "all distributable skill directories contain SKILL.md"
   if [ -n "$MISSING_SKILLS" ]; then
     fail "skills missing SKILL.md:$MISSING_SKILLS"
   fi
@@ -270,11 +276,12 @@ else
 fi
 
 if [ -d "$OC_DIST/agents" ]; then
+  EXPECTED_AGENT_COUNT=$(find "$ROOT_DIR/core/agents" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
   AGENT_COUNT=$(find "$OC_DIST/agents" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
-  assert_eq "$AGENT_COUNT" "6" "agents/ has exactly 6 .md files"
+  assert_eq "$AGENT_COUNT" "$EXPECTED_AGENT_COUNT" "agents/ mirrors the core agent set"
 
   # Verify specific agent files
-  for agent in specwright-architect specwright-build-fixer specwright-executor specwright-researcher specwright-reviewer specwright-tester; do
+  for agent in specwright-architect specwright-build-fixer specwright-executor specwright-integration-tester specwright-researcher specwright-reviewer specwright-tester; do
     if [ -f "$OC_DIST/agents/${agent}.md" ]; then
       pass "agents/${agent}.md exists"
     else
@@ -294,8 +301,9 @@ else
 fi
 
 if [ -d "$OC_DIST/protocols" ]; then
+  EXPECTED_PROTO_COUNT=$(find "$ROOT_DIR/core/protocols" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
   PROTO_COUNT=$(find "$OC_DIST/protocols" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
-  assert_eq "$PROTO_COUNT" "25" "protocols/ has exactly 25 .md files"
+  assert_eq "$PROTO_COUNT" "$EXPECTED_PROTO_COUNT" "protocols/ mirrors the core protocol set"
 
   # Spot-check specific protocol files
   for proto in state.md git.md git-freshness.md delegation.md recovery.md evidence.md; do
@@ -916,17 +924,17 @@ fi
 echo "--- Claude Code output validation ---"
 
 if [ -d "$CC_DIST" ]; then
-  # skills/ with 19 dirs
+  EXPECTED_CC_SKILL_COUNT=$(find "$ROOT_DIR/core/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
   CC_SKILL_COUNT=$(find "$CC_DIST/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
-  assert_eq "$CC_SKILL_COUNT" "19" "claude-code skills/ has 19 subdirectories"
+  assert_eq "$CC_SKILL_COUNT" "$EXPECTED_CC_SKILL_COUNT" "claude-code skills/ mirrors the core skill directory set"
 
-  # agents/ with 6 files
+  EXPECTED_CC_AGENT_COUNT=$(find "$ROOT_DIR/core/agents" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
   CC_AGENT_COUNT=$(find "$CC_DIST/agents" -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
-  assert_eq "$CC_AGENT_COUNT" "6" "claude-code agents/ has 6 files"
+  assert_eq "$CC_AGENT_COUNT" "$EXPECTED_CC_AGENT_COUNT" "claude-code agents/ mirrors the core agent set"
 
-  # protocols/ with 20 files
+  EXPECTED_CC_PROTO_COUNT=$(find "$ROOT_DIR/core/protocols" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
   CC_PROTO_COUNT=$(find "$CC_DIST/protocols" -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
-  assert_eq "$CC_PROTO_COUNT" "24" "claude-code protocols/ has 24 files"
+  assert_eq "$CC_PROTO_COUNT" "$EXPECTED_CC_PROTO_COUNT" "claude-code protocols/ mirrors the core protocol set"
 
   # Claude Code-specific: hooks/ and .claude-plugin/ exist
   if [ -d "$CC_DIST/hooks" ]; then

--- a/tests/test-opencode-build.sh
+++ b/tests/test-opencode-build.sh
@@ -115,7 +115,7 @@ echo "--- Running: build.sh opencode ---"
 BUILD_OUTPUT=$("$BUILD_SCRIPT" opencode 2>&1) || {
   fail "build.sh opencode exited with non-zero status"
   echo "  Build output:"
-  echo "$BUILD_OUTPUT" | sed 's/^/    /'
+  printf '    %s\n' "${BUILD_OUTPUT//$'\n'/$'\n    '}"
   echo ""
   echo "RESULT: $PASS passed, $FAIL failed (build failed, cannot continue)"
   # Clean up
@@ -295,10 +295,10 @@ fi
 
 if [ -d "$OC_DIST/protocols" ]; then
   PROTO_COUNT=$(find "$OC_DIST/protocols" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')
-  assert_eq "$PROTO_COUNT" "24" "protocols/ has exactly 24 .md files"
+  assert_eq "$PROTO_COUNT" "25" "protocols/ has exactly 25 .md files"
 
   # Spot-check specific protocol files
-  for proto in state.md git.md delegation.md recovery.md evidence.md; do
+  for proto in state.md git.md git-freshness.md delegation.md recovery.md evidence.md; do
     if [ -f "$OC_DIST/protocols/$proto" ]; then
       pass "protocols/$proto exists"
     else
@@ -664,7 +664,7 @@ for skill_dir in "$OC_DIST"/skills/*/; do
   REFS=$(grep -oE '\.specwright/protocols/[a-z-]+\.md' "$skill_file" 2>/dev/null || true)
   if [ -n "$REFS" ]; then
     while IFS= read -r ref; do
-      PROTO_NAME=$(echo "$ref" | sed 's|\.specwright/protocols/||')
+      PROTO_NAME="${ref#.specwright/protocols/}"
       if ! echo "$DISTINCT_PROTOCOLS" | grep -qF "$PROTO_NAME"; then
         DISTINCT_PROTOCOLS="$DISTINCT_PROTOCOLS $PROTO_NAME"
         REWRITTEN_PROTOCOLS=$((REWRITTEN_PROTOCOLS + 1))
@@ -904,7 +904,7 @@ echo "--- Running: build.sh claude-code ---"
 CC_BUILD_OUTPUT=$("$BUILD_SCRIPT" claude-code 2>&1) || {
   fail "build.sh claude-code exited with non-zero status (REGRESSION)"
   echo "  Build output:"
-  echo "$CC_BUILD_OUTPUT" | sed 's/^/    /'
+  printf '    %s\n' "${CC_BUILD_OUTPUT//$'\n'/$'\n    '}"
 }
 
 if [ -d "$CC_DIST" ]; then
@@ -1002,6 +1002,8 @@ rm -rf "$DIST_DIR"
 
 ALL_BUILD_OUTPUT=$("$BUILD_SCRIPT" all 2>&1) || {
   fail "build.sh all exited with non-zero status"
+  echo "  Build output:"
+  printf '    %s\n' "${ALL_BUILD_OUTPUT//$'\n'/$'\n    '}"
 }
 
 if [ -d "$OC_DIST" ]; then


### PR DESCRIPTION
## Summary
- add `core/protocols/git-freshness.md` as the shared checkpoint contract for branch-head and queue-managed freshness assessment
- add `adapters/shared/specwright-git-freshness.mjs` so later lifecycle stages can resolve target refs and classify `fresh`, `stale`, `diverged`, `blocked`, and `queue-managed` outcomes deterministically
- extend the default build harnesses and focused shell fixtures so the shared helper is packaged, exercised on the normal test path, and validated against temp-repo freshness scenarios
- document the storage-boundary split between clone-local runtime state, project-level artifacts, and optional auditable work artifacts without relying on symlink layouts

## Acceptance Criteria
- `AC-1` PASS: `core/protocols/git-freshness.md` now defines the checkpoint contract, validation backends, reconcile modes, and result categories without embedding lifecycle policy. Evidence: `core/protocols/git-freshness.md`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-2` PASS: `adapters/shared/specwright-git-freshness.mjs` now exposes a deterministic assessment path that resolves the selected work target, reads Git state explicitly, and returns machine-readable results. Evidence: `adapters/shared/specwright-git-freshness.mjs`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-3` PASS: freshness assessment remains non-mutating; explicit fetch behavior is documented and test-covered. Evidence: `core/protocols/git-freshness.md`, `tests/test-git-freshness-engine.sh`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-4` PASS: the helper now distinguishes `fresh`, `stale`, `diverged`, `blocked`, and `queue-managed` outcomes for later lifecycle consumers. Evidence: `adapters/shared/specwright-git-freshness.mjs`, `tests/test-git-freshness-engine.sh`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-5` PASS: focused temp-repo fixtures now fail on stale, blocked, and queue-mode regressions. Evidence: `tests/test-git-freshness-engine.sh`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/test-quality.md`
- `AC-6` PASS: the protocol and helper terminology stay aligned with the recorded `targetRef` and freshness config model from Unit 01. Evidence: `core/protocols/git-freshness.md`, `adapters/shared/specwright-git-freshness.mjs`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-7` PASS: the protocol now explicitly distinguishes clone-local runtime state from project-level and optionally auditable artifacts. Evidence: `core/protocols/git-freshness.md`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-8` PASS: the helper and protocol operate from resolved roots and recorded work state rather than symlink assumptions or a `.git`-only storage model. Evidence: `core/protocols/git-freshness.md`, `adapters/shared/specwright-git-freshness.mjs`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
- `AC-9` PASS: Unit 02 now documents which artifacts stay local-only versus which may later become reviewable or pushable. Evidence: `core/protocols/git-freshness.md`, `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`

## Blast Radius
- Shared runtime helper: `adapters/shared/specwright-git-freshness.mjs`
- Protocol contract: `core/protocols/git-freshness.md`
- Default build/test path: `tests/test-claude-code-build.sh`, `tests/test-opencode-build.sh`
- Focused regression coverage: `tests/test-git-freshness-engine.sh`

## Gate Results
- `build`: PASS (`0/0/2`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/build-report.md`
- `tests`: PASS (`0/0/2`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/test-quality.md`
- `security`: PASS (`0/0/0`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/security-report.md`
- `wiring`: WARN (`0/1/1`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/wiring-report.md`. The shared helper is still only consumed by the regression harness; Unit 03 is planned to wire it into build/verify/ship checkpoints.
- `semantic`: PASS (`0/0/1`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/semantic-report.md`
- `spec`: PASS (`0/0/1`) — `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`

## Evidence Links
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/build-report.md`
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/test-quality.md`
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/security-report.md`
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/wiring-report.md`
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/semantic-report.md`
- `.git/specwright/work/branch-freshness-policy/units/02-git-freshness-engine/evidence/spec-compliance.md`
