### PR TITLE
docs(04-config-validation-and-visibility): ship unit 04 config validation and visibility

### DIFF
--- a/core/protocols/git-freshness.md
+++ b/core/protocols/git-freshness.md
@@ -160,8 +160,8 @@ The helper is an assessor, not a mutator.
 ## Caller Responsibilities
 
 - lifecycle skills decide whether a result blocks, warns, or proceeds
-- publication mode for optional auditable work artifacts is configured outside
-  this helper
+- publication mode for optional auditable work artifacts comes from
+  `config.git.workArtifacts` in `protocols/git.md`, not from this helper
 - redaction or safe publication of evidence is handled by the surfaces that
   expose or commit those artifacts
 

--- a/core/protocols/git.md
+++ b/core/protocols/git.md
@@ -27,6 +27,10 @@ hardcoded.
         "ship": "require"
       }
     },
+    "workArtifacts": {
+      "mode": "clone-local",
+      "trackedRoot": null
+    },
     "branchPrefix": "feat/",
     "mergeStrategy": "squash",
     "prRequired": true,
@@ -45,6 +49,7 @@ hardcoded.
 | `baseBranch` | string | `main` | compatibility alias for the default integration branch |
 | `targets` | object | see above | canonical branch-role defaults used to resolve work-level target refs |
 | `freshness` | object | see above | canonical checkpoint policy for build, verify, and ship freshness checks |
+| `workArtifacts` | object or null | `null` (`clone-local`) | optional publication mode for auditable work artifacts |
 | `branchPrefix` | string | `feat/` | prefix for feature branches |
 | `mergeStrategy` | enum | `squash` | `squash`, `rebase`, `merge` |
 | `prRequired` | boolean | `true` | whether PRs are required for shipping |
@@ -84,6 +89,29 @@ selected work:
 
 This keeps the branch-target model explicit without introducing a custom branch
 DSL.
+
+## Work-Artifact Publication Mode
+
+`git.workArtifacts` is the canonical config surface for optional auditable work
+artifacts. It is optional; when omitted, those artifacts remain clone-local.
+
+Supported shape:
+
+- `mode`: `clone-local` or `tracked`
+- `trackedRoot`: repo-relative path required when `mode = tracked`
+
+Semantics:
+
+- `clone-local` keeps optional auditable work artifacts under clone-local
+  Specwright state. They do not become tracked project files by default.
+- `tracked` publishes only the optional auditable work artifacts under an
+  explicit tracked root inside `projectRoot`.
+- `trackedRoot` must not point at `.git`, `repoStateRoot`,
+  `worktreeStateRoot`, session state, or a symlinked mirror of those runtime
+  roots.
+- This setting does not move project-level artifacts such as `CONSTITUTION.md`,
+  `CHARTER.md`, or `TESTING.md`; those remain project artifacts regardless of
+  work-artifact publication mode.
 
 ## Logical Roots And Selected Work
 

--- a/core/skills/sw-doctor/SKILL.md
+++ b/core/skills/sw-doctor/SKILL.md
@@ -68,6 +68,12 @@ Within the State pass, check all of the following and report them by name:
 - legacy-write drift where the shared layout exists but checkout-local legacy
   state files are still being treated as writable sources
 
+Within the Config pass, check all of the following and report them by name:
+- queue validation without the required provider-aware configuration surface
+- work-artifact publication mode that points at clone-local runtime roots,
+  session state, or symlinked `.git` mirrors instead of an explicit tracked
+  artifact path
+
 STATE_DRIFT findings must print the inline remediation command
 `sw-status --repair {unitId}` and include the owning work ID.
 

--- a/core/skills/sw-doctor/SKILL.md
+++ b/core/skills/sw-doctor/SKILL.md
@@ -74,6 +74,9 @@ Within the Config pass, check all of the following and report them by name:
   session state, or symlinked `.git` mirrors instead of an explicit tracked
   artifact path
 
+CONFIG_MISMATCH findings must name the offending config key and print the
+corrective action.
+
 STATE_DRIFT findings must print the inline remediation command
 `sw-status --repair {unitId}` and include the owning work ID.
 

--- a/core/skills/sw-guard/SKILL.md
+++ b/core/skills/sw-guard/SKILL.md
@@ -65,6 +65,7 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
   Validate detected tools by running them (e.g., `--version` check). Present
   standalone recommendations with explicit "detected via heuristics" labeling.
 - When Git workflow config is present or inferred, seed or migrate `git.targets` and `git.freshness` from the detected Git workflow strategy without requiring users to define a custom branch DSL.
+- Detect or confirm target-role defaults, freshness checkpoints, and any optional work-artifact publication mode as one explicit Git policy surface, but keep the publication choice separately from clone-local runtime state.
 - For unfamiliar stacks or niche tools, use WebSearch to identify tooling conventions.
 - Detect existing guardrails before recommending. Show delta on re-runs.
 
@@ -87,6 +88,7 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
 **Configuration (LOW freedom):**
 - External file writes: diff-show-approve. Installation commands require explicit approval.
 - Update config.json with detected tool commands if `.specwright/` exists.
+- When present, update the approved work-artifact publication choice in config separately from clone-local runtime state.
   Follow `protocols/context.md` for config updates.
 - Never modify CONSTITUTION.md (sw-learn's responsibility).
 

--- a/core/skills/sw-init/SKILL.md
+++ b/core/skills/sw-init/SKILL.md
@@ -113,9 +113,10 @@ Quality gates are configured in config (all six default to enabled; user may dis
 
 **Git workflow configuration (MEDIUM freedom):**
 - Detect workflow by scanning branch names, remotes, CI files. Present detected strategy with confidence.
-- Confirm via AskUserQuestion: strategy (trunk-based/github-flow/gitflow/custom), branch prefix, merge strategy, PR required, commit format.
+- Confirm via AskUserQuestion: strategy (trunk-based/github-flow/gitflow/custom), target-role defaults and freshness checkpoints, branch prefix, merge strategy, PR required, commit format.
+- Ask whether optional auditable work artifacts stay clone-local or are published under a tracked work-artifact root. Project-level anchor docs remain project artifacts and runtime session state stays local-only.
 - Store `git.targets` and `git.freshness` in `config.json`, seeding branch-role defaults and freshness checkpoints from the detected workflow strategy while preserving `baseBranch` as a compatibility alias and without requiring users to define a custom branch DSL.
-- Store the resulting settings in the `config.json` `git` section per `protocols/git.md`.
+- Store the resulting settings in the `config.json` `git` section per `protocols/git.md`. Record any optional work-artifact publication choice in config instead of inferring it from `.git/` paths or symlinks.
 - If old git schema detected: offer migration with sensible defaults.
 
 **Configuration (LOW freedom):**

--- a/core/skills/sw-status/SKILL.md
+++ b/core/skills/sw-status/SKILL.md
@@ -39,8 +39,10 @@ other works are active in the repository, and what the next action should be.
   summary so hidden `.git` state is inspectable.
 - Show the current session first: `worktreeId`, mode, branch, and
   `attachedWorkId`.
-- If the session is attached, show that work's status, unit/task progress,
-  gates, and per-work lock freshness.
+- If the session is attached, show that work's status, unit/task progress, the
+  selected work's target branch and latest freshness state, configured
+  work-artifact publication mode when present, gates, and per-work lock
+  freshness.
 - Enumerate other active works discovered under `repoStateRoot/work/*`, along
   with their recorded owner worktrees and whether the owner still has a live
   top-level session.

--- a/core/skills/sw-sync/SKILL.md
+++ b/core/skills/sw-sync/SKILL.md
@@ -34,6 +34,15 @@ claimed by a live Specwright session or a subordinate helper worktree.
 - Summary report: branches fetched, removed, skipped, protected, and any stale
   active works detected
 
+## Advisory Reporting
+
+- After fetch/prune completes, `sw-sync` may report stale active works against
+  their recorded targets and latest known freshness state.
+- This report is advisory only and does not take ownership of
+  reconcile-or-ship decisions away from the lifecycle skills.
+- `sw-sync` never rebases, merges, retargets, or clears a freshness block on
+  behalf of `sw-build`, `sw-verify`, or `sw-ship`.
+
 ## Constraints
 
 **Fetch (HIGH freedom):**
@@ -49,14 +58,6 @@ claimed by a live Specwright session or a subordinate helper worktree.
 - Treat subordinate helper worktrees discovered via `git worktree list --porcelain`
   as protected branch owners even when they are not user-facing sessions.
 - Never delete a branch that appears in that protection set.
-
-**Stale active work visibility (MEDIUM freedom):**
-- After fetch/prune completes, `sw-sync` may report stale active works against
-  their recorded targets and latest known freshness state.
-- This report is advisory only and does not take ownership of
-  reconcile-or-ship decisions away from the lifecycle skills.
-- `sw-sync` never rebases, merges, retargets, or clears a freshness block on
-  behalf of `sw-build`, `sw-verify`, or `sw-ship`.
 
 **Stale branch detection (HIGH freedom):**
 - Primary signal: `git branch -vv` entries with `[gone]`
@@ -95,6 +96,7 @@ claimed by a live Specwright session or a subordinate helper worktree.
 ## Protocol References
 
 - `protocols/git.md` -- branch lifecycle and cleanup rules
+- `protocols/git-freshness.md` -- freshness result shape and status semantics for advisory reporting
 - `protocols/context.md` -- logical roots and session loading
 - `protocols/state.md` -- per-work workflow fields used for protection
 - `protocols/headless.md` -- non-interactive behavior

--- a/core/skills/sw-sync/SKILL.md
+++ b/core/skills/sw-sync/SKILL.md
@@ -31,7 +31,8 @@ claimed by a live Specwright session or a subordinate helper worktree.
 - Remotes fetched and pruned
 - Base branch fast-forwarded when safe
 - Candidate stale branches previewed, then deleted only after confirmation
-- Summary report: branches fetched, removed, skipped, and protected
+- Summary report: branches fetched, removed, skipped, protected, and any stale
+  active works detected
 
 ## Constraints
 
@@ -48,6 +49,14 @@ claimed by a live Specwright session or a subordinate helper worktree.
 - Treat subordinate helper worktrees discovered via `git worktree list --porcelain`
   as protected branch owners even when they are not user-facing sessions.
 - Never delete a branch that appears in that protection set.
+
+**Stale active work visibility (MEDIUM freedom):**
+- After fetch/prune completes, `sw-sync` may report stale active works against
+  their recorded targets and latest known freshness state.
+- This report is advisory only and does not take ownership of
+  reconcile-or-ship decisions away from the lifecycle skills.
+- `sw-sync` never rebases, merges, retargets, or clears a freshness block on
+  behalf of `sw-build`, `sw-verify`, or `sw-ship`.
 
 **Stale branch detection (HIGH freedom):**
 - Primary signal: `git branch -vv` entries with `[gone]`

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -33,6 +33,7 @@ MULTI_WORKTREE_RUNTIME_TEST="$ROOT_DIR/tests/test-multi-worktree-state.sh"
 TARGET_MODEL_DOCS_TEST="$ROOT_DIR/tests/test-branch-freshness-target-model-docs.sh"
 GIT_FRESHNESS_ENGINE_TEST="$ROOT_DIR/tests/test-git-freshness-engine.sh"
 LIFECYCLE_FRESHNESS_TEST="$ROOT_DIR/tests/test-lifecycle-freshness-checkpoints.sh"
+CONFIG_VISIBILITY_DOCS_TEST="$ROOT_DIR/tests/test-config-validation-visibility-docs.sh"
 
 PASS=0
 FAIL=0
@@ -1181,6 +1182,31 @@ if echo "$LIFECYCLE_FRESHNESS_OUTPUT" | grep -Fq "PASS: sw-build forbids hidden 
   pass "lifecycle regression output includes rewrite-guard coverage"
 else
   fail "lifecycle regression output missing rewrite-guard coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Config validation and visibility docs ==="
+
+if [ -x "$CONFIG_VISIBILITY_DOCS_TEST" ]; then
+  pass "tests/test-config-validation-visibility-docs.sh is executable"
+else
+  fail "tests/test-config-validation-visibility-docs.sh is missing or not executable"
+fi
+
+CONFIG_VISIBILITY_EXIT=0
+CONFIG_VISIBILITY_OUTPUT="$(bash "$CONFIG_VISIBILITY_DOCS_TEST" 2>&1)" || CONFIG_VISIBILITY_EXIT=$?
+
+if [ "$CONFIG_VISIBILITY_EXIT" -ne 0 ]; then
+  fail "tests/test-config-validation-visibility-docs.sh passes under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${CONFIG_VISIBILITY_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-config-validation-visibility-docs.sh passes under the configured test path"
+fi
+if echo "$CONFIG_VISIBILITY_OUTPUT" | grep -Fq "PASS: sw-sync stays advisory on reconcile and ship decisions"; then
+  pass "config-visibility regression output includes sync-boundary coverage"
+else
+  fail "config-visibility regression output missing sync-boundary coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -1197,7 +1197,7 @@ CONFIG_VISIBILITY_EXIT=0
 CONFIG_VISIBILITY_OUTPUT="$(bash "$CONFIG_VISIBILITY_DOCS_TEST" 2>&1)" || CONFIG_VISIBILITY_EXIT=$?
 
 if [ "$CONFIG_VISIBILITY_EXIT" -ne 0 ]; then
-  fail "tests/test-config-validation-visibility-docs.sh passes under the configured test path"
+  fail "tests/test-config-validation-visibility-docs.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${CONFIG_VISIBILITY_OUTPUT//$'\n'/$'\n    '}"
 else

--- a/tests/test-config-validation-visibility-docs.sh
+++ b/tests/test-config-validation-visibility-docs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Regression checks for the config/visibility surfaces introduced by
+# branch-freshness-policy Unit 04.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
+GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+echo "=== config validation and visibility docs ==="
+echo ""
+
+for file in "$INIT_SKILL" "$GUARD_SKILL"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- Task 1: init and guard configuration surfaces ---"
+assert_contains "$INIT_SKILL" "target-role defaults and freshness checkpoints" "sw-init confirms target defaults and checkpoint policy together"
+assert_contains "$INIT_SKILL" "optional auditable work artifacts stay clone-local or are published under a tracked work-artifact root" "sw-init asks for optional work-artifact publication mode"
+assert_contains "$INIT_SKILL" "Project-level anchor docs remain project artifacts and runtime session state stays local-only" "sw-init preserves the storage boundary split"
+assert_contains "$GUARD_SKILL" "target-role defaults, freshness checkpoints, and any optional work-artifact publication mode" "sw-guard keeps the Git policy surface explicit"
+assert_contains "$GUARD_SKILL" "separately from clone-local runtime state" "sw-guard distinguishes publication policy from runtime-local state"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/test-config-validation-visibility-docs.sh
+++ b/tests/test-config-validation-visibility-docs.sh
@@ -12,6 +12,7 @@ INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
 GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
 DOCTOR_SKILL="$ROOT_DIR/core/skills/sw-doctor/SKILL.md"
 STATUS_SKILL="$ROOT_DIR/core/skills/sw-status/SKILL.md"
+SYNC_SKILL="$ROOT_DIR/core/skills/sw-sync/SKILL.md"
 
 PASS=0
 FAIL=0
@@ -40,7 +41,7 @@ assert_contains() {
 echo "=== config validation and visibility docs ==="
 echo ""
 
-for file in "$INIT_SKILL" "$GUARD_SKILL" "$DOCTOR_SKILL" "$STATUS_SKILL"; do
+for file in "$INIT_SKILL" "$GUARD_SKILL" "$DOCTOR_SKILL" "$STATUS_SKILL" "$SYNC_SKILL"; do
   if [ -f "$file" ]; then
     pass "exists: ${file#"$ROOT_DIR"/}"
   else
@@ -62,6 +63,11 @@ assert_contains "$DOCTOR_SKILL" "queue validation without the required provider-
 assert_contains "$DOCTOR_SKILL" "work-artifact publication mode" "sw-doctor validates artifact publication mode safely"
 assert_contains "$STATUS_SKILL" "selected work's target branch and latest freshness state" "sw-status surfaces target branch plus freshness state"
 assert_contains "$STATUS_SKILL" "work-artifact publication mode when present" "sw-status surfaces publication mode when present"
+
+echo ""
+echo "--- Task 3: sync boundaries ---"
+assert_contains "$SYNC_SKILL" "report stale active works against" "sw-sync can report stale active works"
+assert_contains "$SYNC_SKILL" "reconcile-or-ship decisions away from the lifecycle skills" "sw-sync stays advisory on reconcile and ship decisions"
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-config-validation-visibility-docs.sh
+++ b/tests/test-config-validation-visibility-docs.sh
@@ -10,6 +10,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
 GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
+DOCTOR_SKILL="$ROOT_DIR/core/skills/sw-doctor/SKILL.md"
+STATUS_SKILL="$ROOT_DIR/core/skills/sw-status/SKILL.md"
 
 PASS=0
 FAIL=0
@@ -38,7 +40,7 @@ assert_contains() {
 echo "=== config validation and visibility docs ==="
 echo ""
 
-for file in "$INIT_SKILL" "$GUARD_SKILL"; do
+for file in "$INIT_SKILL" "$GUARD_SKILL" "$DOCTOR_SKILL" "$STATUS_SKILL"; do
   if [ -f "$file" ]; then
     pass "exists: ${file#"$ROOT_DIR"/}"
   else
@@ -53,6 +55,13 @@ assert_contains "$INIT_SKILL" "optional auditable work artifacts stay clone-loca
 assert_contains "$INIT_SKILL" "Project-level anchor docs remain project artifacts and runtime session state stays local-only" "sw-init preserves the storage boundary split"
 assert_contains "$GUARD_SKILL" "target-role defaults, freshness checkpoints, and any optional work-artifact publication mode" "sw-guard keeps the Git policy surface explicit"
 assert_contains "$GUARD_SKILL" "separately from clone-local runtime state" "sw-guard distinguishes publication policy from runtime-local state"
+
+echo ""
+echo "--- Task 2: doctor and status visibility surfaces ---"
+assert_contains "$DOCTOR_SKILL" "queue validation without the required provider-aware configuration surface" "sw-doctor rejects queue mode without provider-aware config"
+assert_contains "$DOCTOR_SKILL" "work-artifact publication mode" "sw-doctor validates artifact publication mode safely"
+assert_contains "$STATUS_SKILL" "selected work's target branch and latest freshness state" "sw-status surfaces target branch plus freshness state"
+assert_contains "$STATUS_SKILL" "work-artifact publication mode when present" "sw-status surfaces publication mode when present"
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-config-validation-visibility-docs.sh
+++ b/tests/test-config-validation-visibility-docs.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+GIT_PROTOCOL="$ROOT_DIR/core/protocols/git.md"
 INIT_SKILL="$ROOT_DIR/core/skills/sw-init/SKILL.md"
 GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
 DOCTOR_SKILL="$ROOT_DIR/core/skills/sw-doctor/SKILL.md"
@@ -50,24 +51,32 @@ for file in "$INIT_SKILL" "$GUARD_SKILL" "$DOCTOR_SKILL" "$STATUS_SKILL" "$SYNC_
 done
 
 echo ""
+# These literal-match sentinels intentionally guard the published support
+# surface, but use short phrases so punctuation-only rewrites do not cause
+# false failures.
 echo "--- Task 1: init and guard configuration surfaces ---"
 assert_contains "$INIT_SKILL" "target-role defaults and freshness checkpoints" "sw-init confirms target defaults and checkpoint policy together"
-assert_contains "$INIT_SKILL" "optional auditable work artifacts stay clone-local or are published under a tracked work-artifact root" "sw-init asks for optional work-artifact publication mode"
-assert_contains "$INIT_SKILL" "Project-level anchor docs remain project artifacts and runtime session state stays local-only" "sw-init preserves the storage boundary split"
-assert_contains "$GUARD_SKILL" "target-role defaults, freshness checkpoints, and any optional work-artifact publication mode" "sw-guard keeps the Git policy surface explicit"
+assert_contains "$INIT_SKILL" "optional auditable work artifacts" "sw-init asks for optional work-artifact publication mode"
+assert_contains "$INIT_SKILL" "runtime session state stays local-only" "sw-init preserves the storage boundary split"
+assert_contains "$GUARD_SKILL" "target-role defaults, freshness checkpoints" "sw-guard keeps the Git policy surface explicit"
 assert_contains "$GUARD_SKILL" "separately from clone-local runtime state" "sw-guard distinguishes publication policy from runtime-local state"
 
 echo ""
 echo "--- Task 2: doctor and status visibility surfaces ---"
-assert_contains "$DOCTOR_SKILL" "queue validation without the required provider-aware configuration surface" "sw-doctor rejects queue mode without provider-aware config"
+assert_contains "$DOCTOR_SKILL" "provider-aware configuration surface" "sw-doctor rejects queue mode without provider-aware config"
 assert_contains "$DOCTOR_SKILL" "work-artifact publication mode" "sw-doctor validates artifact publication mode safely"
-assert_contains "$STATUS_SKILL" "selected work's target branch and latest freshness state" "sw-status surfaces target branch plus freshness state"
+assert_contains "$DOCTOR_SKILL" "CONFIG_MISMATCH findings must name the offending config key" "sw-doctor makes config remediation explicit"
+assert_contains "$STATUS_SKILL" "target branch and latest freshness state" "sw-status surfaces target branch plus freshness state"
 assert_contains "$STATUS_SKILL" "work-artifact publication mode when present" "sw-status surfaces publication mode when present"
 
 echo ""
-echo "--- Task 3: sync boundaries ---"
+echo "--- Task 3: protocol anchor and sync boundaries ---"
+assert_contains "$GIT_PROTOCOL" '"workArtifacts": {' "git protocol adds a canonical workArtifacts config surface"
+assert_contains "$GIT_PROTOCOL" '"mode": "clone-local"' "git protocol names clone-local publication mode"
+assert_contains "$GIT_PROTOCOL" '"trackedRoot": null' "git protocol names the tracked artifact root field"
 assert_contains "$SYNC_SKILL" "report stale active works against" "sw-sync can report stale active works"
 assert_contains "$SYNC_SKILL" "reconcile-or-ship decisions away from the lifecycle skills" "sw-sync stays advisory on reconcile and ship decisions"
+assert_contains "$SYNC_SKILL" "protocols/git-freshness.md" "sw-sync references the shared freshness protocol"
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- extend `sw-init` and `sw-guard` so the Git policy surface explicitly covers target-role defaults, freshness checkpoints, and optional work-artifact publication mode without collapsing runtime-local state into tracked artifacts
- extend `sw-doctor` and `sw-status` so queue-mode misconfiguration, target branch visibility, freshness visibility, and publication-mode visibility are all first-class support-surface checks
- keep `sw-sync` advisory by surfacing stale active works without taking over reconcile or ship decisions from lifecycle skills
- add `tests/test-config-validation-visibility-docs.sh` and wire it into `tests/test-claude-code-build.sh` so the default repo validation path enforces the new contract

## Acceptance Criteria
- `AC-1` PASS: `core/skills/sw-init/SKILL.md` and `core/skills/sw-guard/SKILL.md` now describe target-role defaults and freshness policy from repo Git strategy without a custom branch DSL. Evidence: `core/skills/sw-init/SKILL.md`, `core/skills/sw-guard/SKILL.md`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`
- `AC-2` PASS: `core/skills/sw-doctor/SKILL.md` now describes queue validation without the required provider-aware configuration surface and validates unsafe publication targets. Evidence: `core/skills/sw-doctor/SKILL.md`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`
- `AC-3` PASS: `core/skills/sw-status/SKILL.md` now surfaces the selected work's target branch and latest freshness state clearly enough for block/warn diagnosis. Evidence: `core/skills/sw-status/SKILL.md`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`
- `AC-4` PASS: `core/skills/sw-sync/SKILL.md` may report stale active works against recorded targets while keeping reconcile-or-ship decisions with the lifecycle skills. Evidence: `core/skills/sw-sync/SKILL.md`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`
- `AC-5` PASS: the touched support-surface skills keep provider-specific detail bounded to configuration and validation responsibilities rather than inlining merge-queue playbooks. Evidence: `core/skills/sw-init/SKILL.md`, `core/skills/sw-guard/SKILL.md`, `core/skills/sw-doctor/SKILL.md`, `core/skills/sw-sync/SKILL.md`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`
- `AC-6` PASS: regression tests now fail if these surfaces omit target visibility, accept invalid queue-mode combinations silently, or let `sw-sync` drift into branch-rewrite behavior. Evidence: `tests/test-config-validation-visibility-docs.sh`, `tests/test-claude-code-build.sh`, `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`

## Blast Radius
- Support-surface skills: `core/skills/sw-init/SKILL.md`, `core/skills/sw-guard/SKILL.md`, `core/skills/sw-doctor/SKILL.md`, `core/skills/sw-status/SKILL.md`, `core/skills/sw-sync/SKILL.md`
- Focused regression: `tests/test-config-validation-visibility-docs.sh`
- Default shell harness: `tests/test-claude-code-build.sh`

## Gate Results
- `build`: PASS (`0/0/2`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/build-report.md`
- `tests`: PASS (`0/0/0`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/test-quality.md`
- `security`: PASS (`0/0/0`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/security-report.md`
- `wiring`: PASS (`0/0/1`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/wiring-report.md`
- `semantic`: PASS (`0/0/1`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/semantic-report.md`
- `spec`: PASS (`0/0/0`) — `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`

## Evidence Links
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/build-report.md`
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/test-quality.md`
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/security-report.md`
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/wiring-report.md`
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/semantic-report.md`
- `.git/specwright/work/branch-freshness-policy/units/04-config-validation-and-visibility/evidence/spec-compliance.md`