### PR TITLE
feat(audit-chain): establish tracked artifact root model

### DIFF
--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 
 const FAILURE_CODE = 'GIT_RESOLUTION_FAILED';
 const PRIMARY_WORKTREE_ID = 'main-worktree';
+const PROJECT_ARTIFACTS_DIR = '.specwright';
 const LEGACY_STATE_SEGMENTS = ['.specwright', 'state'];
 const SHARED_CONFIG_FILE = 'config.json';
 const FALLBACK_REPO_LOCAL_GIT_ENV_VARS = new Set([
@@ -124,6 +125,7 @@ export function resolveSpecwrightRoots(options = {}) {
   }
 
   const projectRoot = resolve(projectRootResult.value);
+  const projectArtifactsRoot = join(projectRoot, PROJECT_ARTIFACTS_DIR);
 
   const gitDirResult = resolveGitRoot(projectRoot, 'gitDir', ['rev-parse', '--git-dir']);
   if (!gitDirResult.ok) {
@@ -137,14 +139,18 @@ export function resolveSpecwrightRoots(options = {}) {
 
   const gitDir = resolve(projectRoot, gitDirResult.value);
   const gitCommonDir = resolve(projectRoot, gitCommonDirResult.value);
+  const repoStateRoot = join(gitCommonDir, 'specwright');
+  const worktreeStateRoot = join(gitDir, 'specwright');
 
   return {
     ok: true,
     projectRoot,
+    projectArtifactsRoot,
     gitDir,
     gitCommonDir,
-    repoStateRoot: join(gitCommonDir, 'specwright'),
-    worktreeStateRoot: join(gitDir, 'specwright'),
+    repoStateRoot,
+    worktreeStateRoot,
+    workArtifactsRoot: resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot),
     worktreeId: deriveWorktreeId(gitDir, gitCommonDir)
   };
 }
@@ -167,6 +173,73 @@ export function resolveLegacyStatePaths(options = {}) {
 
 function parseJsonFile(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function parseJsonFileSafe(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTrackedRoot(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isPathWithin(basePath, targetPath) {
+  const relativePath = relative(basePath, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function loadResolvedConfig(projectArtifactsRoot, repoStateRoot) {
+  const candidates = [
+    join(projectArtifactsRoot, SHARED_CONFIG_FILE),
+    join(repoStateRoot, SHARED_CONFIG_FILE)
+  ];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+
+    const config = parseJsonFileSafe(candidate);
+    if (config && typeof config === 'object') {
+      return {
+        path: candidate,
+        config
+      };
+    }
+  }
+
+  return {
+    path: null,
+    config: null
+  };
+}
+
+function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot) {
+  const { config } = loadResolvedConfig(projectArtifactsRoot, repoStateRoot);
+  const workArtifacts = config?.git?.workArtifacts ?? {};
+  const mode = workArtifacts?.mode === 'tracked' ? 'tracked' : 'clone-local';
+  const trackedRoot = normalizeTrackedRoot(workArtifacts?.trackedRoot);
+
+  if (mode === 'tracked' && trackedRoot) {
+    const trackedPath = resolve(projectRoot, trackedRoot);
+    const trackedRelative = relative(projectRoot, trackedPath);
+    const firstSegment = trackedRelative.split(/[\\/]/u)[0];
+
+    if (isPathWithin(projectRoot, trackedPath) && firstSegment !== '.git') {
+      return trackedPath;
+    }
+  }
+
+  return join(repoStateRoot, 'work');
 }
 
 function normalizeAttachedWorkId(value) {
@@ -231,8 +304,14 @@ function summarizeGates(gates) {
     .join(', ');
 }
 
-function buildWorkArtifacts(baseDir, workId, workDir) {
-  const relativeWorkDir = workDir || `work/${workId}`;
+function buildWorkArtifacts(baseDir, workId, workDir, options = {}) {
+  const defaultWorkDir = options.defaultWorkDir ?? `work/${workId}`;
+  let relativeWorkDir = workDir || defaultWorkDir;
+
+  if (options.stripLegacyWorkPrefix && relativeWorkDir.startsWith('work/')) {
+    relativeWorkDir = relativeWorkDir.slice('work/'.length);
+  }
+
   const workDirPath = resolve(baseDir, relativeWorkDir);
 
   return {
@@ -330,11 +409,20 @@ function listSessionFiles(roots) {
 
 export function loadSpecwrightState(options = {}) {
   const legacy = resolveLegacyStatePaths(options);
-  const sharedConfigPath = legacy.ok ? join(legacy.repoStateRoot, SHARED_CONFIG_FILE) : null;
-  const usingSharedLayout = Boolean(sharedConfigPath && existsSync(sharedConfigPath));
+  const projectConfigPath = legacy.ok ? join(legacy.projectArtifactsRoot, SHARED_CONFIG_FILE) : null;
+  const repoConfigPath = legacy.ok ? join(legacy.repoStateRoot, SHARED_CONFIG_FILE) : null;
+  const sessionPath = legacy.ok ? join(legacy.worktreeStateRoot, 'session.json') : null;
+  const projectConfigExists = Boolean(projectConfigPath && existsSync(projectConfigPath));
+  const repoConfigExists = Boolean(repoConfigPath && existsSync(repoConfigPath));
+  const sessionExists = Boolean(sessionPath && existsSync(sessionPath));
+  const sharedWorkRoot = legacy.ok ? join(legacy.repoStateRoot, 'work') : null;
+  const sharedWorkExists = Boolean(sharedWorkRoot && existsSync(sharedWorkRoot));
+  const sharedConfigPath = projectConfigExists
+    ? projectConfigPath
+    : (repoConfigExists ? repoConfigPath : null);
+  const usingSharedLayout = Boolean(repoConfigExists || sessionExists || sharedWorkExists);
 
   if (usingSharedLayout) {
-    const sessionPath = join(legacy.worktreeStateRoot, 'session.json');
     const continuationPath = join(legacy.worktreeStateRoot, 'continuation.md');
     const session = existsSync(sessionPath) ? parseJsonFile(sessionPath) : null;
     const attachedWork = resolveSharedWorkflowPath(legacy.repoStateRoot, session?.attachedWorkId);
@@ -348,6 +436,8 @@ export function loadSpecwrightState(options = {}) {
       ...legacy,
       layout: 'shared',
       sharedConfigPath,
+      projectConfigPath,
+      repoConfigPath: repoConfigExists ? repoConfigPath : null,
       sessionPath,
       session,
       attachedWorkId,
@@ -363,7 +453,9 @@ export function loadSpecwrightState(options = {}) {
   return {
     ...legacy,
     layout: 'legacy',
-    sharedConfigPath: null,
+    sharedConfigPath,
+    projectConfigPath,
+    repoConfigPath: repoConfigExists ? repoConfigPath : null,
     sessionPath: null,
     session: null,
     attachedWorkId: workflow?.currentWork?.id ?? null,
@@ -413,9 +505,13 @@ export function normalizeActiveWork(stateInfo) {
   }
 
   const artifacts = buildWorkArtifacts(
-    stateInfo.repoStateRoot,
+    stateInfo.workArtifactsRoot ?? resolve(stateInfo.repoStateRoot, 'work'),
     workflow.id,
-    workflow.workDir
+    workflow.workDir,
+    {
+      defaultWorkDir: workflow.id,
+      stripLegacyWorkPrefix: true
+    }
   );
   const tasksCompleted = Array.isArray(workflow.tasksCompleted) ? workflow.tasksCompleted : [];
 
@@ -432,7 +528,7 @@ export function normalizeActiveWork(stateInfo) {
     workDirPath: artifacts.workDirPath,
     specPath: artifacts.specPath,
     planPath: artifacts.planPath,
-    artifactsRoot: stateInfo.repoStateRoot,
+    artifactsRoot: stateInfo.workArtifactsRoot ?? resolve(stateInfo.repoStateRoot, 'work'),
     gates: workflow.gates ?? {},
     gatesSummary: summarizeGates(workflow.gates),
     lock: workflow.lock ?? null,

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 
 const FAILURE_CODE = 'GIT_RESOLUTION_FAILED';
@@ -150,7 +150,7 @@ export function resolveSpecwrightRoots(options = {}) {
     gitCommonDir,
     repoStateRoot,
     worktreeStateRoot,
-    workArtifactsRoot: resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot),
+    workArtifactsRoot: resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot, worktreeStateRoot),
     worktreeId: deriveWorktreeId(gitDir, gitCommonDir)
   };
 }
@@ -197,6 +197,34 @@ function isPathWithin(basePath, targetPath) {
   return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
 }
 
+function pathsOverlap(pathA, pathB) {
+  return isPathWithin(pathA, pathB) || isPathWithin(pathB, pathA);
+}
+
+function resolvePathThroughExistingAncestors(basePath, targetPath) {
+  const relativePath = relative(basePath, targetPath);
+  if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return targetPath;
+  }
+
+  let currentPath = basePath;
+  for (const segment of relativePath.split(/[\\/]/u)) {
+    const candidatePath = join(currentPath, segment);
+    if (existsSync(candidatePath)) {
+      try {
+        currentPath = realpathSync(candidatePath);
+        continue;
+      } catch {
+        // Fall back to lexical resolution when an existing path cannot be resolved.
+      }
+    }
+
+    currentPath = resolve(currentPath, segment);
+  }
+
+  return currentPath;
+}
+
 function loadResolvedConfig(projectArtifactsRoot, repoStateRoot) {
   const candidates = [
     join(projectArtifactsRoot, SHARED_CONFIG_FILE),
@@ -223,7 +251,7 @@ function loadResolvedConfig(projectArtifactsRoot, repoStateRoot) {
   };
 }
 
-function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot) {
+function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot, worktreeStateRoot) {
   const { config } = loadResolvedConfig(projectArtifactsRoot, repoStateRoot);
   const workArtifacts = config?.git?.workArtifacts ?? {};
   const mode = workArtifacts?.mode === 'tracked' ? 'tracked' : 'clone-local';
@@ -231,10 +259,19 @@ function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRo
 
   if (mode === 'tracked' && trackedRoot) {
     const trackedPath = resolve(projectRoot, trackedRoot);
+    const effectiveTrackedPath = resolvePathThroughExistingAncestors(projectRoot, trackedPath);
     const trackedRelative = relative(projectRoot, trackedPath);
     const firstSegment = trackedRelative.split(/[\\/]/u)[0];
 
-    if (isPathWithin(projectRoot, trackedPath) && firstSegment !== '.git') {
+    if (
+      isPathWithin(projectRoot, trackedPath) &&
+      isPathWithin(projectRoot, effectiveTrackedPath) &&
+      firstSegment !== '.git' &&
+      !pathsOverlap(trackedPath, repoStateRoot) &&
+      !pathsOverlap(trackedPath, worktreeStateRoot) &&
+      !pathsOverlap(effectiveTrackedPath, repoStateRoot) &&
+      !pathsOverlap(effectiveTrackedPath, worktreeStateRoot)
+    ) {
       return trackedPath;
     }
   }
@@ -306,13 +343,23 @@ function summarizeGates(gates) {
 
 function buildWorkArtifacts(baseDir, workId, workDir, options = {}) {
   const defaultWorkDir = options.defaultWorkDir ?? `work/${workId}`;
-  let relativeWorkDir = workDir || defaultWorkDir;
+  const normalizedDefaultWorkDir = defaultWorkDir.replace(/[\\]/gu, '/');
+  let relativeWorkDir = (workDir || defaultWorkDir).replace(/[\\]/gu, '/');
 
   if (options.stripLegacyWorkPrefix && relativeWorkDir.startsWith('work/')) {
     relativeWorkDir = relativeWorkDir.slice('work/'.length);
   }
 
-  const workDirPath = resolve(baseDir, relativeWorkDir);
+  let fallbackWorkDir = normalizedDefaultWorkDir;
+  if (options.stripLegacyWorkPrefix && fallbackWorkDir.startsWith('work/')) {
+    fallbackWorkDir = fallbackWorkDir.slice('work/'.length);
+  }
+
+  let workDirPath = resolve(baseDir, relativeWorkDir);
+  if (!isPathWithin(baseDir, workDirPath)) {
+    relativeWorkDir = fallbackWorkDir;
+    workDirPath = resolve(baseDir, relativeWorkDir);
+  }
 
   return {
     workDir: relativeWorkDir,
@@ -420,7 +467,7 @@ export function loadSpecwrightState(options = {}) {
   const sharedConfigPath = projectConfigExists
     ? projectConfigPath
     : (repoConfigExists ? repoConfigPath : null);
-  const usingSharedLayout = Boolean(repoConfigExists || sessionExists || sharedWorkExists);
+  const usingSharedLayout = Boolean(projectConfigExists || repoConfigExists || sessionExists || sharedWorkExists);
 
   if (usingSharedLayout) {
     const continuationPath = join(legacy.worktreeStateRoot, 'continuation.md');
@@ -504,8 +551,9 @@ export function normalizeActiveWork(stateInfo) {
     return null;
   }
 
+  const workArtifactsRoot = stateInfo.workArtifactsRoot ?? resolve(stateInfo.repoStateRoot, 'work');
   const artifacts = buildWorkArtifacts(
-    stateInfo.workArtifactsRoot ?? resolve(stateInfo.repoStateRoot, 'work'),
+    workArtifactsRoot,
     workflow.id,
     workflow.workDir,
     {
@@ -528,7 +576,7 @@ export function normalizeActiveWork(stateInfo) {
     workDirPath: artifacts.workDirPath,
     specPath: artifacts.specPath,
     planPath: artifacts.planPath,
-    artifactsRoot: stateInfo.workArtifactsRoot ?? resolve(stateInfo.repoStateRoot, 'work'),
+    artifactsRoot: workArtifactsRoot,
     gates: workflow.gates ?? {},
     gatesSummary: summarizeGates(workflow.gates),
     lock: workflow.lock ?? null,

--- a/core/protocols/context.md
+++ b/core/protocols/context.md
@@ -73,8 +73,10 @@ Run this sequence before loading Specwright state:
 4. resolve `gitCommonDir`
 5. derive `repoStateRoot`
 6. derive `worktreeStateRoot`
-7. resolve `workArtifactsRoot` from tracked config when present; otherwise
-   default to `{repoStateRoot}/work`
+7. resolve `workArtifactsRoot`: read `config.git.workArtifacts` from
+   `{projectArtifactsRoot}/config.json` when present, else from
+   `{repoStateRoot}/config.json`; default to `{repoStateRoot}/work` when
+   neither config exists or the mode is not `tracked`
 
 If Git root resolution fails, report which root failed and whether the problem
 is local to this worktree or repo-wide.
@@ -95,10 +97,11 @@ should explicitly say the repository is using the legacy working-tree Specwright
 
 ### Preferred mode: shared/session runtime layout
 
-If `{worktreeStateRoot}/session.json` exists, `{repoStateRoot}/work/` exists,
-or `{repoStateRoot}/config.json` exists, the repository is using the
-shared/session runtime layout. That is the normal path for both primary and
-linked worktrees.
+If `{projectArtifactsRoot}/config.json` exists, `{worktreeStateRoot}/session.json`
+exists, `{repoStateRoot}/work/` exists, or `{repoStateRoot}/config.json`
+exists, the repository is using the shared/session root model. Tracked project
+config alone is enough to opt into that model even before any work or session
+file exists. That is the normal path for both primary and linked worktrees.
 
 **Important:** a linked worktree is not degraded merely because the checkout
 lacks a working-tree `.specwright/` directory. Shared repo state lives under

--- a/core/protocols/context.md
+++ b/core/protocols/context.md
@@ -2,45 +2,58 @@
 
 ## Logical Roots
 
-Every skill, hook, and adapter resolves the same three logical roots on every
+Every skill, hook, and adapter resolves the same five logical roots on every
 invocation:
 
 | Root | Resolution | Purpose |
 |---|---|---|
 | `projectRoot` | `git rev-parse --show-toplevel` | source tree and user-facing cwd |
-| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | shared repo-level Specwright state |
+| `projectArtifactsRoot` | `{projectRoot}/.specwright` | tracked project artifacts and shared agent guidance |
+| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | shared clone-local runtime state |
 | `worktreeStateRoot` | `git rev-parse --git-dir` + `/specwright` | per-worktree session and continuation state |
+| `workArtifactsRoot` | `{repoStateRoot}/work` by default; `{projectRoot}/{config.git.workArtifacts.trackedRoot}` when tracked mode is configured | auditable work artifacts |
 
-Callers must prefer those logical roots over checkout-local `.specwright/...`
-path concatenation.
+Callers must prefer those logical roots over hardcoded `.specwright/...` or
+`.git/specwright/...` path concatenation.
 
 ## Standard Context Documents
 
-### Shared repo documents
+### Tracked project artifacts
 
-Load from `repoStateRoot` when needed for alignment or verification:
+Load from `projectArtifactsRoot` when needed for alignment or verification:
 
-- `{repoStateRoot}/config.json` — project settings, commands, gates, git,
-  integration, backlog settings
-- `{repoStateRoot}/CONSTITUTION.md` — development practices and principles
-- `{repoStateRoot}/CHARTER.md` — technology vision and project purpose
-- `{repoStateRoot}/TESTING.md` — testing strategy (optional; if absent,
+- `{projectArtifactsRoot}/config.json` — tracked project settings, commands,
+  gates, git, integration, and backlog settings
+- `{projectArtifactsRoot}/CONSTITUTION.md` — development practices and
+  principles
+- `{projectArtifactsRoot}/CHARTER.md` — technology vision and project purpose
+- `{projectArtifactsRoot}/TESTING.md` — testing strategy (optional; if absent,
   Constitution testing rules remain authoritative)
-- `{repoStateRoot}/LANDSCAPE.md` — codebase architecture and module knowledge
-  (optional)
-- `{repoStateRoot}/AUDIT.md` — codebase health findings and tech debt tracking
-  (optional)
-- `{repoStateRoot}/research/*.md` — external research briefs (loaded by
+- `{projectArtifactsRoot}/LANDSCAPE.md` — codebase architecture and module
+  knowledge (optional)
+- `{projectArtifactsRoot}/AUDIT.md` — codebase health findings and tech debt
+  tracking (optional)
+- `{projectArtifactsRoot}/research/*.md` — external research briefs (loaded by
   `sw-design` on demand; warn if stale per `protocols/research.md`)
 
-### Per-work documents
+### Runtime work records
 
 Load from the selected work under `repoStateRoot/work/{workId}`:
 
 - `workflow.json` — lifecycle, gates, units, attachment, per-work lock
+- `stage-report.md` — runtime-local stage handoff digest
+- `units/{unitId}/stage-report.md` — runtime-local unit handoff digest
+
+### Auditable work artifacts
+
+Load from the selected work under `{workArtifactsRoot}/{workId}`:
+
 - `design.md`, `context.md`, `decisions.md`, `assumptions.md`
-- `units/{unitId}/spec.md`, `plan.md`, `context.md`, `stage-report.md`,
-  `evidence/`
+- `approvals.md`, `integration-criteria.md`
+- `units/{unitId}/spec.md`, `plan.md`, `context.md`
+- `units/{unitId}/implementation-rationale.md`
+- `units/{unitId}/review-packet.md`
+- `units/{unitId}/evidence/`
 
 ### Per-worktree documents
 
@@ -55,20 +68,37 @@ Load from `worktreeStateRoot`:
 Run this sequence before loading Specwright state:
 
 1. resolve `projectRoot`
-2. resolve `gitDir`
-3. resolve `gitCommonDir`
-4. derive `repoStateRoot`
-5. derive `worktreeStateRoot`
+2. derive `projectArtifactsRoot`
+3. resolve `gitDir`
+4. resolve `gitCommonDir`
+5. derive `repoStateRoot`
+6. derive `worktreeStateRoot`
+7. resolve `workArtifactsRoot` from tracked config when present; otherwise
+   default to `{repoStateRoot}/work`
 
 If Git root resolution fails, report which root failed and whether the problem
 is local to this worktree or repo-wide.
 
 ## Loading Mode
 
-### Preferred mode: shared/session layout
+### Tracked project-artifact root
 
-If `{repoStateRoot}/config.json` exists, the repository is using the shared
-state layout. That is the normal path for both primary and linked worktrees.
+If `{projectArtifactsRoot}/config.json` exists, that path is authoritative for
+tracked project config and anchor docs.
+
+If only `{repoStateRoot}/config.json` exists, callers may read it as a
+compatibility bridge for migrated runtime state, but they should warn that the
+tracked config has not yet been moved back to `projectArtifactsRoot`.
+
+If callers fall all the way back to `{projectArtifactsRoot}/state/`, they
+should explicitly say the repository is using the legacy working-tree Specwright layout.
+
+### Preferred mode: shared/session runtime layout
+
+If `{worktreeStateRoot}/session.json` exists, `{repoStateRoot}/work/` exists,
+or `{repoStateRoot}/config.json` exists, the repository is using the
+shared/session runtime layout. That is the normal path for both primary and
+linked worktrees.
 
 **Important:** a linked worktree is not degraded merely because the checkout
 lacks a working-tree `.specwright/` directory. Shared repo state lives under
@@ -76,23 +106,25 @@ lacks a working-tree `.specwright/` directory. Shared repo state lives under
 
 ### Migration fallback: legacy working-tree layout
 
-If the shared/session layout is absent, callers may read legacy files from
-`{projectRoot}/.specwright/` during migration:
+If the shared/session runtime layout is absent, callers may read legacy runtime
+files from `{projectArtifactsRoot}/state/` during migration:
 
-- `{projectRoot}/.specwright/config.json`
-- `{projectRoot}/.specwright/CONSTITUTION.md`
-- `{projectRoot}/.specwright/CHARTER.md`
-- `{projectRoot}/.specwright/TESTING.md`
-- `{projectRoot}/.specwright/state/workflow.json`
-- `{projectRoot}/.specwright/state/continuation.md`
+- `{projectArtifactsRoot}/state/workflow.json`
+- `{projectArtifactsRoot}/state/continuation.md`
 
 Legacy `workflow.json` remains a migration-only bridge. It still uses the v2
 `currentWork` wrapper, so work-aware callers must normalize that wrapper
 explicitly or stop and direct the user to `/sw-init` before relying on work
 status, branch, or unit fields.
 
-Once either new logical root exists, writes go only to the new layout. Mixed
-read/write behavior is forbidden.
+Once the new roots exist, writes go only to their authoritative surface:
+
+- tracked project artifacts -> `projectArtifactsRoot`
+- auditable work artifacts -> `workArtifactsRoot`
+- runtime work state -> `repoStateRoot`
+- runtime session state -> `worktreeStateRoot`
+
+Mixed read/write behavior is forbidden.
 
 ## Session And Work Resolution
 
@@ -119,11 +151,11 @@ Before any operation:
 ```javascript
 resolveLogicalRoots();
 
-if (exists(repoStateRoot + "/config.json")) {
-  config = read(repoStateRoot + "/config.json");
-} else if (exists(projectRoot + "/.specwright/config.json")) {
-  config = read(projectRoot + "/.specwright/config.json"); // migration only
-  warn("Using legacy working-tree Specwright layout — run /sw-init to migrate shared/session roots.");
+if (exists(projectArtifactsRoot + "/config.json")) {
+  config = read(projectArtifactsRoot + "/config.json");
+} else if (exists(repoStateRoot + "/config.json")) {
+  config = read(repoStateRoot + "/config.json"); // compatibility bridge only
+  warn("Using runtime-local config compatibility path — run /sw-init to migrate tracked config back to projectArtifactsRoot.");
 } else {
   error("Run /sw-init first.");
 }
@@ -170,7 +202,9 @@ Load on demand:
 
 - the selected work's `workflow.json`
 - `CONSTITUTION.md`, `CHARTER.md`, `TESTING.md`
-- work-local artifacts for the selected work and unit
+- runtime `stage-report.md` digests from `repoStateRoot`
+- auditable work artifacts for the selected work and unit from
+  `workArtifactsRoot`
 
 Read-only repo-wide views such as `sw-status`, `sw-sync`, and `sw-doctor` may
 enumerate all works from `{repoStateRoot}/work/*/workflow.json` in addition to

--- a/core/protocols/decision.md
+++ b/core/protocols/decision.md
@@ -292,8 +292,8 @@ CCR-reviewed decisions also add `**CCR verdict**` and `**CCR findings**`.
 
 ## Stage Report
 
-Every pipeline skill handoff writes `{workDir}/stage-report.md` before emitting
-the terminal three-line handoff.
+Every pipeline skill handoff writes `{stageReportPath}` before emitting the
+terminal three-line handoff.
 
 **Top line:** `Attention required: {single-sentence summary}`
 
@@ -317,7 +317,7 @@ When a pipeline skill finishes, emit exactly three lines:
 
 ```text
 Done. {one-line outcome}.
-Artifacts: {workDir}/stage-report.md
+Artifacts: {stageReportPath}
 Next: /sw-{next-skill}
 ```
 

--- a/core/protocols/git-freshness.md
+++ b/core/protocols/git-freshness.md
@@ -41,6 +41,7 @@ This clone-local runtime state is never treated as a publishable audit trail.
 These project-level artifacts describe how the project is supposed to work and
 may need to be reviewed or pushed with normal Git history. They include:
 
+- `config.json`
 - `CONSTITUTION.md`
 - `CHARTER.md`
 - `TESTING.md`
@@ -55,14 +56,18 @@ publication decision from runtime orchestration. Examples include:
 - `context.md`
 - `decisions.md`
 - `assumptions.md`
+- `approvals.md`
+- `integration-criteria.md`
 - `spec.md`
 - `plan.md`
-- `stage-report.md`
+- `implementation-rationale.md`
+- `review-packet.md`
 - evidence artifacts
 
 These optional auditable work artifacts may remain clone-local in one mode and
-be published in another. The helper contract must not assume one universal
-storage backend for them.
+be published in another. They resolve under `workArtifactsRoot`, not under
+runtime-only `repoStateRoot`. The helper contract must not assume one
+universal storage backend for them.
 
 ## Resolution Rules
 

--- a/core/protocols/git.md
+++ b/core/protocols/git.md
@@ -102,16 +102,18 @@ Supported shape:
 
 Semantics:
 
-- `clone-local` keeps optional auditable work artifacts under clone-local
-  Specwright state. They do not become tracked project files by default.
-- `tracked` publishes only the optional auditable work artifacts under an
-  explicit tracked root inside `projectRoot`.
+- `clone-local` resolves `workArtifactsRoot = {repoStateRoot}/work` and keeps
+  optional auditable work artifacts under clone-local Specwright state. They do
+  not become tracked project files by default.
+- `tracked` resolves `workArtifactsRoot = {projectRoot}/{trackedRoot}` and
+  publishes only the optional auditable work artifacts under that explicit
+  tracked root inside `projectRoot`.
 - `trackedRoot` must not point at `.git`, `repoStateRoot`,
   `worktreeStateRoot`, session state, or a symlinked mirror of those runtime
   roots.
-- This setting does not move project-level artifacts such as `CONSTITUTION.md`,
-  `CHARTER.md`, or `TESTING.md`; those remain project artifacts regardless of
-  work-artifact publication mode.
+- This setting does not move project-level artifacts such as `config.json`,
+  `CONSTITUTION.md`, `CHARTER.md`, or `TESTING.md`; those remain under
+  `projectArtifactsRoot` regardless of work-artifact publication mode.
 
 ## Logical Roots And Selected Work
 
@@ -121,8 +123,10 @@ roots as `protocols/context.md` and `protocols/state.md`:
 | Root | Resolution | Purpose |
 |---|---|---|
 | `projectRoot` | `git rev-parse --show-toplevel` | checkout path and command cwd |
-| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | shared work records |
+| `projectArtifactsRoot` | `{projectRoot}/.specwright` | tracked config and anchor docs |
+| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | shared runtime work records |
 | `worktreeStateRoot` | `git rev-parse --git-dir` + `/specwright` | current session record |
+| `workArtifactsRoot` | `{repoStateRoot}/work` or `{projectRoot}/{trackedRoot}` | auditable work artifacts for the selected work |
 
 The selected work comes from `worktreeStateRoot/session.json.attachedWorkId`
 unless a later skill introduces an explicit selector.

--- a/core/protocols/state.md
+++ b/core/protocols/state.md
@@ -7,8 +7,10 @@ State is resolved through logical Git roots, not checkout-local path literals.
 | Root | Resolution | Purpose |
 |---|---|---|
 | `projectRoot` | `git rev-parse --show-toplevel` | Source tree and user-facing command cwd |
-| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | Shared repo-wide Specwright state |
+| `projectArtifactsRoot` | `{projectRoot}/.specwright` | Tracked project artifacts and guidance |
+| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | Shared clone-local runtime state |
 | `worktreeStateRoot` | `git rev-parse --git-dir` + `/specwright` | Per-worktree runtime session state |
+| `workArtifactsRoot` | `{repoStateRoot}/work` by default; tracked root from `config.git.workArtifacts` when configured | Auditable work artifacts |
 
 Callers must not treat `cwd/.specwright/...` as authoritative once the new
 layout exists. Legacy working-tree `.specwright/` remains a migration fallback
@@ -23,34 +25,53 @@ Two state files now exist:
 | `{repoStateRoot}/work/{workId}/workflow.json` | one work | lifecycle, units, gates, task progress, attachment, lock | skills operating on that selected work |
 | `{worktreeStateRoot}/session.json` | one worktree | local work selection and session mode | skills running in that worktree |
 
-Shared work artifacts live beside the per-work workflow file:
+Tracked project artifacts live under the project root:
 
 ```text
-{repoStateRoot}/
+{projectArtifactsRoot}/
   config.json
   CONSTITUTION.md
   CHARTER.md
   TESTING.md
+  LANDSCAPE.md
+  AUDIT.md
+  patterns.md
+  research/
+```
+
+Auditable work artifacts live under the selected work root:
+
+```text
+{workArtifactsRoot}/
+  {workId}/
+    design.md
+    context.md
+    decisions.md
+    assumptions.md
+    approvals.md
+    integration-criteria.md
+    units/
+      {unitId}/
+        spec.md
+        plan.md
+        context.md
+        implementation-rationale.md
+        review-packet.md
+        evidence/
+```
+
+Runtime work and session data stay under the Git admin directories:
+
+```text
+{repoStateRoot}/
   work/
     {workId}/
       workflow.json
-      design.md
-      context.md
-      decisions.md
-      assumptions.md
       stage-report.md
       units/
         {unitId}/
-          spec.md
-          plan.md
-          context.md
           stage-report.md
-          evidence/
-```
 
-Per-worktree runtime data lives under the active Git admin directory:
-
-```text
 {worktreeStateRoot}/
   session.json
   continuation.md
@@ -70,7 +91,7 @@ stages populate them.
   "id": "string, kebab-case",
   "description": "string",
   "status": "designing | planning | building | verifying | shipping | shipped | abandoned",
-  "workDir": "work/{workId}/units/{unitId} or work/{workId}",
+  "workDir": "relative path under workArtifactsRoot/{workId} (legacy work/{workId}/... allowed during migration)",
   "unitId": "string | null",
   "tasksTotal": "number | null",
   "tasksCompleted": ["task-id strings"],
@@ -102,7 +123,7 @@ stages populate them.
       "description": "string",
       "status": "pending | planned | building | verifying | shipping | shipped | abandoned",
       "order": "number",
-      "workDir": "relative path under repoStateRoot/work/{workId}",
+      "workDir": "relative path under workArtifactsRoot/{workId} (legacy work/{workId}/... allowed during migration)",
       "prNumber": "number | null",
       "prMergedAt": "ISO timestamp | null"
     }
@@ -156,9 +177,14 @@ stages populate them.
 - Older workflow files may also omit `targetRef` and `freshness`; readers must
   treat both omissions as backward-compatible legacy state until the new model
   is populated, even though the schema block above shows the populated shape.
-- `workDir` remains the unit-local artifact path for the selected unit. Skills
-  still resolve unit-local files through `workflow.workDir`, never by guessing
-  from IDs.
+- `workDir` remains the unit-local auditable artifact path for the selected
+  unit. Skills still resolve unit-local files through `workflow.workDir`,
+  never by guessing from IDs.
+- Readers must accept existing `work/`-prefixed `workDir` values during
+  migration and normalize them before joining against `workArtifactsRoot`.
+- `stage-report.md` files are runtime-only handoff digests. They resolve from
+  `repoStateRoot/work/{workId}` and are not part of the auditable
+  `workArtifactsRoot` tree.
 - `lock` is per-work. A lock on work A must not block mutations to work B.
 
 ## Session Schema
@@ -273,15 +299,18 @@ No repo-global active-work registry is required in the first version.
 
 ## Path Resolution Convention
 
-Two artifact scopes remain:
+Four artifact scopes remain:
 
 | Scope | How to resolve | Contains |
 |---|---|---|
-| Unit-local | `workflow.workDir` under `{repoStateRoot}` | `spec.md`, `plan.md`, `context.md`, unit `stage-report.md`, `evidence/` |
-| Work-level | `{repoStateRoot}/work/{workId}/` | `workflow.json`, `design.md`, `decisions.md`, `assumptions.md`, work `stage-report.md` |
+| Project-level tracked | `{projectArtifactsRoot}/` | `config.json`, anchor docs, research, learnings |
+| Work-level auditable | `{workArtifactsRoot}/{workId}/` | `design.md`, `context.md`, `decisions.md`, `assumptions.md`, `approvals.md`, `integration-criteria.md` |
+| Unit-local auditable | `workflow.workDir` under `{workArtifactsRoot}` | `spec.md`, `plan.md`, `context.md`, `implementation-rationale.md`, `review-packet.md`, `evidence/` |
+| Runtime work/session | `{repoStateRoot}/work/{workId}/` and `{worktreeStateRoot}/` | `workflow.json`, work and unit `stage-report.md` files, attachment/lock/task state, `session.json`, `continuation.md` |
 
-For single-unit work, both scopes may refer to the same work directory. For
-multi-unit work, `workflow.workDir` points at `units/{unitId}/`.
+For single-unit work, the work-level and unit-local auditable scopes may point
+at the same work directory. For multi-unit work, `workflow.workDir` points at
+`{workId}/units/{unitId}/` after normalization.
 
 ## Read-Modify-Write Sequence
 
@@ -324,15 +353,15 @@ construction because each `session.json` belongs to one worktree.
 ## Legacy Compatibility
 
 During migration, callers may still read legacy checkout-local `.specwright/`
-artifacts only when the new layout is absent. Once `{repoStateRoot}` or
-`{worktreeStateRoot}` exists, writes go only to the new shared/session layout.
-Mixed writes are forbidden.
+artifacts only when the new layout is absent. Once the new roots exist, writes
+go only to their authoritative surface. Mixed writes are forbidden.
 
 ## Critical Rules
 
 - **NEVER** treat one repo-global `workflow.json` as the source of truth in the
   new model
-- **ALWAYS** resolve paths through `repoStateRoot` and `worktreeStateRoot`
+- **ALWAYS** resolve paths through the documented logical roots instead of
+  concatenating checkout-local literals
 - **NEVER** let subordinate sessions claim top-level ownership
 - **ALWAYS** preserve existing fields not being changed
 - **NEVER** partially update a JSON state file

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -29,36 +29,23 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 
 - `{worktreeStateRoot}/session.json` -- selected work for this worktree
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json`, `{workDir}/spec.md`, `{workDir}/plan.md`
-- `{repoStateRoot}/work/{selectedWork.id}/design.md`, `{workDir}/context.md`
+- `{workArtifactsRoot}/{selectedWork.id}/design.md`, `{workDir}/context.md`
 - `{repoStateRoot}/CONSTITUTION.md`, `{repoStateRoot}/config.json`
 
 ## Outputs
 
-- After each task: failing tests, passing implementation, task commit, workflow progress, refreshed `{workDir}/stage-report.md`
-- After all tasks: as-built notes in `plan.md`, three-line handoff to `/sw-verify`, ready-to-verify build state; the handoff points at `Artifacts: {workDir}/stage-report.md`
+- After each task: failing tests, passing implementation, task commit, workflow progress, refreshed `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
+- After all tasks: as-built notes in `plan.md`, three-line handoff to `/sw-verify`, ready-to-verify build state; the handoff points at `Artifacts: {repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
 
 ## Constraints
 
 **Execution model (LOW freedom):** Run in the foreground in the current turn. "Autonomous" means unattended decisions inside this build, not background execution.
 
-**Stage boundary (LOW freedom):** Follow `protocols/stage-boundary.md`. Implement only the active unit; never create pull requests, run `gh pr create`, or invoke `/sw-ship`. Before the terminal handoff, write `{workDir}/stage-report.md`; the handoff points at it and the Next line is `Next: /sw-verify`.
+**Stage boundary (LOW freedom):** Follow `protocols/stage-boundary.md`. Implement only the active unit; never create pull requests, run `gh pr create`, or invoke `/sw-ship`. Before the terminal handoff, write `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`; the handoff points at it and the Next line is `Next: /sw-verify`.
 
-**Branch setup (LOW freedom):** First action before coding: resolve the
-session-selected work from the current worktree, verify that no other live
-top-level worktree owns it, then check out the feature branch from
-`config.git.branchPrefix` and sync it per `protocols/git.md`. The selected
-work's recorded `targetRef`, when present, is the first branch-resolution
-input via `protocols/git.md`; repo config defaults and the `baseBranch`
-compatibility alias are fallbacks only. Use
-`{git.branchPrefix}{selectedWork.unitId}` for multi-unit work and never commit
-to the base branch. If the selected work is already owned elsewhere, STOP with
-explicit adopt/takeover guidance instead of mutating it silently.
+**Branch setup (LOW freedom):** First action before coding: resolve the session-selected work from the current worktree, verify that no other live top-level worktree owns it, then check out the feature branch from `config.git.branchPrefix` and sync it per `protocols/git.md`. The selected work's recorded `targetRef`, when present, is the first branch-resolution input via `protocols/git.md`; repo config defaults and the `baseBranch` compatibility alias are fallbacks only. Use `{git.branchPrefix}{selectedWork.unitId}` for multi-unit work and never commit to the base branch. If the selected work is already owned elsewhere, STOP with explicit adopt/takeover guidance instead of mutating it silently.
 
-**Build freshness checkpoint (LOW freedom) — after branch setup:**
-Evaluate the build checkpoint via `protocols/git-freshness.md` using the
-selected work's recorded `targetRef` and `freshness`. `require` blocks stale,
-diverged, and blocked freshness results; `warn` surfaces advisory drift;
-queue-managed results do not trigger hidden rebases or other branch rewrites.
+**Build freshness checkpoint (LOW freedom) — after branch setup:** Evaluate the build checkpoint via `protocols/git-freshness.md` using the selected work's recorded `targetRef` and `freshness`. `require` blocks stale, diverged, and blocked freshness results; `warn` surfaces advisory drift; queue-managed results do not trigger hidden rebases or other branch rewrites.
 
 **Task loop (MEDIUM freedom):** Work one task at a time. Finish it before starting the next and emit a status card after each task commit.
 

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -34,14 +34,14 @@ between research and gate handoff, applying `protocols/decision.md` for all deci
 
 ## Outputs
 
-When complete, ALL of the following exist in `{repoStateRoot}/work/{id}/`:
+When complete, runtime and auditable artifacts exist in both locations:
 
-- `stage-report.md` -- design handoff digest with attention-required at the top
-- `design.md` -- solution overview, approach, integration points, risk assessment
+- `{repoStateRoot}/work/{id}/stage-report.md` -- runtime-local design handoff digest with attention-required at the top
+- `{workArtifactsRoot}/{id}/design.md` -- solution overview, approach, integration points, risk assessment
   - Required section: `## Blast Radius` listing: modules/files the design touches, failure propagation scope for each (local/adjacent/systemic), and what the design does NOT change.
-- `context.md` -- research findings, file paths, gotchas (travels with downstream agents)
-- design assumptions artifact -- classified assumptions with resolution status
-- `decisions.md` -- all autonomous decisions recorded per `protocols/decision.md`
+- `{workArtifactsRoot}/{id}/context.md` -- research findings, file paths, gotchas (travels with downstream agents)
+- design assumptions artifact under `{workArtifactsRoot}/{id}/` -- classified assumptions with resolution status
+- `{workArtifactsRoot}/{id}/decisions.md` -- all autonomous decisions recorded per `protocols/decision.md`
 
 When warranted: `data-model.md`, `contracts.md`, `testing-strategy.md`, `infra.md`, `migrations.md`.
 
@@ -91,10 +91,12 @@ NEVER write specs, decompose, implement, branch, or test. After gate handoff, ST
 
 **Gate handoff (LOW freedom):**
 On completion, emit the three-line handoff per the `protocols/decision.md`
-Gate Handoff section. Write `{workDir}/stage-report.md` before the handoff.
-The Artifacts line points at `Artifacts: {workDir}/stage-report.md`. Detail
-lives in the artifact files (`design.md`, `decisions.md`, design assumptions
-artifact, `context.md`). The Next line remains machine-parseable: `Next: /sw-plan`.
+Gate Handoff section. Write `{repoStateRoot}/work/{id}/stage-report.md`
+before the handoff. The Artifacts line points at
+`Artifacts: {repoStateRoot}/work/{id}/stage-report.md`. Detail lives in the
+auditable artifact files under `{workArtifactsRoot}/{id}/` (`design.md`,
+`decisions.md`, design assumptions artifact, `context.md`). The Next line
+remains machine-parseable: `Next: /sw-plan`.
 
 **State mutations (LOW freedom):**
 Follow `protocols/state.md` for read-modify-write mechanics. Postconditions:

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -26,22 +26,22 @@ applying `protocols/decision.md` for all decisions. Gate handoff at the end.
 
 - `{worktreeStateRoot}/session.json` -- selected work for this worktree
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work state
-- `{repoStateRoot}/work/{selectedWork.id}/design.md` -- approved solution design
-- `{repoStateRoot}/work/{selectedWork.id}/context.md` -- research findings from sw-design
-- `{repoStateRoot}/work/{selectedWork.id}/decisions.md` -- design-phase decisions
+- `{workArtifactsRoot}/{selectedWork.id}/design.md` -- approved solution design
+- `{workArtifactsRoot}/{selectedWork.id}/context.md` -- research findings from sw-design
+- `{workArtifactsRoot}/{selectedWork.id}/decisions.md` -- design-phase decisions
 - Conditional design artifacts: `data-model.md`, `contracts.md`, `testing-strategy.md`, `infra.md`, `migrations.md`
 - `{repoStateRoot}/CONSTITUTION.md` -- practices to follow
 - `{repoStateRoot}/config.json` -- project configuration
 
 ## Outputs
 
-**Single-unit work**: `spec.md` + `plan.md` in `{repoStateRoot}/work/{selectedWork.id}/` (flat layout).
+**Single-unit work**: `spec.md` + `plan.md` in `{workArtifactsRoot}/{selectedWork.id}/` (flat layout).
 
-**Multi-unit work**: For each unit in `{repoStateRoot}/work/{selectedWork.id}/units/{unit-id}/`:
+**Multi-unit work**: For each unit in `{workArtifactsRoot}/{selectedWork.id}/units/{unit-id}/`:
 `spec.md` + `plan.md` + `context.md`. `workUnits` array in workflow.json.
-Also: `integration-criteria.md` in the design-level directory (`{repoStateRoot}/work/{selectedWork.id}/`).
+Also: `integration-criteria.md` in the design-level directory (`{workArtifactsRoot}/{selectedWork.id}/`).
 
-Also: `{workDir}/stage-report.md` for the planning handoff.
+Also: `{repoStateRoot}/work/{selectedWork.id}/stage-report.md` for the planning handoff.
 
 Also: `decisions.md` updated with planning-phase autonomous decisions.
 
@@ -66,7 +66,7 @@ Resolve the selected work from the current worktree session. Check that
 
 **Integration criteria (MEDIUM freedom, multi-unit only):**
 - When decomposing into multiple work units, also write `integration-criteria.md` in
-  the design-level directory (`{repoStateRoot}/work/{selectedWork.id}/`). Not generated for
+  the design-level directory (`{workArtifactsRoot}/{selectedWork.id}/`). Not generated for
   single-unit work.
 - Two IC types coexist in `integration-criteria.md`: structural (IC-{n}) and behavioral
   (IC-B{n}). Both types go to the same file.
@@ -121,11 +121,13 @@ directory structure, config examples. NOT allowed: function bodies, algorithm lo
 
 **Gate handoff (LOW freedom):**
 On completion, emit the three-line handoff per the `protocols/decision.md`
-Gate Handoff section. Write `{workDir}/stage-report.md` before the handoff.
-The Artifacts line points at `Artifacts: {workDir}/stage-report.md`. Detail
-lives in the artifact files (`spec.md` / `plan.md` / `context.md` for each
-unit, `integration-criteria.md` for multi-unit work). The Next line remains
-machine-parseable: `Next: /sw-build`.
+Gate Handoff section. Write `{repoStateRoot}/work/{selectedWork.id}/stage-report.md`
+before the handoff. The Artifacts line points at
+`Artifacts: {repoStateRoot}/work/{selectedWork.id}/stage-report.md`. Detail
+lives in the auditable artifact files under
+`{workArtifactsRoot}/{selectedWork.id}/` (`spec.md` / `plan.md` / `context.md`
+for each unit, `integration-criteria.md` for multi-unit work). The Next line
+remains machine-parseable: `Next: /sw-build`.
 
 **State mutations (LOW freedom):**
 Follow `protocols/state.md`. Mutate only the selected work's `workflow.json` and

--- a/core/skills/sw-ship/SKILL.md
+++ b/core/skills/sw-ship/SKILL.md
@@ -30,7 +30,7 @@ human gate — reviewers verify before merge.
 
 ## Outputs
 
-- `{workDir}/stage-report.md` -- shipping handoff digest with attention-at-top
+- `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md` -- shipping handoff digest with attention-at-top
 - Pull request created with evidence-mapped body
 - Selected work's `workflow.json` status set to `shipped`
 
@@ -93,8 +93,9 @@ next `planned` unit
 **Gate handoff (LOW freedom):**
 On completion, emit the three-line handoff per the `protocols/decision.md`
 Gate Handoff section. The one-line outcome names the PR (e.g.,
-"PR #142 created"). Write `{workDir}/stage-report.md` before the handoff, and
-the Artifacts: line points at that file (`Artifacts: {workDir}/stage-report.md`).
+"PR #142 created"). Write `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
+before the handoff, and the Artifacts: line points at that file
+(`Artifacts: {repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`).
 The Next: line ALWAYS contains a `/sw-...` slash command — never prose.
 When more units are queued, Next points to `/sw-build`. When the work is
 complete, Next points to `/sw-learn` (sw-learn remains optional; the

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -31,7 +31,7 @@ gate handoff using `protocols/decision.md` template.
 
 ## Outputs
 
-- `{workDir}/stage-report.md` -- verify handoff digest with attention-at-top
+- `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md` -- verify handoff digest with attention-at-top
 - Evidence files in `{workDir}/evidence/`, one per gate
 - Selected work's `workflow.json` gates section updated; status set to `verifying` during run
 - Aggregate report presented at gate handoff
@@ -127,7 +127,7 @@ six gates complete.
 
 When activated:
 - Load `integration-criteria.md` from the design-level directory
-  (`{repoStateRoot}/work/{selectedWork.id}/`). If the file does not exist → SKIP with
+  (`{workArtifactsRoot}/{selectedWork.id}/`). If the file does not exist → SKIP with
   INFO note ("No integration-criteria.md found"). Identify behavioral ICs
   (IC-B{n} entries).
 - For each IC-B, search for test evidence: a test file exercising the described
@@ -150,8 +150,9 @@ On completion, emit the three-line handoff per the `protocols/decision.md`
 Gate Handoff section. The one-line outcome reflects the aggregate gate
 verdict (e.g., "all gates PASS", "2 WARN, 0 BLOCK", "gate-spec FAIL").
 Detail lives in the per-gate evidence files under `{workDir}/evidence/`.
-Write `{workDir}/stage-report.md` before the handoff, and point the
-Artifacts line at `Artifacts: {workDir}/stage-report.md`.
+Write `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
+before the handoff, and point the Artifacts line at
+`Artifacts: {repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`.
 The Next: line points to `/sw-build` (on BLOCK) or `/sw-ship` (on PASS
 or WARN). Example: `Next: /sw-ship`.
 

--- a/evals/tests/test_state_drift_stage_report.py
+++ b/evals/tests/test_state_drift_stage_report.py
@@ -235,7 +235,7 @@ class TestStageReportProtocol(unittest.TestCase):
             self.assertIn(required, self.stage_report)
 
     def test_gate_handoff_points_to_stage_report(self):
-        self.assertIn("Artifacts: {workDir}/stage-report.md", self.gate_handoff)
+        self.assertIn("Artifacts: {stageReportPath}", self.gate_handoff)
 
 
 class TestPipelineSkillsReferenceStageReport(unittest.TestCase):

--- a/tests/test-audit-chain-root-model.sh
+++ b/tests/test-audit-chain-root-model.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# Regression checks for the audit-chain root model introduced by
+# agentic-audit-chain Unit 01.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/test-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/test-lib.sh"
+
+CONTEXT_PROTOCOL="$ROOT_DIR/core/protocols/context.md"
+STATE_PROTOCOL="$ROOT_DIR/core/protocols/state.md"
+GIT_PROTOCOL="$ROOT_DIR/core/protocols/git.md"
+GIT_FRESHNESS_PROTOCOL="$ROOT_DIR/core/protocols/git-freshness.md"
+STATE_PATHS_MODULE="$ROOT_DIR/adapters/shared/specwright-state-paths.mjs"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local path="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$path"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local path="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$path"; then
+    fail "$label (found unexpected: '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
+assert_output_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -Fq -- "$needle"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+git_nested_prepare || exit 1
+
+repo_state_root() {
+  printf '%s/specwright\n' "$(git_common_dir "$1")"
+}
+
+worktree_state_root() {
+  printf '%s/specwright\n' "$(git_dir "$1")"
+}
+
+fresh_timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+write_project_config() {
+  local dir="$1"
+  local mode="${2:-clone-local}"
+  local tracked_root="${3:-}"
+  local tracked_root_json="null"
+
+  mkdir -p "$dir/.specwright"
+  if [ "$mode" = "tracked" ]; then
+    tracked_root_json="\"$tracked_root\""
+  fi
+
+  cat > "$dir/.specwright/config.json" <<EOF
+{
+  "version": "2.0",
+  "git": {
+    "targets": {
+      "defaultRole": "integration",
+      "roles": {
+        "integration": { "branch": "main" }
+      }
+    },
+    "workArtifacts": {
+      "mode": "$mode",
+      "trackedRoot": $tracked_root_json
+    }
+  }
+}
+EOF
+}
+
+write_runtime_work() {
+  local dir="$1"
+  local work_id="$2"
+  local work_dir="${3:-work/$work_id}"
+  local branch="${4:-$(git_nested -C "$dir" branch --show-current)}"
+  local runtime_root worktree_root
+
+  runtime_root="$(repo_state_root "$dir")"
+  worktree_root="$(worktree_state_root "$dir")"
+  mkdir -p "$runtime_root/work/$work_id" "$worktree_root"
+
+  cat > "$runtime_root/work/$work_id/workflow.json" <<EOF
+{
+  "version": "3.0",
+  "id": "$work_id",
+  "status": "building",
+  "workDir": "$work_dir",
+  "unitId": "unit-$work_id",
+  "tasksCompleted": [],
+  "tasksTotal": 3,
+  "currentTask": "task-1",
+  "branch": "$branch"
+}
+EOF
+
+  cat > "$worktree_root/session.json" <<EOF
+{
+  "version": "3.0",
+  "worktreeId": "test-worktree",
+  "worktreePath": "$(cd "$dir" && pwd -P)",
+  "branch": "$branch",
+  "attachedWorkId": "$work_id",
+  "mode": "top-level",
+  "lastSeenAt": "$(fresh_timestamp)"
+}
+EOF
+}
+
+inspect_state_json() {
+  local dir="$1"
+  (
+    cd "$dir" &&
+    STATE_PATHS_MODULE="$STATE_PATHS_MODULE" node --input-type=module <<'EOF'
+const { resolveSpecwrightRoots, loadSpecwrightState, normalizeActiveWork } = await import(process.env.STATE_PATHS_MODULE);
+
+const roots = resolveSpecwrightRoots();
+const state = loadSpecwrightState();
+const work = normalizeActiveWork(state);
+
+process.stdout.write(JSON.stringify({
+  roots: roots.ok ? {
+    projectArtifactsRoot: roots.projectArtifactsRoot,
+    repoStateRoot: roots.repoStateRoot,
+    worktreeStateRoot: roots.worktreeStateRoot,
+    workArtifactsRoot: roots.workArtifactsRoot
+  } : roots,
+  layout: state.layout,
+  sharedConfigPath: state.sharedConfigPath ?? null,
+  projectConfigPath: state.projectConfigPath ?? null,
+  workflowPath: state.workflowPath ?? null,
+  workDirPath: work?.workDirPath ?? null,
+  specPath: work?.specPath ?? null,
+  planPath: work?.planPath ?? null,
+  artifactsRoot: work?.artifactsRoot ?? null
+}));
+EOF
+  )
+}
+
+echo "=== audit-chain root model ==="
+echo ""
+
+for file in \
+  "$CONTEXT_PROTOCOL" \
+  "$STATE_PROTOCOL" \
+  "$GIT_PROTOCOL" \
+  "$GIT_FRESHNESS_PROTOCOL"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- Protocol root split ---"
+assert_contains "$CONTEXT_PROTOCOL" "\`projectArtifactsRoot\`" "context protocol defines projectArtifactsRoot"
+assert_contains "$CONTEXT_PROTOCOL" "\`workArtifactsRoot\`" "context protocol defines workArtifactsRoot"
+assert_contains "$CONTEXT_PROTOCOL" '{projectArtifactsRoot}/config.json' "context protocol loads tracked config from projectArtifactsRoot"
+assert_contains "$CONTEXT_PROTOCOL" '{workArtifactsRoot}/{workId}' "context protocol loads auditable work artifacts from workArtifactsRoot"
+assert_contains "$STATE_PROTOCOL" "work and unit \`stage-report.md\` files" "state protocol treats stage-report files as runtime-only"
+assert_contains "$STATE_PROTOCOL" 'relative path under workArtifactsRoot/{workId}' "state protocol moves workDir under workArtifactsRoot"
+assert_contains "$GIT_PROTOCOL" "\`workArtifactsRoot = {repoStateRoot}/work\`" "git protocol maps clone-local mode to repoStateRoot/work"
+assert_contains "$GIT_PROTOCOL" "\`projectArtifactsRoot\`" "git protocol keeps project artifacts on the tracked root"
+assert_contains "$GIT_FRESHNESS_PROTOCOL" "\`implementation-rationale.md\`" "git-freshness protocol names implementation rationale as auditable"
+assert_contains "$GIT_FRESHNESS_PROTOCOL" "\`review-packet.md\`" "git-freshness protocol names review packet as auditable"
+assert_not_contains "$GIT_FRESHNESS_PROTOCOL" "- \`stage-report.md\`" "git-freshness protocol no longer treats stage-report.md as auditable"
+
+echo ""
+echo "--- Clone-local work-artifact mode ---"
+CLONE_LOCAL_REPO="$TEST_TMPDIR/clone-local"
+init_git_repo "$CLONE_LOCAL_REPO"
+write_project_config "$CLONE_LOCAL_REPO" "clone-local"
+write_runtime_work "$CLONE_LOCAL_REPO" "root-proof"
+CLONE_LOCAL_REAL="$(cd "$CLONE_LOCAL_REPO" && pwd -P)"
+CLONE_LOCAL_OUTPUT="$(inspect_state_json "$CLONE_LOCAL_REPO")"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"layout\":\"shared\"" "clone-local config still resolves shared runtime layout"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"projectArtifactsRoot\":\"$CLONE_LOCAL_REAL/.specwright\"" "projectArtifactsRoot resolves to tracked .specwright root"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"sharedConfigPath\":\"$CLONE_LOCAL_REAL/.specwright/config.json\"" "shared config prefers tracked project config"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$CLONE_LOCAL_REPO")/work\"" "clone-local mode resolves workArtifactsRoot under repoStateRoot/work"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"workflowPath\":\"$(repo_state_root "$CLONE_LOCAL_REPO")/work/root-proof/workflow.json\"" "runtime workflow stays under repoStateRoot"
+assert_output_contains "$CLONE_LOCAL_OUTPUT" "\"specPath\":\"$(repo_state_root "$CLONE_LOCAL_REPO")/work/root-proof/spec.md\"" "clone-local mode routes spec paths through repoStateRoot/work"
+
+echo ""
+echo "--- Tracked work-artifact mode ---"
+TRACKED_REPO="$TEST_TMPDIR/tracked"
+init_git_repo "$TRACKED_REPO"
+write_project_config "$TRACKED_REPO" "tracked" ".specwright/audit-work"
+write_runtime_work "$TRACKED_REPO" "root-proof"
+TRACKED_REAL="$(cd "$TRACKED_REPO" && pwd -P)"
+TRACKED_OUTPUT="$(inspect_state_json "$TRACKED_REPO")"
+assert_output_contains "$TRACKED_OUTPUT" "\"workArtifactsRoot\":\"$TRACKED_REAL/.specwright/audit-work\"" "tracked mode resolves workArtifactsRoot from config.git.workArtifacts"
+assert_output_contains "$TRACKED_OUTPUT" "\"artifactsRoot\":\"$TRACKED_REAL/.specwright/audit-work\"" "tracked mode keeps normalized work artifacts on the tracked root"
+assert_output_contains "$TRACKED_OUTPUT" "\"specPath\":\"$TRACKED_REAL/.specwright/audit-work/root-proof/spec.md\"" "tracked mode routes spec paths through configured workArtifactsRoot"
+assert_output_contains "$TRACKED_OUTPUT" "\"workflowPath\":\"$(repo_state_root "$TRACKED_REPO")/work/root-proof/workflow.json\"" "tracked mode keeps workflow.json in runtime state"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/test-audit-chain-root-model.sh
+++ b/tests/test-audit-chain-root-model.sh
@@ -13,8 +13,14 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 CONTEXT_PROTOCOL="$ROOT_DIR/core/protocols/context.md"
 STATE_PROTOCOL="$ROOT_DIR/core/protocols/state.md"
+DECISION_PROTOCOL="$ROOT_DIR/core/protocols/decision.md"
 GIT_PROTOCOL="$ROOT_DIR/core/protocols/git.md"
 GIT_FRESHNESS_PROTOCOL="$ROOT_DIR/core/protocols/git-freshness.md"
+DESIGN_SKILL="$ROOT_DIR/core/skills/sw-design/SKILL.md"
+PLAN_SKILL="$ROOT_DIR/core/skills/sw-plan/SKILL.md"
+BUILD_SKILL="$ROOT_DIR/core/skills/sw-build/SKILL.md"
+VERIFY_SKILL="$ROOT_DIR/core/skills/sw-verify/SKILL.md"
+SHIP_SKILL="$ROOT_DIR/core/skills/sw-ship/SKILL.md"
 STATE_PATHS_MODULE="$ROOT_DIR/adapters/shared/specwright-state-paths.mjs"
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
@@ -178,8 +184,14 @@ echo ""
 for file in \
   "$CONTEXT_PROTOCOL" \
   "$STATE_PROTOCOL" \
+  "$DECISION_PROTOCOL" \
   "$GIT_PROTOCOL" \
-  "$GIT_FRESHNESS_PROTOCOL"; do
+  "$GIT_FRESHNESS_PROTOCOL" \
+  "$DESIGN_SKILL" \
+  "$PLAN_SKILL" \
+  "$BUILD_SKILL" \
+  "$VERIFY_SKILL" \
+  "$SHIP_SKILL"; do
   if [ -f "$file" ]; then
     pass "exists: ${file#"$ROOT_DIR"/}"
   else
@@ -195,11 +207,31 @@ assert_contains "$CONTEXT_PROTOCOL" '{projectArtifactsRoot}/config.json' "contex
 assert_contains "$CONTEXT_PROTOCOL" '{workArtifactsRoot}/{workId}' "context protocol loads auditable work artifacts from workArtifactsRoot"
 assert_contains "$STATE_PROTOCOL" "work and unit \`stage-report.md\` files" "state protocol treats stage-report files as runtime-only"
 assert_contains "$STATE_PROTOCOL" 'relative path under workArtifactsRoot/{workId}' "state protocol moves workDir under workArtifactsRoot"
+assert_contains "$DECISION_PROTOCOL" 'Artifacts: {stageReportPath}' "decision protocol parameterizes stage report handoff path"
 assert_contains "$GIT_PROTOCOL" "\`workArtifactsRoot = {repoStateRoot}/work\`" "git protocol maps clone-local mode to repoStateRoot/work"
 assert_contains "$GIT_PROTOCOL" "\`projectArtifactsRoot\`" "git protocol keeps project artifacts on the tracked root"
 assert_contains "$GIT_FRESHNESS_PROTOCOL" "\`implementation-rationale.md\`" "git-freshness protocol names implementation rationale as auditable"
 assert_contains "$GIT_FRESHNESS_PROTOCOL" "\`review-packet.md\`" "git-freshness protocol names review packet as auditable"
 assert_not_contains "$GIT_FRESHNESS_PROTOCOL" "- \`stage-report.md\`" "git-freshness protocol no longer treats stage-report.md as auditable"
+assert_contains "$DESIGN_SKILL" '{repoStateRoot}/work/{id}/stage-report.md' "sw-design routes stage reports through runtime state"
+assert_contains "$PLAN_SKILL" '{repoStateRoot}/work/{selectedWork.id}/stage-report.md' "sw-plan routes stage reports through runtime state"
+assert_contains "$BUILD_SKILL" '{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md' "sw-build routes unit stage reports through runtime state"
+assert_contains "$VERIFY_SKILL" '{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md' "sw-verify routes unit stage reports through runtime state"
+assert_contains "$SHIP_SKILL" '{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md' "sw-ship routes unit stage reports through runtime state"
+assert_contains "$PLAN_SKILL" '{workArtifactsRoot}/{selectedWork.id}/design.md' "sw-plan reads auditable design artifacts from workArtifactsRoot"
+assert_contains "$BUILD_SKILL" '{workArtifactsRoot}/{selectedWork.id}/design.md' "sw-build reads auditable design artifacts from workArtifactsRoot"
+assert_contains "$VERIFY_SKILL" '{workArtifactsRoot}/{selectedWork.id}/' "sw-verify reads integration criteria from workArtifactsRoot"
+
+echo ""
+echo "--- Config-only shared root model ---"
+CONFIG_ONLY_REPO="$TEST_TMPDIR/config-only"
+init_git_repo "$CONFIG_ONLY_REPO"
+write_project_config "$CONFIG_ONLY_REPO" "clone-local"
+CONFIG_ONLY_REAL="$(cd "$CONFIG_ONLY_REPO" && pwd -P)"
+CONFIG_ONLY_OUTPUT="$(inspect_state_json "$CONFIG_ONLY_REPO")"
+assert_output_contains "$CONFIG_ONLY_OUTPUT" "\"layout\":\"shared\"" "tracked project config alone opts into the shared root model"
+assert_output_contains "$CONFIG_ONLY_OUTPUT" "\"sharedConfigPath\":\"$CONFIG_ONLY_REAL/.specwright/config.json\"" "config-only repo still resolves the tracked shared config path"
+assert_output_contains "$CONFIG_ONLY_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$CONFIG_ONLY_REPO")/work\"" "config-only repo falls back to repoStateRoot/work for clone-local artifacts"
 
 echo ""
 echo "--- Clone-local work-artifact mode ---"
@@ -228,6 +260,45 @@ assert_output_contains "$TRACKED_OUTPUT" "\"workArtifactsRoot\":\"$TRACKED_REAL/
 assert_output_contains "$TRACKED_OUTPUT" "\"artifactsRoot\":\"$TRACKED_REAL/.specwright/audit-work\"" "tracked mode keeps normalized work artifacts on the tracked root"
 assert_output_contains "$TRACKED_OUTPUT" "\"specPath\":\"$TRACKED_REAL/.specwright/audit-work/root-proof/spec.md\"" "tracked mode routes spec paths through configured workArtifactsRoot"
 assert_output_contains "$TRACKED_OUTPUT" "\"workflowPath\":\"$(repo_state_root "$TRACKED_REPO")/work/root-proof/workflow.json\"" "tracked mode keeps workflow.json in runtime state"
+
+echo ""
+echo "--- Tracked work-artifact safety boundaries ---"
+GIT_ROOT_REPO="$TEST_TMPDIR/git-root"
+init_git_repo "$GIT_ROOT_REPO"
+write_project_config "$GIT_ROOT_REPO" "tracked" ".git/specwright"
+GIT_ROOT_OUTPUT="$(inspect_state_json "$GIT_ROOT_REPO")"
+assert_output_contains "$GIT_ROOT_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$GIT_ROOT_REPO")/work\"" "trackedRoot under .git is rejected in favor of repoStateRoot/work"
+
+OUTSIDE_ROOT_REPO="$TEST_TMPDIR/outside-root"
+init_git_repo "$OUTSIDE_ROOT_REPO"
+write_project_config "$OUTSIDE_ROOT_REPO" "tracked" "../../outside"
+OUTSIDE_ROOT_OUTPUT="$(inspect_state_json "$OUTSIDE_ROOT_REPO")"
+assert_output_contains "$OUTSIDE_ROOT_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$OUTSIDE_ROOT_REPO")/work\"" "trackedRoot outside the project is rejected in favor of repoStateRoot/work"
+
+REPO_ROOT_REPO="$TEST_TMPDIR/repo-root"
+init_git_repo "$REPO_ROOT_REPO"
+write_project_config "$REPO_ROOT_REPO" "tracked" "."
+REPO_ROOT_OUTPUT="$(inspect_state_json "$REPO_ROOT_REPO")"
+assert_output_contains "$REPO_ROOT_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$REPO_ROOT_REPO")/work\"" "trackedRoot overlapping the repo root is rejected in favor of repoStateRoot/work"
+
+SYMLINK_ROOT_REPO="$TEST_TMPDIR/symlink-root"
+init_git_repo "$SYMLINK_ROOT_REPO"
+mkdir -p "$SYMLINK_ROOT_REPO/.specwright" "$(repo_state_root "$SYMLINK_ROOT_REPO")/work"
+ln -s "$(repo_state_root "$SYMLINK_ROOT_REPO")/work" "$SYMLINK_ROOT_REPO/.specwright/audit-link"
+write_project_config "$SYMLINK_ROOT_REPO" "tracked" ".specwright/audit-link"
+SYMLINK_ROOT_OUTPUT="$(inspect_state_json "$SYMLINK_ROOT_REPO")"
+assert_output_contains "$SYMLINK_ROOT_OUTPUT" "\"workArtifactsRoot\":\"$(repo_state_root "$SYMLINK_ROOT_REPO")/work\"" "trackedRoot symlinked into runtime state is rejected in favor of repoStateRoot/work"
+
+echo ""
+echo "--- Malformed workDir containment ---"
+ESCAPE_REPO="$TEST_TMPDIR/escape-workdir"
+init_git_repo "$ESCAPE_REPO"
+write_project_config "$ESCAPE_REPO" "tracked" ".specwright/audit-work"
+write_runtime_work "$ESCAPE_REPO" "root-proof" "../escape"
+ESCAPE_REAL="$(cd "$ESCAPE_REPO" && pwd -P)"
+ESCAPE_OUTPUT="$(inspect_state_json "$ESCAPE_REPO")"
+assert_output_contains "$ESCAPE_OUTPUT" "\"workDirPath\":\"$ESCAPE_REAL/.specwright/audit-work/root-proof\"" "escaped workDir falls back to a contained tracked work directory"
+assert_output_contains "$ESCAPE_OUTPUT" "\"specPath\":\"$ESCAPE_REAL/.specwright/audit-work/root-proof/spec.md\"" "escaped workDir cannot push spec paths outside workArtifactsRoot"
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -35,6 +35,7 @@ GIT_FRESHNESS_ENGINE_TEST="$ROOT_DIR/tests/test-git-freshness-engine.sh"
 LIFECYCLE_FRESHNESS_TEST="$ROOT_DIR/tests/test-lifecycle-freshness-checkpoints.sh"
 WORKFLOW_PROOF_TEST="$ROOT_DIR/tests/test-workflow-proof.sh"
 CONFIG_VISIBILITY_DOCS_TEST="$ROOT_DIR/tests/test-config-validation-visibility-docs.sh"
+AUDIT_CHAIN_ROOT_MODEL_TEST="$ROOT_DIR/tests/test-audit-chain-root-model.sh"
 
 PASS=0
 FAIL=0
@@ -1235,6 +1236,31 @@ if [ "$WORKFLOW_PROOF_EXIT" -eq 0 ] && echo "$WORKFLOW_PROOF_OUTPUT" | grep -Fq 
   pass "workflow-proof regression output includes queue-managed ship coverage"
 else
   fail "workflow-proof regression output missing queue-managed ship coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Audit-chain root model ==="
+
+if [ -x "$AUDIT_CHAIN_ROOT_MODEL_TEST" ]; then
+  pass "tests/test-audit-chain-root-model.sh is executable"
+else
+  fail "tests/test-audit-chain-root-model.sh is missing or not executable"
+fi
+
+AUDIT_CHAIN_ROOT_MODEL_EXIT=0
+AUDIT_CHAIN_ROOT_MODEL_OUTPUT="$(bash "$AUDIT_CHAIN_ROOT_MODEL_TEST" 2>&1)" || AUDIT_CHAIN_ROOT_MODEL_EXIT=$?
+
+if [ "$AUDIT_CHAIN_ROOT_MODEL_EXIT" -ne 0 ]; then
+  fail "tests/test-audit-chain-root-model.sh passes under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${AUDIT_CHAIN_ROOT_MODEL_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-audit-chain-root-model.sh passes under the configured test path"
+fi
+if echo "$AUDIT_CHAIN_ROOT_MODEL_OUTPUT" | grep -Fq "PASS: tracked mode routes spec paths through configured workArtifactsRoot"; then
+  pass "audit-chain root-model regression output includes tracked-root coverage"
+else
+  fail "audit-chain root-model regression output missing tracked-root coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test-handoff-template.sh
+++ b/tests/test-handoff-template.sh
@@ -59,8 +59,8 @@ assert_file_contains "core/protocols/decision.md" "^## Gate Handoff" \
   "decision.md has '## Gate Handoff' heading"
 assert_file_contains "core/protocols/decision.md" "Done\. \{one-line outcome\}" \
   "decision.md template includes 'Done. {one-line outcome}.'"
-assert_file_contains "core/protocols/decision.md" "Artifacts: \{workDir\}/stage-report\.md" \
-  "decision.md template includes 'Artifacts: {workDir}/stage-report.md'"
+assert_file_contains "core/protocols/decision.md" "Artifacts: \{stageReportPath\}" \
+  "decision.md template includes 'Artifacts: {stageReportPath}'"
 assert_file_contains "core/protocols/decision.md" "Next: /sw-\{next-skill\}" \
   "decision.md template includes 'Next: /sw-{next-skill}'"
 

--- a/tests/test-sw-build-inner-loop.sh
+++ b/tests/test-sw-build-inner-loop.sh
@@ -162,10 +162,10 @@ for heading in "Mid-build checks" "Task tracking" "Parallel execution"; do
   fi
 done
 
-if grep -q "stage-report.md" "$SKILL_FILE" && grep -q "/sw-verify" "$SKILL_FILE"; then
-  pass "handoff still points at stage-report.md and /sw-verify"
+if grep -q "{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md" "$SKILL_FILE" && grep -q "/sw-verify" "$SKILL_FILE"; then
+  pass "handoff still points at the runtime stage-report path and /sw-verify"
 else
-  fail "handoff still points at stage-report.md and /sw-verify"
+  fail "handoff still points at the runtime stage-report path and /sw-verify"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- establish the canonical split between tracked project artifacts, auditable work artifacts, and clone-local runtime state
- update the shared Specwright state resolver to prefer tracked `.specwright/config.json` and normalize legacy `work/` paths safely
- add regression coverage proving clone-local and tracked work-artifact modes resolve to the correct roots under temp repos

## Acceptance Criteria
- [x] AC-1 `core/protocols/context.md` defines `projectArtifactsRoot` and `workArtifactsRoot`, and loads tracked project artifacts from the tracked project root.
  Evidence: `core/protocols/context.md:5-17`, `core/protocols/context.md:21-57`, `core/protocols/context.md:84-127`; `tests/test-audit-chain-root-model.sh:192-195`, `tests/test-audit-chain-root-model.sh:212-215`.
- [x] AC-2 `core/protocols/state.md` classifies workflow/session/continuation/locks/attachments/stage reports as runtime state and design/spec/evidence/rationale/review artifacts as auditable work artifacts.
  Evidence: `core/protocols/state.md:19-78`, `core/protocols/state.md:84-95`, `core/protocols/state.md:177-187`, `core/protocols/state.md:300-309`; `tests/test-audit-chain-root-model.sh:196-197`, `tests/test-audit-chain-root-model.sh:216-230`.
- [x] AC-3 `core/protocols/git.md` maps `git.workArtifacts` to `workArtifactsRoot`, keeps project artifacts under `projectArtifactsRoot`, and does not reintroduce symlinked `.git` mirrors.
  Evidence: `core/protocols/git.md:93-116`, `core/protocols/git.md:118-129`; `tests/test-audit-chain-root-model.sh:198-199`, `tests/test-audit-chain-root-model.sh:215-230`.
- [x] AC-4 `core/protocols/git-freshness.md` uses the same artifact-class language and keeps clone-local runtime state non-publishable.
  Evidence: `core/protocols/git-freshness.md:22-70`; `tests/test-audit-chain-root-model.sh:200-202`.
- [x] AC-5 `adapters/shared/specwright-state-paths.mjs` exposes deterministic `projectArtifactsRoot` and `workArtifactsRoot` resolution for clone-local and tracked publication modes.
  Evidence: `adapters/shared/specwright-state-paths.mjs:119-155`, `adapters/shared/specwright-state-paths.mjs:200-242`, `adapters/shared/specwright-state-paths.mjs:307-323`, `adapters/shared/specwright-state-paths.mjs:410-531`; `tests/test-audit-chain-root-model.sh:144-170`, `tests/test-audit-chain-root-model.sh:212-230`, `tests/test-claude-code-build.sh:1242-1263`.
- [x] AC-6 regressions fail if protocols or the resolver disagree about project-artifact, work-artifact, or runtime-only ownership.
  Evidence: `tests/test-audit-chain-root-model.sh:191-236`, `tests/test-claude-code-build.sh:38`, `tests/test-claude-code-build.sh:1242-1263`.

## Blast Radius
- `core/protocols/context.md`
- `core/protocols/state.md`
- `core/protocols/git.md`
- `core/protocols/git-freshness.md`
- `adapters/shared/specwright-state-paths.mjs`
- `tests/test-audit-chain-root-model.sh`
- `tests/test-claude-code-build.sh`

## Gate Results
| Gate | Verdict | Findings |
|---|---|---|
| build | PASS | 0 BLOCK, 0 WARN, 2 INFO |
| tests | PASS | 0 BLOCK, 0 WARN, 0 INFO |
| security | PASS | 0 BLOCK, 0 WARN, 0 INFO |
| wiring | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| semantic | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| spec | PASS | 0 BLOCK, 0 WARN, 0 INFO |

## Evidence Links
- Local build evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/build-report.md`
- Local test evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/test-quality.md`
- Local security evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/security-report.md`
- Local wiring evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/wiring-report.md`
- Local semantic evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/semantic-report.md`
- Local spec evidence: `.git/specwright/work/agentic-audit-chain/units/01-root-and-artifact-foundation/evidence/spec-compliance.md`
