### PR TITLE
docs(audit-chain): add rationale and review packet workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Skills reference shared protocols in `protocols/` for fragile operations:
 - `git.md` -- Strategy-aware git operations (branch lifecycle, commits, PRs)
 - `git-freshness.md` -- Shared branch freshness checkpoint contract and result semantics
 - `approvals.md` -- Durable human approval scopes, hashing, freshness, and headless constraints
+- `review-packet.md` -- Reviewer-facing audit packet structure, synthesis rules, and publication-mode constraints
 - `recovery.md` -- Compaction recovery
 - `evidence.md` -- Gate evidence format
 - `context.md` -- Anchor doc and config loading

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -56,6 +56,7 @@ Skills reference shared protocols in `protocols/` for fragile operations:
 - `git.md` -- Strategy-aware git operations (branch lifecycle, commits, PRs)
 - `git-freshness.md` -- Shared branch freshness checkpoint contract and result semantics
 - `approvals.md` -- Durable human approval scopes, hashing, freshness, and headless constraints
+- `review-packet.md` -- Reviewer-facing audit packet structure, synthesis rules, and publication-mode constraints
 - `recovery.md` -- Compaction recovery
 - `evidence.md` -- Gate evidence format, freshness, and verdict rendering
 - `context.md` -- Anchor doc and config loading

--- a/core/protocols/evidence.md
+++ b/core/protocols/evidence.md
@@ -54,6 +54,25 @@ Not for:
 - Primary communication
 - User decision-making
 
+## Reviewer Synthesis
+
+`review-packet.md` is a sibling audit artifact, not another gate report.
+
+- Location: `{workDir}/review-packet.md`
+- Producer: `sw-verify`, after the standard gate run completes
+- Inputs: approvals, `implementation-rationale.md`, gate evidence files, and
+  the gate-spec compliance matrix
+
+Rules:
+
+- The packet synthesizes evidence for reviewer consumption; it does not rerun
+  gates or duplicate gate logic.
+- Gate evidence files remain canonical for detailed findings and proof.
+- `spec-compliance.md` remains the canonical AC / IC proof surface.
+- In `clone-local` work-artifact mode, the packet or downstream PR body must
+  inline reviewer-usable summaries instead of depending on local-only file
+  links.
+
 ## Verdict Rendering
 
 ### Default Stance

--- a/core/protocols/review-packet.md
+++ b/core/protocols/review-packet.md
@@ -1,0 +1,133 @@
+# Review Packet Protocol
+
+Define the canonical reviewer-facing audit artifact for one work unit.
+
+## Purpose
+
+`review-packet.md` is the durable synthesis surface that explains:
+
+- what the agent changed
+- why the agent implemented it this way
+- which approvals were in force
+- where spec conformance was proven
+- which gate findings still need attention
+
+It exists so reviewers do not need raw transcripts or every gate report open at
+once to understand an agent-authored change.
+
+## File Location
+
+- Unit-level audit artifact: `{workDir}/review-packet.md`
+- The packet lives with auditable work artifacts, not in runtime-only
+  `workflow.json` state.
+
+## Required Inputs
+
+`sw-verify` assembles the packet from existing durable artifacts:
+
+- `{workArtifactsRoot}/{workId}/approvals.md`
+- `{workDir}/implementation-rationale.md`
+- `{workDir}/evidence/*.md`
+- `{workDir}/evidence/spec-compliance.md`
+- `{workDir}/spec.md`
+- `{workArtifactsRoot}/{workId}/integration-criteria.md` when behavioral ICs
+  are relevant
+
+The packet synthesizes those sources. It does not create a second source of
+truth for gate execution or approval state.
+
+## Canonical Structure
+
+```markdown
+# Review Packet
+
+## Approval Lineage
+{design and current unit approval status, including stale or missing lineage}
+
+## What Changed
+{changed files, blast radius, and concise reviewer-oriented diff summary}
+
+## Why The Agent Implemented It This Way
+{digest derived from implementation-rationale.md}
+
+## Spec Conformance
+{AC / IC proof summary sourced from gate-spec's compliance matrix}
+
+## Gate Summary
+{gate verdicts with evidence references}
+
+## Remaining Attention
+{WARNs, manual review items, or explicit "none"}
+```
+
+## Section Rules
+
+### Approval Lineage
+
+- Report both `design` and current `unit-spec` lineage when available.
+- Distinguish `APPROVED`, `STALE`, `SUPERSEDED`, and missing approval clearly.
+- Include the human approval source reference when present.
+- Never imply approval truth comes from `workflow.json`.
+
+### What Changed
+
+- Summarize the implementation blast radius for reviewers.
+- Focus on files, behavior, and interfaces that changed.
+- Do not dump raw git diff or transcript excerpts.
+
+### Why The Agent Implemented It This Way
+
+- Digest the curated task entries from `implementation-rationale.md`.
+- Preserve key choices, deviations, and execution path (`executor` vs
+  `build-fixer`) where they matter to review.
+- This section is rationale, not chat history or shell history.
+
+### Spec Conformance
+
+- `gate-spec` remains the canonical AC / IC proof surface.
+- The packet may summarize or excerpt the matrix, but it must not replace or
+  contradict gate-spec's evidence.
+- Missing proof in gate-spec remains a gate problem, not something the packet
+  may silently fill in.
+
+### Gate Summary
+
+- Summarize final gate verdicts and point to the underlying evidence files.
+- Do not rerun gates or recreate gate logic here.
+- Gate evidence remains the detailed source of truth.
+
+### Remaining Attention
+
+- Include only residual WARNs, blocked manual review items, or explicit absence
+  of remaining attention.
+- Do not repeat PASS-only noise in this section.
+
+## Publication-Mode Constraint
+
+`review-packet.md` must stay reviewer-usable in both work-artifact modes:
+
+- `tracked`: may link directly to tracked audit artifacts and evidence files
+- `clone-local`: must not depend on local-only file links for reviewer
+  comprehension
+
+When `workArtifacts.mode = clone-local`, the packet itself or the downstream PR
+body must inline the approval, rationale, conformance, and attention summaries
+needed by a remote reviewer.
+
+## Non-Goals
+
+The review packet is not:
+
+- a transcript archive
+- a second gate engine
+- a replacement for per-gate evidence files
+- a runtime-state mirror
+
+## Producer / Consumer Responsibilities
+
+- `sw-build` produces the rationale artifact that the packet digests.
+- `sw-verify` assembles `review-packet.md` after gate execution.
+- `sw-ship` derives reviewer-visible PR context from the packet according to
+  publication mode.
+- `sw-review` uses the packet as the primary reviewer-response context when the
+  associated work is available.

--- a/core/protocols/review-packet.md
+++ b/core/protocols/review-packet.md
@@ -127,7 +127,6 @@ The review packet is not:
 
 - `sw-build` produces the rationale artifact that the packet digests.
 - `sw-verify` assembles `review-packet.md` after gate execution.
-- `sw-ship` derives reviewer-visible PR context from the packet according to
-  publication mode.
-- `sw-review` uses the packet as the primary reviewer-response context when the
-  associated work is available.
+- `sw-ship` and `sw-review` adopt this packet in the later support-surface
+  cutover work. Until that wiring lands, this protocol defines their target
+  interface rather than claiming the consumer behavior already exists.

--- a/core/skills/gate-spec/SKILL.md
+++ b/core/skills/gate-spec/SKILL.md
@@ -33,6 +33,8 @@ that closes the loop.
 - Evidence file at `{workDir}/evidence/spec-compliance.md`
 - Compliance matrix: each criterion → implementation ref + test ref + status
 - Gate status in the selected work's `workflow.json`
+- The compliance matrix remains the canonical AC / IC proof surface that
+  downstream `review-packet.md` synthesis summarizes or references
 
 ## Constraints
 
@@ -75,6 +77,11 @@ that closes the loop.
 |---|-----------|---------------|------|--------|
 | AC-1 | Description | file:line | test_name at file:line | PASS |
 ```
+
+**Matrix stability (LOW freedom):**
+Preserve the five-column compliance matrix shape above. `sw-verify` may digest
+or quote it in `review-packet.md`, but gate-spec remains the canonical proof
+surface for AC / IC conformance.
 
 ## Protocol References
 

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -35,7 +35,7 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 
 ## Outputs
 
-- After each task: failing tests, passing implementation, task commit, workflow progress, refreshed `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
+- After each task: failing tests, passing implementation, task commit, workflow progress, updated `{workDir}/implementation-rationale.md`, refreshed `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
 - After all tasks: as-built notes in `plan.md`, three-line handoff to `/sw-verify`, ready-to-verify build state; the handoff points at `Artifacts: {repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md`
 
 ## Constraints
@@ -51,6 +51,14 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 **Approval checkpoint (LOW freedom) — before task loop:** Use `protocols/approvals.md` and the shared helper with the current unit artifact set (`spec.md`, `plan.md`, `context.md`). Interactive `/sw-build` runs may record an `APPROVED` `unit-spec` entry in `{workArtifactsRoot}/{selectedWork.id}/approvals.md` with source classification `command`; headless runs must validate existing human approval instead. Never move approval truth into `workflow.json`.
 
 **Task loop (MEDIUM freedom):** Work one task at a time. Finish it before starting the next and emit a status card after each task commit.
+
+**Implementation rationale (LOW freedom) — after each task commit:** Update
+`{workDir}/implementation-rationale.md` as an append-only curated artifact with
+one section per completed task. Each task entry must record the task ID,
+relevant AC references, changed files, tests added or updated, why this
+approach was chosen, any deviation from the approved unit artifacts, the
+execution path (`executor` or `build-fixer`), and the commit SHA. This artifact
+captures rationale, not transcript excerpts.
 
 **TDD cycle (LOW freedom for sequence):**
 1. **RED:** delegate to `specwright-tester`, write hard-to-pass tests, and confirm they fail.

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -52,13 +52,18 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 
 **Task loop (MEDIUM freedom):** Work one task at a time. Finish it before starting the next and emit a status card after each task commit.
 
-**Implementation rationale (LOW freedom) — after each task commit:** Update
-`{workDir}/implementation-rationale.md` as an append-only curated artifact with
-one section per completed task. Each task entry must record the task ID,
-relevant AC references, changed files, tests added or updated, why this
-approach was chosen, any deviation from the approved unit artifacts, the
-execution path (`executor` or `build-fixer`), and the commit SHA. This artifact
-captures rationale, not transcript excerpts.
+**Implementation rationale (LOW freedom) — at each task commit boundary:**
+Maintain `{workDir}/implementation-rationale.md` as an append-only curated
+artifact with one section per completed task. In `tracked` work-artifact mode,
+stage the task's rationale content before creating the task commit so the
+tracked tree stays clean; if the resulting commit SHA is only known after the
+commit is created, capture that SHA in the next synchronized rationale update
+instead of leaving tracked artifacts dirty between tasks. Each task entry must
+record the task ID, relevant AC references, changed files, tests added or
+updated, why this approach was chosen, any deviation from the approved unit
+artifacts, the execution path (`executor` or `build-fixer`), and the task
+commit SHA once it is known. This artifact captures rationale, not transcript
+excerpts.
 
 **TDD cycle (LOW freedom for sequence):**
 1. **RED:** delegate to `specwright-tester`, write hard-to-pass tests, and confirm they fail.
@@ -86,6 +91,7 @@ Per-task integration and regression runs do not happen inside this loop.
 - `protocols/git.md` -- branch lifecycle and commit discipline
 - `protocols/git-freshness.md` -- build-entry freshness checkpoint
 - `protocols/approvals.md` -- spec approval capture and validation
+- `protocols/review-packet.md` -- rationale artifact contract consumed by the reviewer packet
 - `protocols/delegation.md` -- tester/executor/build-fixer context handoff
 - `protocols/build-quality.md` -- post-build review and as-built notes
 - `protocols/decision.md` -- late discoveries and error handling

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -27,12 +27,14 @@ gate handoff using `protocols/decision.md` template.
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit and previous gate results
 - `{repoStateRoot}/config.json` -- gate configuration (object or array format)
 - `{workDir}/spec.md` -- for spec compliance gate
+- `{workDir}/implementation-rationale.md` -- curated build-time reasoning when present
 - Gate skill files in `skills/gate-*/SKILL.md`
 
 ## Outputs
 
 - `{repoStateRoot}/work/{selectedWork.id}/units/{selectedWork.unitId}/stage-report.md` -- verify handoff digest with attention-at-top
 - Evidence files in `{workDir}/evidence/`, one per gate
+- `{workDir}/review-packet.md` -- reviewer-focused synthesis built from approvals, rationale, proof, and gate outcomes
 - Selected work's `workflow.json` gates section updated; status set to `verifying` during run
 - Aggregate report presented at gate handoff
 
@@ -82,6 +84,15 @@ Gates are internal skills — load SKILL.md and execute inline. Pass work unit c
 
 **Gate Re-Run Policy (LOW freedom):**
 Always re-run all gates regardless of existing results or age.
+
+**Review packet synthesis (LOW freedom) — after gate execution, before
+handoff:** Use `protocols/review-packet.md` to assemble
+`{workDir}/review-packet.md` from approval lineage, `implementation-rationale.md`,
+gate evidence, and the canonical gate-spec compliance matrix. This is a
+synthesis step, not a second gate engine: do not rerun gates, recreate proof
+logic, or backfill rationale from transcripts. In `clone-local`
+work-artifact mode, keep the packet reviewer-usable without relying on
+local-only file links.
 
 **Failure handling (MEDIUM freedom):**
 Gate FAIL or ERROR: continue. Run ALL remaining gates, record all results.
@@ -177,6 +188,7 @@ the selected work's `gates` section after each gate completes. Do NOT set
 - `protocols/state.md` -- workflow state and locking
 - `protocols/git-freshness.md` -- pre-gate freshness checkpoint
 - `protocols/approvals.md` -- approval freshness and lineage validation
+- `protocols/review-packet.md` -- reviewer packet synthesis contract
 - `protocols/evidence.md` -- evidence freshness and storage
 - `protocols/evidence.md#verdict-rendering` -- verdict rendering and escalation
 - `protocols/headless.md` -- non-interactive execution defaults

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -28,6 +28,7 @@ gate handoff using `protocols/decision.md` template.
 - `{repoStateRoot}/config.json` -- gate configuration (object or array format)
 - `{workDir}/spec.md` -- for spec compliance gate
 - `{workDir}/implementation-rationale.md` -- curated build-time reasoning when present
+- `{workArtifactsRoot}/{selectedWork.id}/integration-criteria.md` -- behavioral IC list for packet and final-unit conformance summary (when present)
 - Gate skill files in `skills/gate-*/SKILL.md`
 
 ## Outputs

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -38,6 +38,7 @@ WORKFLOW_PROOF_TEST="$ROOT_DIR/tests/test-workflow-proof.sh"
 CONFIG_VISIBILITY_DOCS_TEST="$ROOT_DIR/tests/test-config-validation-visibility-docs.sh"
 AUDIT_CHAIN_ROOT_MODEL_TEST="$ROOT_DIR/tests/test-audit-chain-root-model.sh"
 APPROVAL_LIFECYCLE_TEST="$ROOT_DIR/tests/test-approval-lifecycle-docs.sh"
+REVIEW_PACKET_DOCS_TEST="$ROOT_DIR/tests/test-review-packet-docs.sh"
 
 PASS=0
 FAIL=0
@@ -171,6 +172,7 @@ run_smoke_checks() {
   assert_path_exists "$CC_DIST/protocols/state.md" "smoke build includes state protocol"
   assert_path_exists "$CC_DIST/protocols/git-freshness.md" "smoke build includes git-freshness protocol"
   assert_path_exists "$CC_DIST/protocols/approvals.md" "smoke build includes approvals protocol"
+  assert_path_exists "$CC_DIST/protocols/review-packet.md" "smoke build includes review-packet protocol"
   assert_path_exists "$CC_DIST/agents/specwright-executor.md" "smoke build includes executor agent"
   assert_path_exists "$CC_DIST/hooks/session-start.mjs" "smoke build includes session-start hook"
   assert_path_exists "$CC_DIST/.claude-plugin/plugin.json" "smoke build includes plugin manifest"
@@ -194,6 +196,7 @@ run_smoke_checks() {
   fi
 
   assert_file_contains "$CC_DIST/CLAUDE.md" "approvals.md" "smoke CLAUDE.md indexes approvals protocol"
+  assert_file_contains "$CC_DIST/CLAUDE.md" "review-packet.md" "smoke CLAUDE.md indexes review-packet protocol"
   assert_file_contains "$CC_DIST/skills/sw-build/SKILL.md" "Approval checkpoint" "smoke sw-build includes approval checkpoint"
   assert_file_contains "$CC_DIST/skills/sw-verify/SKILL.md" "Approval Lineage" "smoke sw-verify includes approval lineage"
   assert_file_contains "$CC_DIST/protocols/context.md" "projectArtifactsRoot" "smoke context protocol preserves project artifact root"
@@ -408,7 +411,7 @@ if [ -d "$CC_DIST/protocols" ]; then
   assert_eq "$PROTO_COUNT" "$EXPECTED_PROTO_COUNT" "protocols/ mirrors the core protocol set"
 
   # Spot-check specific protocol files
-  for proto in state.md git.md git-freshness.md approvals.md delegation.md recovery.md evidence.md stage-boundary.md context.md repo-map.md; do
+  for proto in state.md git.md git-freshness.md approvals.md review-packet.md delegation.md recovery.md evidence.md stage-boundary.md context.md repo-map.md; do
     if [ -f "$CC_DIST/protocols/$proto" ]; then
       pass "protocols/$proto exists"
     else
@@ -523,11 +526,13 @@ assert_file_not_contains "$ROOT_DIR/DESIGN.md" ".specwright/worktrees/" "DESIGN.
 assert_file_not_contains "$ROOT_DIR/DESIGN.md" "workflow.json # Current state" "DESIGN.md no longer describes a singleton .specwright/state/workflow.json layout"
 assert_file_contains "$ROOT_DIR/CLAUDE.md" "git-freshness.md" "root CLAUDE.md lists git-freshness.md in the protocol index"
 assert_file_contains "$ROOT_DIR/CLAUDE.md" "approvals.md" "root CLAUDE.md lists approvals.md in the protocol index"
+assert_file_contains "$ROOT_DIR/CLAUDE.md" "review-packet.md" "root CLAUDE.md lists review-packet.md in the protocol index"
 
 assert_file_contains "$CC_DIST/CLAUDE.md" "repoStateRoot" "dist CLAUDE.md references the shared repo state root"
 assert_file_contains "$CC_DIST/CLAUDE.md" "worktreeStateRoot" "dist CLAUDE.md references the per-worktree state root"
 assert_file_contains "$CC_DIST/CLAUDE.md" "git-freshness.md" "dist CLAUDE.md lists git-freshness.md in the protocol index"
 assert_file_contains "$CC_DIST/CLAUDE.md" "approvals.md" "dist CLAUDE.md lists approvals.md in the protocol index"
+assert_file_contains "$CC_DIST/CLAUDE.md" "review-packet.md" "dist CLAUDE.md lists review-packet.md in the protocol index"
 assert_file_not_contains "$CC_DIST/CLAUDE.md" "**\`.specwright/CONSTITUTION.md\`**" "dist CLAUDE.md no longer points anchor docs at checkout-local .specwright/"
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -1413,6 +1418,31 @@ if [ "$APPROVAL_LIFECYCLE_EXIT" -eq 0 ] && echo "$APPROVAL_LIFECYCLE_OUTPUT" | g
   pass "approval-lifecycle regression output includes fail-closed approval coverage"
 else
   fail "approval-lifecycle regression output missing fail-closed approval coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Review packet docs ==="
+
+if [ -x "$REVIEW_PACKET_DOCS_TEST" ]; then
+  pass "tests/test-review-packet-docs.sh is executable"
+else
+  fail "tests/test-review-packet-docs.sh is missing or not executable"
+fi
+
+REVIEW_PACKET_EXIT=0
+REVIEW_PACKET_OUTPUT="$(bash "$REVIEW_PACKET_DOCS_TEST" 2>&1)" || REVIEW_PACKET_EXIT=$?
+
+if [ "$REVIEW_PACKET_EXIT" -ne 0 ]; then
+  fail "tests/test-review-packet-docs.sh passes under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${REVIEW_PACKET_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-review-packet-docs.sh passes under the configured test path"
+fi
+if echo "$REVIEW_PACKET_OUTPUT" | grep -Fq "COVERAGE: review-packet.clone-local-guard"; then
+  pass "review-packet regression output includes clone-local reviewer guard coverage"
+else
+  fail "review-packet regression output missing clone-local reviewer guard coverage"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test-review-packet-docs.sh
+++ b/tests/test-review-packet-docs.sh
@@ -74,6 +74,7 @@ assert_contains "$REVIEW_PACKET_PROTOCOL" "## Remaining Attention" "review-packe
 assert_contains "$REVIEW_PACKET_PROTOCOL" "must not depend on local-only file links" "review-packet protocol guards clone-local reviewer visibility"
 assert_contains "$REVIEW_PACKET_PROTOCOL" "a transcript archive" "review-packet protocol rejects transcript storage"
 assert_contains "$REVIEW_PACKET_PROTOCOL" "a second gate engine" "review-packet protocol rejects duplicated gate logic"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "support-surface" "review-packet protocol marks ship/review consumer wiring as deferred"
 
 echo ""
 echo "--- Evidence synthesis contract ---"
@@ -87,13 +88,16 @@ assert_contains "$EVIDENCE_PROTOCOL" "canonical AC / IC proof surface" "evidence
 echo ""
 echo "--- Build and verify lifecycle surfaces ---"
 assert_contains "$BUILD_SKILL" "{workDir}/implementation-rationale.md" "sw-build outputs the implementation rationale artifact"
-assert_contains "$BUILD_SKILL" "append-only curated artifact" "sw-build keeps rationale append-only and curated"
+assert_contains "$BUILD_SKILL" "append-only curated" "sw-build keeps rationale append-only and curated"
+assert_contains "$BUILD_SKILL" "tracked tree stays clean" "sw-build guards tracked work-artifact cleanliness for rationale updates"
 assert_contains "$BUILD_SKILL" "relevant AC references" "sw-build requires AC references in rationale"
-assert_contains "$BUILD_SKILL" "tests added or updated" "sw-build requires test-summary rationale coverage"
+assert_contains "$BUILD_SKILL" "tests added or" "sw-build requires test-summary rationale coverage"
 assert_contains "$BUILD_SKILL" "execution path (\`executor\` or \`build-fixer\`)" "sw-build records executor vs build-fixer path"
-assert_contains "$BUILD_SKILL" "captures rationale, not transcript excerpts" "sw-build forbids transcript-style rationale capture"
+assert_contains "$BUILD_SKILL" "captures rationale, not transcript" "sw-build forbids transcript-style rationale capture"
+assert_contains "$BUILD_SKILL" "protocols/review-packet.md" "sw-build protocol references include review-packet"
 assert_contains "$VERIFY_SKILL" "{workDir}/review-packet.md" "sw-verify outputs the review packet artifact"
 assert_contains "$VERIFY_SKILL" "implementation-rationale.md" "sw-verify consumes implementation rationale"
+assert_contains "$VERIFY_SKILL" "integration-criteria.md" "sw-verify inputs include conditional packet integration criteria"
 assert_contains "$VERIFY_SKILL" "canonical gate-spec compliance matrix" "sw-verify keeps gate-spec as the proof source"
 assert_contains "$VERIFY_SKILL" "not a second gate engine" "sw-verify forbids duplicate gate logic in the packet"
 assert_contains "$VERIFY_SKILL" "local-only file links" "sw-verify carries the clone-local reviewer guardrail"
@@ -107,8 +111,8 @@ assert_contains "$ROOT_CLAUDE" "review-packet.md" "root CLAUDE.md indexes the re
 assert_contains "$ADAPTER_CLAUDE" "review-packet.md" "adapter CLAUDE.md indexes the review-packet protocol"
 
 echo ""
-emit_coverage_marker "review-packet.clone-local-guard"
 echo "RESULT: $PASS passed, $FAIL failed"
 if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
+emit_coverage_marker "review-packet.clone-local-guard"

--- a/tests/test-review-packet-docs.sh
+++ b/tests/test-review-packet-docs.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Regression checks for Unit 03 — rationale and review-packet docs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REVIEW_PACKET_PROTOCOL="$ROOT_DIR/core/protocols/review-packet.md"
+EVIDENCE_PROTOCOL="$ROOT_DIR/core/protocols/evidence.md"
+BUILD_SKILL="$ROOT_DIR/core/skills/sw-build/SKILL.md"
+VERIFY_SKILL="$ROOT_DIR/core/skills/sw-verify/SKILL.md"
+GATE_SPEC_SKILL="$ROOT_DIR/core/skills/gate-spec/SKILL.md"
+ROOT_AGENTS="$ROOT_DIR/AGENTS.md"
+ROOT_CLAUDE="$ROOT_DIR/CLAUDE.md"
+ADAPTER_CLAUDE="$ROOT_DIR/adapters/claude-code/CLAUDE.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+emit_coverage_marker() {
+  printf 'COVERAGE: %s\n' "$1"
+}
+
+echo "=== review packet docs ==="
+echo ""
+
+for file in \
+  "$REVIEW_PACKET_PROTOCOL" \
+  "$EVIDENCE_PROTOCOL" \
+  "$BUILD_SKILL" \
+  "$VERIFY_SKILL" \
+  "$GATE_SPEC_SKILL" \
+  "$ROOT_AGENTS" \
+  "$ROOT_CLAUDE" \
+  "$ADAPTER_CLAUDE"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- Review packet contract ---"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## Approval Lineage" "review-packet protocol defines approval lineage section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## What Changed" "review-packet protocol defines change summary section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## Why The Agent Implemented It This Way" "review-packet protocol defines rationale digest section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## Spec Conformance" "review-packet protocol defines conformance section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## Gate Summary" "review-packet protocol defines gate summary section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "## Remaining Attention" "review-packet protocol defines remaining attention section"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "must not depend on local-only file links" "review-packet protocol guards clone-local reviewer visibility"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "a transcript archive" "review-packet protocol rejects transcript storage"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "a second gate engine" "review-packet protocol rejects duplicated gate logic"
+
+echo ""
+echo "--- Evidence synthesis contract ---"
+assert_contains "$EVIDENCE_PROTOCOL" "## Reviewer Synthesis" "evidence protocol defines reviewer synthesis section"
+assert_contains "$EVIDENCE_PROTOCOL" "\`review-packet.md\` is a sibling audit artifact" "evidence protocol distinguishes packet from gate reports"
+assert_contains "$EVIDENCE_PROTOCOL" "implementation-rationale.md" "evidence protocol names implementation rationale as packet input"
+assert_contains "$EVIDENCE_PROTOCOL" "gate-spec compliance matrix" "evidence protocol names gate-spec matrix as packet input"
+assert_contains "$EVIDENCE_PROTOCOL" "does not rerun" "evidence protocol forbids packet gate reruns"
+assert_contains "$EVIDENCE_PROTOCOL" "canonical AC / IC proof surface" "evidence protocol keeps spec proof canonical"
+
+echo ""
+echo "--- Build and verify lifecycle surfaces ---"
+assert_contains "$BUILD_SKILL" "{workDir}/implementation-rationale.md" "sw-build outputs the implementation rationale artifact"
+assert_contains "$BUILD_SKILL" "append-only curated artifact" "sw-build keeps rationale append-only and curated"
+assert_contains "$BUILD_SKILL" "relevant AC references" "sw-build requires AC references in rationale"
+assert_contains "$BUILD_SKILL" "tests added or updated" "sw-build requires test-summary rationale coverage"
+assert_contains "$BUILD_SKILL" "execution path (\`executor\` or \`build-fixer\`)" "sw-build records executor vs build-fixer path"
+assert_contains "$BUILD_SKILL" "captures rationale, not transcript excerpts" "sw-build forbids transcript-style rationale capture"
+assert_contains "$VERIFY_SKILL" "{workDir}/review-packet.md" "sw-verify outputs the review packet artifact"
+assert_contains "$VERIFY_SKILL" "implementation-rationale.md" "sw-verify consumes implementation rationale"
+assert_contains "$VERIFY_SKILL" "canonical gate-spec compliance matrix" "sw-verify keeps gate-spec as the proof source"
+assert_contains "$VERIFY_SKILL" "not a second gate engine" "sw-verify forbids duplicate gate logic in the packet"
+assert_contains "$VERIFY_SKILL" "local-only file links" "sw-verify carries the clone-local reviewer guardrail"
+
+echo ""
+echo "--- Canonical proof surface and protocol indexes ---"
+assert_contains "$GATE_SPEC_SKILL" "canonical AC / IC proof surface" "gate-spec names its matrix as the canonical proof surface"
+assert_contains "$GATE_SPEC_SKILL" "Preserve the five-column compliance matrix shape" "gate-spec preserves the stable matrix shape"
+assert_contains "$ROOT_AGENTS" "review-packet.md" "AGENTS.md indexes the review-packet protocol"
+assert_contains "$ROOT_CLAUDE" "review-packet.md" "root CLAUDE.md indexes the review-packet protocol"
+assert_contains "$ADAPTER_CLAUDE" "review-packet.md" "adapter CLAUDE.md indexes the review-packet protocol"
+
+echo ""
+emit_coverage_marker "review-packet.clone-local-guard"
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `core/protocols/review-packet.md` as the canonical reviewer-facing audit artifact for one work unit
- update `sw-build`, `sw-verify`, `gate-spec`, and `evidence.md` so rationale capture and reviewer synthesis share one explicit contract instead of duplicating gate logic
- add default-path regressions proving review-packet sections, clone-local reviewer visibility, and anti-transcript guardrails across the Claude adapter surface

## Reviewer Audit Chain
### Approval Lineage
- `design`: `MISSING`. No durable design approval entry exists for the current `design.md` / `context.md` / `decisions.md` artifact set.
- `unit-spec`: `STALE`. The `/sw-build` approval recorded at `2026-04-15T21:37:59Z` no longer matches the current `spec.md` / `plan.md` / `context.md` hash.
- Publication mode remains `clone-local`, so the reviewer-critical audit summary is inlined here instead of relying on local-only artifact links.

### Implementation Rationale
- No `implementation-rationale.md` exists for this already in-flight unit.
- This unit adds the rationale contract itself so later units can carry durable curated rationale without requiring transcript review.

### Remaining Attention
- approval lineage remains incomplete for this in-flight work
- no gate-level BLOCK or WARN findings remain

## Acceptance Criteria
- [x] AC-1 `core/protocols/review-packet.md` defines the canonical `review-packet.md` structure, including approval lineage, rationale digest, conformance proof, gate summary, and remaining attention sections.
  Evidence: `core/protocols/review-packet.md:39-61`; `tests/test-review-packet-docs.sh:67-76`.
- [x] AC-2 `core/skills/sw-build/SKILL.md` writes or updates `implementation-rationale.md` after each task commit with task ID, AC references, changed files, test summary, rationale, deviation, execution path, and commit SHA.
  Evidence: `core/skills/sw-build/SKILL.md:55-61`; `tests/test-review-packet-docs.sh:88-99`.
- [x] AC-3 `core/protocols/evidence.md` and `core/skills/sw-verify/SKILL.md` describe `review-packet.md` generation as a synthesis step built from approvals, rationale, gate evidence, and spec proof rather than a second copy of gate logic.
  Evidence: `core/protocols/evidence.md:57-74`; `core/skills/sw-verify/SKILL.md:88-95`; `tests/test-review-packet-docs.sh:79-99`.
- [x] AC-4 `core/skills/gate-spec/SKILL.md` preserves a conformance matrix shape that `review-packet.md` can reference as the canonical AC / IC proof surface.
  Evidence: `core/skills/gate-spec/SKILL.md:36-37`; `core/skills/gate-spec/SKILL.md:81-84`; `tests/test-review-packet-docs.sh:102-104`.
- [x] AC-5 The review-packet contract explicitly forbids relying on local-only file links when `workArtifacts.mode = clone-local`; the packet or downstream PR body must stay reviewer-usable in both publication modes.
  Evidence: `core/protocols/review-packet.md:105-115`; `tests/test-review-packet-docs.sh:74`; `tests/test-claude-code-build.sh:1442-1445`.
- [x] AC-6 Regression tests fail if the touched rationale or review-packet surfaces drop required sections or drift toward transcript capture instead of curated rationale.
  Evidence: `tests/test-review-packet-docs.sh:1-114`; `tests/test-claude-code-build.sh:1423-1445`.

## Blast Radius
- `AGENTS.md`
- `adapters/claude-code/CLAUDE.md`
- `core/protocols/evidence.md`
- `core/protocols/review-packet.md`
- `core/skills/gate-spec/SKILL.md`
- `core/skills/sw-build/SKILL.md`
- `core/skills/sw-verify/SKILL.md`
- `tests/test-claude-code-build.sh`
- `tests/test-review-packet-docs.sh`

## Gate Results
| Gate | Verdict | Findings |
|---|---|---|
| build | PASS | 0 BLOCK, 0 WARN, 2 INFO |
| tests | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| security | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| wiring | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| semantic | PASS | 0 BLOCK, 0 WARN, 1 INFO |
| spec | PASS | 0 BLOCK, 0 WARN, 1 INFO |

Note: verify also surfaced one non-gate warning category for this older in-flight work: durable approval lineage is incomplete because `design` is missing and the current `unit-spec` approval is stale.

## Evidence Links
- Local review packet artifact: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/review-packet.md` (clone-local; reviewer summary inlined above)
- Local build evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/build-report.md`
- Local test evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/test-quality.md`
- Local security evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/security-report.md`
- Local wiring evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/wiring-report.md`
- Local semantic evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/semantic-report.md`
- Local spec evidence: `.git/specwright/work/agentic-audit-chain/units/03-rationale-and-review-packet/evidence/spec-compliance.md`
