### PR TITLE
docs(audit-chain): prove workflow and finish migration

### DIFF
--- a/core/agents/specwright-integration-tester.md
+++ b/core/agents/specwright-integration-tester.md
@@ -46,9 +46,9 @@ Your philosophy: **a test that skips when infrastructure is absent tells you not
 
 ## Before writing any tests
 
-1. Read `config.json` to identify the project language, runtime, and framework. Do not assume a stack — read config.json and examine what is there.
+1. Read `{projectArtifactsRoot}/config.json` to identify the project language, runtime, and framework. Do not assume a stack — read config.json and examine what is there.
 2. Detect and adapt to the project language and testing stack by reading existing test files.
-3. Read `.specwright/TESTING.md` if it exists. It contains boundary classifications that determine which components are internal, external, or expensive boundaries. Read TESTING.md before classifying any test.
+3. Read `{projectArtifactsRoot}/TESTING.md` if it exists. It contains boundary classifications that determine which components are internal, external, or expensive boundaries. Read TESTING.md before classifying any test.
 4. Read the spec criteria being tested.
 
 ## No skip conditions for missing infrastructure

--- a/core/agents/specwright-tester.md
+++ b/core/agents/specwright-tester.md
@@ -52,7 +52,7 @@ coverage (one test per function instead of per behavior).
 
 ## Testing strategy awareness
 
-If `.specwright/TESTING.md` exists, read it for boundary classifications per
+If `{projectArtifactsRoot}/TESTING.md` exists, read it for boundary classifications per
 `protocols/testing-strategy.md`. Constitution overrides TESTING.md.
 
 - **Internal boundary**: at least one integration test with real component required.

--- a/core/protocols/audit.md
+++ b/core/protocols/audit.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-`.specwright/AUDIT.md` — optional reference document. Never blocks workflow.
+`{projectArtifactsRoot}/AUDIT.md` — optional reference document. Never blocks workflow.
 
 Header: `Snapshot:` (ISO 8601), `Scope:` (full | focused: {path}), `Dimensions:` (list), `Findings:` (count, B/W/I).
 

--- a/core/protocols/backlog.md
+++ b/core/protocols/backlog.md
@@ -21,7 +21,7 @@ If `backlog` is absent from `config.json`, default to `markdown`.
 
 ### markdown
 
-Writes to `.specwright/BACKLOG.md`. Creates the file if it doesn't exist.
+Writes to `{projectArtifactsRoot}/BACKLOG.md`. Creates the file if it doesn't exist.
 
 ### github-issues
 
@@ -36,13 +36,13 @@ gh issue create --title "{BL-n} {title}" --body "{detail}" --label "{backlog.lab
 2. Auth is active (`gh auth status`)
 
 If either check fails: emit one warning ("GitHub Issues unavailable — writing to
-BACKLOG.md instead"), then write to markdown. Never silently drop items.
+`{projectArtifactsRoot}/BACKLOG.md` instead"), then write to markdown. Never silently drop items.
 
 ## ID Generation
 
 IDs are `BL-{n}` where `n` is a zero-padded three-digit integer (BL-001, BL-002, …).
 
-**For markdown target:** Read `.specwright/BACKLOG.md`, find the highest existing
+**For markdown target:** Read `{projectArtifactsRoot}/BACKLOG.md`, find the highest existing
 `BL-{n}` ID, increment by 1. If BACKLOG.md is missing or has no IDs, start at BL-001.
 
 **For github-issues target:** List open issues with the backlog label (`gh issue list

--- a/core/protocols/build-context.md
+++ b/core/protocols/build-context.md
@@ -4,7 +4,7 @@ Continuation snapshots, status cards, and context nudge for sw-build.
 
 ## Continuation Snapshot
 
-After each task commit, write `.specwright/state/continuation.md`: current unit, task just completed, key files modified, remaining tasks. Overwrites each time.
+After each task commit, write `{worktreeStateRoot}/continuation.md`: current unit, task just completed, key files modified, remaining tasks. Overwrites each time.
 
 ## Status Card
 
@@ -90,7 +90,7 @@ Unique violations seen in this build (avoid these patterns):
 - bare-except (1 occurrence): Use specific exception types
 ```
 
-**Injection point:** Written to `.specwright/state/continuation.md` during PreCompact.
+**Injection point:** Written to `{worktreeStateRoot}/continuation.md` during PreCompact.
 Read and injected by the SessionStart hook on the `compact` trigger.
 
 **When feedback-log.md is absent or empty:** No Correction Summary section is written.

--- a/core/protocols/decision.md
+++ b/core/protocols/decision.md
@@ -43,7 +43,7 @@ Resolve ambiguity in order:
 
 ### CURATION
 - Promote to `patterns.md` when the pattern recurs across 2+ units or matches a known failure class.
-- Promote to `.specwright/TESTING.md` when the learning is a boundary classification or test-infra discovery.
+- Promote to `{projectArtifactsRoot}/TESTING.md` when the learning is a boundary classification or test-infra discovery.
 - Never auto-promote to the constitution or auto-memory; that is Type 1.
 - Record all auto-promotions in `decisions.md`.
 
@@ -133,7 +133,7 @@ Design assumptions are statements treated as true without verification. Untracke
 
 ### Artifact
 
-**Location:** the design assumptions artifact in `.specwright/work/{id}/`
+**Location:** the design assumptions artifact in `{workArtifactsRoot}/{id}/`
 
 Produced by `sw-design` during the critic phase. Travels with the design to `sw-plan` and downstream stages.
 

--- a/core/protocols/evidence.md
+++ b/core/protocols/evidence.md
@@ -174,7 +174,7 @@ Silently absent from the verify report until 5+ units have shipped.
   for the relevant gate.
 
 **Consumption (sw-verify):**
-- Before running gates, scan `.specwright/learnings/` for calibration data from the
+- Before running gates, scan `{projectArtifactsRoot}/learnings/` for calibration data from the
   last 5 work units.
 - 3+ false positives from distinct work units for a gate+dimension -> note:
   "This dimension has been flagged as potentially over-sensitive in recent work units."

--- a/core/protocols/guardrails-detection.md
+++ b/core/protocols/guardrails-detection.md
@@ -16,7 +16,7 @@ Read dependency manifests at the project root (or workspace roots for monorepos)
 | `go.mod` | Go | Presence → `go test`, `gofmt`/`goimports` built into toolchain |
 | `pom.xml` | Java | `<artifactId>` under `<plugins>` identifies Maven plugins |
 
-If `.specwright/config.json` exists, read `commands.*` fields as authoritative
+If `{projectArtifactsRoot}/config.json` exists, read `commands.*` fields as authoritative
 overrides — they take precedence over detected tools.
 
 ### Step 2: Config File Scan

--- a/core/protocols/headless.md
+++ b/core/protocols/headless.md
@@ -70,7 +70,7 @@ to disk so the calling system can read it.
 Specifically:
 - Gate evidence files → written to `{currentWork.workDir}/evidence/` (already happens)
 - Aggregate report → written to evidence directory (already happens)
-- Status cards → written to `.specwright/state/continuation.md` (already happens)
+- Status cards → written to `{worktreeStateRoot}/continuation.md` (already happens)
 - Build task progress → written to `workflow.json` (already happens)
 
 ## Result Summary File

--- a/core/protocols/landscape.md
+++ b/core/protocols/landscape.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-`.specwright/LANDSCAPE.md` is a reference document (not an anchor document). Optional. Never blocks workflow.
+`{projectArtifactsRoot}/LANDSCAPE.md` is a reference document (not an anchor document). Optional. Never blocks workflow.
 
 Required metadata header:
 ```

--- a/core/protocols/learning-lifecycle.md
+++ b/core/protocols/learning-lifecycle.md
@@ -12,11 +12,11 @@ Three targets, ordered by durability:
 | **Auto-memory** | Project-specific patterns, common gotchas | Every session (first 200 lines of MEMORY.md) |
 | **patterns.md** | Detailed patterns with source and rationale | On demand (sw-design, sw-plan read it) |
 
-**Constitution** (`.specwright/CONSTITUTION.md`): Most durable. Add a practice with an ID (e.g., S6, Q5). User approves exact wording. Referenced by CLAUDE.md, loaded by skills, validated by gates.
+**Constitution** (`{projectArtifactsRoot}/CONSTITUTION.md`): Most durable. Add a practice with an ID (e.g., S6, Q5). User approves exact wording. Referenced by CLAUDE.md, loaded by skills, validated by gates.
 
 **Auto-memory** (MEMORY.md in Claude Code's auto-memory directory): Loaded automatically every session. Write compact entries under a `## Specwright Patterns` section. Fire-and-forget — patterns.md is the canonical record.
 
-**patterns.md** (`.specwright/patterns.md`): Full pattern library. Detailed descriptions with source and rationale. Create if missing on first promotion. Grouped by theme, not fixed categories.
+**patterns.md** (`{projectArtifactsRoot}/patterns.md`): Full pattern library. Detailed descriptions with source and rationale. Create if missing on first promotion. Grouped by theme, not fixed categories.
 
 ## Dual-Write Rule
 
@@ -37,7 +37,7 @@ When promoting to patterns.md, also write a compact one-liner to auto-memory. Th
 
 ## Raw File Retention
 
-`.specwright/learnings/{work-id}.json` — raw learning files. Archive only, never deleted. Schema: `{ workId, timestamp, findings: [{ category, source, description, proposedRule, disposition }] }`. Only written when at least one finding is promoted (not all dismissed).
+`{projectArtifactsRoot}/learnings/{work-id}.json` — raw learning files. Archive only, never deleted. Schema: `{ workId, timestamp, findings: [{ category, source, description, proposedRule, disposition }] }`. Only written when at least one finding is promoted (not all dismissed).
 
 ## Graceful Degradation
 

--- a/core/protocols/recovery.md
+++ b/core/protocols/recovery.md
@@ -37,11 +37,11 @@ If no work can be resolved for a work-aware recovery path, stop with:
 
 ### 3. Load Anchor Context
 ```
-Read {repoStateRoot}/CHARTER.md
-Read {repoStateRoot}/CONSTITUTION.md
+Read {projectArtifactsRoot}/CHARTER.md
+Read {projectArtifactsRoot}/CONSTITUTION.md
 ```
 
-Read `{repoStateRoot}/TESTING.md` only when the resumed skill needs testing
+Read `{projectArtifactsRoot}/TESTING.md` only when the resumed skill needs testing
 boundaries and the file exists.
 
 ### 4. Resume Active Work

--- a/core/protocols/research.md
+++ b/core/protocols/research.md
@@ -43,7 +43,7 @@ Confidence measures **source quality**, not design risk:
 ## File Naming
 
 ```
-.specwright/research/{topic-id}-{YYYYMMDD}.md
+{projectArtifactsRoot}/research/{topic-id}-{YYYYMMDD}.md
 ```
 
 Topic ID: kebab-case, descriptive, 2-4 words (e.g., `stripe-api-webhooks`, `react-server-components`, `oauth2-pkce-flow`).
@@ -61,11 +61,14 @@ Consumers (sw-design) must warn when loading stale briefs. The brief itself is n
 
 ## Size Limits
 
-- Maximum **10 briefs** in `.specwright/research/`
+- Maximum **10 briefs** in `{projectArtifactsRoot}/research/`
 - Maximum **20 findings** per brief (keep highest-confidence if more)
 
 ## Consumption by sw-design
 
-During its research phase, sw-design checks `.specwright/research/` for briefs relevant to the current request. Relevant findings are incorporated into `context.md` with brief references (e.g., "per research brief `stripe-api-webhooks-20260301`").
+During its research phase, sw-design checks `{projectArtifactsRoot}/research/`
+for briefs relevant to the current request. Relevant findings are incorporated
+into `context.md` with brief references (e.g., "per research brief
+`stripe-api-webhooks-20260301`").
 
 Stale briefs are surfaced with a warning. sw-design may suggest re-running `/sw-research` to refresh.

--- a/core/protocols/testing-strategy.md
+++ b/core/protocols/testing-strategy.md
@@ -1,7 +1,7 @@
 # Testing Strategy Protocol
 
 How testing decisions flow through the Specwright pipeline. The testing strategy
-is captured in `.specwright/TESTING.md` and consumed by skills and agents
+is captured in `{projectArtifactsRoot}/TESTING.md` and consumed by skills and agents
 throughout the workflow.
 
 ## Precedence
@@ -103,7 +103,7 @@ After detecting the stack, sw-init asks the user about:
 - Rate-limited or cost-attached APIs
 - Any other expensive dependencies
 
-Generates `.specwright/TESTING.md` with three required sections:
+Generates `{projectArtifactsRoot}/TESTING.md` with three required sections:
 - **Boundaries**: Internal, external, and expensive classifications
 - **Test Infrastructure**: Available test databases, containers, fixtures
 - **Mock Allowances**: Which dependencies may be mocked and documented rationale

--- a/core/skills/gate-build/SKILL.md
+++ b/core/skills/gate-build/SKILL.md
@@ -21,7 +21,7 @@ else matters.
 
 ## Inputs
 
-- `.specwright/config.json` -- `commands.build`, `commands.test`,
+- `{projectArtifactsRoot}/config.json` -- `commands.build`, `commands.test`,
   `commands.test:integration`, `commands.test:smoke`
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit for evidence path
 

--- a/core/skills/gate-security/SKILL.md
+++ b/core/skills/gate-security/SKILL.md
@@ -22,7 +22,7 @@ judgment for analysis that tools can't do.
 
 ## Inputs
 
-- `.specwright/config.json` -- `commands.lint`, SAST tool config if available
+- `{projectArtifactsRoot}/config.json` -- `commands.lint`, SAST tool config if available
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Changed files (detected via `git diff`)
 

--- a/core/skills/gate-tests/SKILL.md
+++ b/core/skills/gate-tests/SKILL.md
@@ -23,8 +23,8 @@ test quality, not just pass/fail.
 
 ## Inputs
 
-- `.specwright/config.json` -- test commands, project language
-- `.specwright/TESTING.md` -- testing strategy with boundary classifications (optional)
+- `{projectArtifactsRoot}/config.json` -- test commands, project language
+- `{projectArtifactsRoot}/TESTING.md` -- testing strategy with boundary classifications (optional)
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Test files in the codebase
 

--- a/core/skills/gate-wiring/SKILL.md
+++ b/core/skills/gate-wiring/SKILL.md
@@ -23,7 +23,7 @@ can still be wired incorrectly.
 
 ## Inputs
 
-- `.specwright/config.json` -- architecture layers, project structure
+- `{projectArtifactsRoot}/config.json` -- architecture layers, project structure
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit
 - Changed files (via `git diff`)
 

--- a/core/skills/sw-audit/SKILL.md
+++ b/core/skills/sw-audit/SKILL.md
@@ -25,14 +25,14 @@ and persist findings for future design cycles.
 ## Inputs
 
 - The codebase itself
-- `.specwright/CONSTITUTION.md` -- practices to check against
-- `.specwright/AUDIT.md` -- prior findings (if exists, for ID matching)
-- `.specwright/LANDSCAPE.md` -- module structure (if exists, for triage)
-- `.specwright/config.json` -- audit config (optional `audit` section)
+- `{projectArtifactsRoot}/CONSTITUTION.md` -- practices to check against
+- `{projectArtifactsRoot}/AUDIT.md` -- prior findings (if exists, for ID matching)
+- `{projectArtifactsRoot}/LANDSCAPE.md` -- module structure (if exists, for triage)
+- `{projectArtifactsRoot}/config.json` -- audit config (optional `audit` section)
 
 ## Outputs
 
-- `.specwright/AUDIT.md` -- findings per `protocols/audit.md` format
+- `{projectArtifactsRoot}/AUDIT.md` -- findings per `protocols/audit.md` format
 - Findings presented to user grouped by dimension before saving
 
 ## Constraints

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -31,7 +31,7 @@ Implement the current work unit with TDD. The per-task loop is RED → GREEN →
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json`, `{workDir}/spec.md`, `{workDir}/plan.md`
 - `{workArtifactsRoot}/{selectedWork.id}/design.md`, `{workDir}/context.md`
 - `{workArtifactsRoot}/{selectedWork.id}/approvals.md` -- durable design and unit approval ledger when present
-- `{repoStateRoot}/CONSTITUTION.md`, `{repoStateRoot}/config.json`
+- `{projectArtifactsRoot}/CONSTITUTION.md`, `{projectArtifactsRoot}/config.json`
 
 ## Outputs
 

--- a/core/skills/sw-debug/SKILL.md
+++ b/core/skills/sw-debug/SKILL.md
@@ -25,14 +25,14 @@ autonomously, applying `protocols/decision.md` for the fix/log/defer decision.
 
 - Problem description (argument or recent error context)
 - Initial evidence: error messages, logs, failing test output
-- `.specwright/config.json` — `backlog.type` and `backlog.label`
+- `{projectArtifactsRoot}/config.json` — `backlog.type` and `backlog.label`
 - Codebase files — read during investigation
 
 ## Outputs
 
-- `diagnosis.md` at `.specwright/work/{id}/` — always produced
-- `spec.md` at `.specwright/work/{id}/` — Fix path only (2-3 acceptance criteria)
-- `decisions.md` — fix/log/defer decision recorded per `protocols/decision.md`
+- `diagnosis.md` at `{workArtifactsRoot}/{id}/diagnosis.md` — always produced
+- `spec.md` at `{workArtifactsRoot}/{id}/spec.md` — Fix path only (2-3 acceptance criteria)
+- `decisions.md` at `{workArtifactsRoot}/{id}/decisions.md` — fix/log/defer decision recorded per `protocols/decision.md`
 
 ## Constraints
 

--- a/core/skills/sw-design/SKILL.md
+++ b/core/skills/sw-design/SKILL.md
@@ -25,9 +25,9 @@ between research and gate handoff, applying `protocols/decision.md` for all deci
 ## Inputs
 
 - The user's request (argument or conversation)
-- `{repoStateRoot}/CONSTITUTION.md` -- practices to follow
-- `{repoStateRoot}/CHARTER.md` -- vision and invariants
-- `{repoStateRoot}/config.json` -- project configuration
+- `{projectArtifactsRoot}/CONSTITUTION.md` -- practices to follow
+- `{projectArtifactsRoot}/CHARTER.md` -- vision and invariants
+- `{projectArtifactsRoot}/config.json` -- project configuration
 - `{worktreeStateRoot}/session.json` -- current worktree attachment, when present
 - `{repoStateRoot}/work/*/workflow.json` -- other active works for collision checks
 - The codebase itself

--- a/core/skills/sw-guard/SKILL.md
+++ b/core/skills/sw-guard/SKILL.md
@@ -27,8 +27,8 @@ independently approvable. Existing guardrails are preserved during re-runs.
 ## Inputs
 
 - The codebase (dependency manifests, config files, existing hooks)
-- `.specwright/config.json` -- project configuration (optional -- not required)
-- `.specwright/CONSTITUTION.md` -- practices to follow (if present)
+- `{projectArtifactsRoot}/config.json` -- project configuration (optional -- not required)
+- `{projectArtifactsRoot}/CONSTITUTION.md` -- practices to follow (if present)
 - Existing agent hooks, git hooks, CI workflows
 
 ## Outputs
@@ -47,7 +47,7 @@ When complete, user-approved guardrails are configured. Artifacts may include:
 - Pre-commit hook configurations (framework chosen by user)
 - Pre-push hook configurations (test runner, coverage thresholds)
 - CI/CD workflow files (backstop checks, integration tests, security scanning)
-- `.specwright/config.json` -- updated with detected tool commands (if present)
+- `{projectArtifactsRoot}/config.json` -- updated with detected tool commands (if present)
 
 Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibility of sw-learn.
 
@@ -59,9 +59,9 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
 - Detection scope includes traditional tools (linters, formatters, test runners) and
   semantic analysis tools: ast-grep (`sg`), OpenGrep (`opengrep`), and platform LSP
   (Claude Code `.lsp.json`, Opencode built-in, `cli-lsp-client` standalone).
-- If `.specwright/config.json` exists, read `commands.*` fields as authoritative;
+- If `{projectArtifactsRoot}/config.json` exists, read `commands.*` fields as authoritative;
   supplement with detection for unconfigured dimensions.
-- If `.specwright/config.json` does not exist, rely entirely on detection.
+- If `{projectArtifactsRoot}/config.json` does not exist, rely entirely on detection.
   Validate detected tools by running them (e.g., `--version` check). Present
   standalone recommendations with explicit "detected via heuristics" labeling.
 - When Git workflow config is present or inferred, seed or migrate `git.targets` and `git.freshness` from the detected Git workflow strategy without requiring users to define a custom branch DSL.
@@ -90,10 +90,11 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
 
 **Configuration (LOW freedom):**
 - External file writes: diff-show-approve. Installation commands require explicit approval.
-- Update config.json with detected tool commands if `.specwright/` exists.
+- Update `{projectArtifactsRoot}/config.json` with detected tool commands when the tracked
+  project-artifact root exists.
 - When present, update the approved work-artifact publication choice in config separately from clone-local runtime state.
   Follow `protocols/context.md` for config updates.
-- Preserve the root split: tracked project policy stays under `.specwright/`,
+- Preserve the root split: tracked project policy stays under `{projectArtifactsRoot}`,
   while Git-admin session state remains local-only under the runtime roots.
 - Never modify CONSTITUTION.md (sw-learn's responsibility).
 

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -30,8 +30,8 @@ applying `protocols/decision.md` for all decisions. Gate handoff at the end.
 - `{workArtifactsRoot}/{selectedWork.id}/context.md` -- research findings from sw-design
 - `{workArtifactsRoot}/{selectedWork.id}/decisions.md` -- design-phase decisions
 - Conditional design artifacts: `data-model.md`, `contracts.md`, `testing-strategy.md`, `infra.md`, `migrations.md`
-- `{repoStateRoot}/CONSTITUTION.md` -- practices to follow
-- `{repoStateRoot}/config.json` -- project configuration
+- `{projectArtifactsRoot}/CONSTITUTION.md` -- practices to follow
+- `{projectArtifactsRoot}/config.json` -- project configuration
 
 ## Outputs
 

--- a/core/skills/sw-research/SKILL.md
+++ b/core/skills/sw-research/SKILL.md
@@ -24,12 +24,12 @@ briefs are consumed by sw-design (which has its own gate).
 ## Inputs
 
 - Research topic(s) from argument or conversation context
-- `.specwright/research/` — existing briefs (for deepening or refresh)
-- `.specwright/CHARTER.md` — technology vision (for relevance filtering)
+- `{projectArtifactsRoot}/research/` — existing briefs (for deepening or refresh)
+- `{projectArtifactsRoot}/CHARTER.md` — technology vision (for relevance filtering)
 
 ## Outputs
 
-- `.specwright/research/{topic-id}-{YYYYMMDD}.md` per `protocols/research.md`
+- `{projectArtifactsRoot}/research/{topic-id}-{YYYYMMDD}.md` per `protocols/research.md`
 
 ## Constraints
 
@@ -58,7 +58,7 @@ Low-confidence tracks noted in the brief for consumer awareness. Briefs are
 consumed by sw-design which validates findings at its own gate.
 
 **Persistence (LOW freedom):**
-Write to `.specwright/research/{topic-id}-{YYYYMMDD}.md`. Overwrite same topic+date.
+Write to `{projectArtifactsRoot}/research/{topic-id}-{YYYYMMDD}.md`. Overwrite same topic+date.
 Max 10 briefs. If at cap: log warning, list by date, suggest cleanup.
 Briefs older than 90 days are STALE — warn when loading.
 

--- a/core/skills/sw-sync/SKILL.md
+++ b/core/skills/sw-sync/SKILL.md
@@ -21,7 +21,7 @@ claimed by a live Specwright session or a subordinate helper worktree.
 
 ## Inputs
 
-- `{repoStateRoot}/config.json`
+- `{projectArtifactsRoot}/config.json`
 - `{worktreeStateRoot}/session.json`
 - `{repoStateRoot}/work/*/workflow.json`
 - `git worktree list --porcelain`

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -25,7 +25,7 @@ gate handoff using `protocols/decision.md` template.
 
 - `{worktreeStateRoot}/session.json` -- selected work for this worktree
 - `{repoStateRoot}/work/{selectedWork.id}/workflow.json` -- selected work unit and previous gate results
-- `{repoStateRoot}/config.json` -- gate configuration (object or array format)
+- `{projectArtifactsRoot}/config.json` -- gate configuration (object or array format)
 - `{workDir}/spec.md` -- for spec compliance gate
 - `{workDir}/implementation-rationale.md` -- curated build-time reasoning when present
 - `{workArtifactsRoot}/{selectedWork.id}/integration-criteria.md` -- behavioral IC list for packet and final-unit conformance summary (when present)

--- a/tests/test-audit-chain-migration-surfaces.sh
+++ b/tests/test-audit-chain-migration-surfaces.sh
@@ -12,6 +12,9 @@ AUDIT_SKILL="$ROOT_DIR/core/skills/sw-audit/SKILL.md"
 GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
 RESEARCH_SKILL="$ROOT_DIR/core/skills/sw-research/SKILL.md"
 DEBUG_SKILL="$ROOT_DIR/core/skills/sw-debug/SKILL.md"
+PLAN_SKILL="$ROOT_DIR/core/skills/sw-plan/SKILL.md"
+BUILD_SKILL="$ROOT_DIR/core/skills/sw-build/SKILL.md"
+VERIFY_SKILL="$ROOT_DIR/core/skills/sw-verify/SKILL.md"
 GATE_BUILD_SKILL="$ROOT_DIR/core/skills/gate-build/SKILL.md"
 GATE_SECURITY_SKILL="$ROOT_DIR/core/skills/gate-security/SKILL.md"
 GATE_TESTS_SKILL="$ROOT_DIR/core/skills/gate-tests/SKILL.md"
@@ -75,6 +78,9 @@ for file in \
   "$GUARD_SKILL" \
   "$RESEARCH_SKILL" \
   "$DEBUG_SKILL" \
+  "$PLAN_SKILL" \
+  "$BUILD_SKILL" \
+  "$VERIFY_SKILL" \
   "$GATE_BUILD_SKILL" \
   "$GATE_SECURITY_SKILL" \
   "$GATE_TESTS_SKILL" \
@@ -112,6 +118,11 @@ assert_contains "$RESEARCH_SKILL" "{projectArtifactsRoot}/CHARTER.md" "sw-resear
 assert_contains "$DEBUG_SKILL" "{projectArtifactsRoot}/config.json" "sw-debug reads tracked config from projectArtifactsRoot"
 assert_contains "$DEBUG_SKILL" "{workArtifactsRoot}/{id}/diagnosis.md" "sw-debug writes diagnosis to auditable work artifacts"
 assert_contains "$DEBUG_SKILL" "{workArtifactsRoot}/{id}/spec.md" "sw-debug writes spec to auditable work artifacts"
+assert_contains "$PLAN_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-plan reads constitution from projectArtifactsRoot"
+assert_contains "$PLAN_SKILL" "{projectArtifactsRoot}/config.json" "sw-plan reads tracked config from projectArtifactsRoot"
+assert_contains "$BUILD_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-build reads constitution from projectArtifactsRoot"
+assert_contains "$BUILD_SKILL" "{projectArtifactsRoot}/config.json" "sw-build reads tracked config from projectArtifactsRoot"
+assert_contains "$VERIFY_SKILL" "{projectArtifactsRoot}/config.json" "sw-verify reads tracked config from projectArtifactsRoot"
 assert_contains "$GATE_BUILD_SKILL" "{projectArtifactsRoot}/config.json" "gate-build reads tracked config from projectArtifactsRoot"
 assert_contains "$GATE_SECURITY_SKILL" "{projectArtifactsRoot}/config.json" "gate-security reads tracked config from projectArtifactsRoot"
 assert_contains "$GATE_TESTS_SKILL" "{projectArtifactsRoot}/config.json" "gate-tests reads tracked config from projectArtifactsRoot"

--- a/tests/test-audit-chain-migration-surfaces.sh
+++ b/tests/test-audit-chain-migration-surfaces.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Regression checks for Unit 05 Task 2 — migration and publication-mode docs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SYNC_SKILL="$ROOT_DIR/core/skills/sw-sync/SKILL.md"
+AUDIT_SKILL="$ROOT_DIR/core/skills/sw-audit/SKILL.md"
+GUARD_SKILL="$ROOT_DIR/core/skills/sw-guard/SKILL.md"
+RESEARCH_SKILL="$ROOT_DIR/core/skills/sw-research/SKILL.md"
+DEBUG_SKILL="$ROOT_DIR/core/skills/sw-debug/SKILL.md"
+GATE_BUILD_SKILL="$ROOT_DIR/core/skills/gate-build/SKILL.md"
+GATE_SECURITY_SKILL="$ROOT_DIR/core/skills/gate-security/SKILL.md"
+GATE_TESTS_SKILL="$ROOT_DIR/core/skills/gate-tests/SKILL.md"
+GATE_WIRING_SKILL="$ROOT_DIR/core/skills/gate-wiring/SKILL.md"
+RECOVERY_PROTOCOL="$ROOT_DIR/core/protocols/recovery.md"
+TESTING_STRATEGY_PROTOCOL="$ROOT_DIR/core/protocols/testing-strategy.md"
+DECISION_PROTOCOL="$ROOT_DIR/core/protocols/decision.md"
+BACKLOG_PROTOCOL="$ROOT_DIR/core/protocols/backlog.md"
+RESEARCH_PROTOCOL="$ROOT_DIR/core/protocols/research.md"
+AUDIT_PROTOCOL="$ROOT_DIR/core/protocols/audit.md"
+LANDSCAPE_PROTOCOL="$ROOT_DIR/core/protocols/landscape.md"
+LEARNING_LIFECYCLE_PROTOCOL="$ROOT_DIR/core/protocols/learning-lifecycle.md"
+GUARDRAILS_DETECTION_PROTOCOL="$ROOT_DIR/core/protocols/guardrails-detection.md"
+BUILD_CONTEXT_PROTOCOL="$ROOT_DIR/core/protocols/build-context.md"
+HEADLESS_PROTOCOL="$ROOT_DIR/core/protocols/headless.md"
+EVIDENCE_PROTOCOL="$ROOT_DIR/core/protocols/evidence.md"
+TESTER_AGENT="$ROOT_DIR/core/agents/specwright-tester.md"
+INTEGRATION_TESTER_AGENT="$ROOT_DIR/core/agents/specwright-integration-tester.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+emit_coverage_marker() {
+  printf 'COVERAGE: %s\n' "$1"
+}
+
+assert_contains() {
+  local file="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$label (unexpectedly found: '$needle')"
+  else
+    pass "$label"
+  fi
+}
+
+echo "=== audit-chain migration surfaces ==="
+echo ""
+
+for file in \
+  "$SYNC_SKILL" \
+  "$AUDIT_SKILL" \
+  "$GUARD_SKILL" \
+  "$RESEARCH_SKILL" \
+  "$DEBUG_SKILL" \
+  "$GATE_BUILD_SKILL" \
+  "$GATE_SECURITY_SKILL" \
+  "$GATE_TESTS_SKILL" \
+  "$GATE_WIRING_SKILL" \
+  "$RECOVERY_PROTOCOL" \
+  "$TESTING_STRATEGY_PROTOCOL" \
+  "$DECISION_PROTOCOL" \
+  "$BACKLOG_PROTOCOL" \
+  "$RESEARCH_PROTOCOL" \
+  "$AUDIT_PROTOCOL" \
+  "$LANDSCAPE_PROTOCOL" \
+  "$LEARNING_LIFECYCLE_PROTOCOL" \
+  "$GUARDRAILS_DETECTION_PROTOCOL" \
+  "$BUILD_CONTEXT_PROTOCOL" \
+  "$HEADLESS_PROTOCOL" \
+  "$EVIDENCE_PROTOCOL" \
+  "$TESTER_AGENT" \
+  "$INTEGRATION_TESTER_AGENT"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- Skills use logical roots ---"
+assert_contains "$SYNC_SKILL" "{projectArtifactsRoot}/config.json" "sw-sync reads tracked config from projectArtifactsRoot"
+assert_contains "$AUDIT_SKILL" "{projectArtifactsRoot}/AUDIT.md" "sw-audit persists audit findings under projectArtifactsRoot"
+assert_contains "$AUDIT_SKILL" "{projectArtifactsRoot}/LANDSCAPE.md" "sw-audit reads landscape from projectArtifactsRoot"
+assert_contains "$GUARD_SKILL" "{projectArtifactsRoot}/config.json" "sw-guard reads tracked config from projectArtifactsRoot"
+assert_contains "$GUARD_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-guard reads constitution from projectArtifactsRoot"
+assert_contains "$RESEARCH_SKILL" "{projectArtifactsRoot}/research/" "sw-research uses tracked research root"
+assert_contains "$RESEARCH_SKILL" "{projectArtifactsRoot}/CHARTER.md" "sw-research reads charter from projectArtifactsRoot"
+assert_contains "$DEBUG_SKILL" "{projectArtifactsRoot}/config.json" "sw-debug reads tracked config from projectArtifactsRoot"
+assert_contains "$DEBUG_SKILL" "{workArtifactsRoot}/{id}/diagnosis.md" "sw-debug writes diagnosis to auditable work artifacts"
+assert_contains "$DEBUG_SKILL" "{workArtifactsRoot}/{id}/spec.md" "sw-debug writes spec to auditable work artifacts"
+assert_contains "$GATE_BUILD_SKILL" "{projectArtifactsRoot}/config.json" "gate-build reads tracked config from projectArtifactsRoot"
+assert_contains "$GATE_SECURITY_SKILL" "{projectArtifactsRoot}/config.json" "gate-security reads tracked config from projectArtifactsRoot"
+assert_contains "$GATE_TESTS_SKILL" "{projectArtifactsRoot}/config.json" "gate-tests reads tracked config from projectArtifactsRoot"
+assert_contains "$GATE_TESTS_SKILL" "{projectArtifactsRoot}/TESTING.md" "gate-tests reads TESTING from projectArtifactsRoot"
+assert_contains "$GATE_WIRING_SKILL" "{projectArtifactsRoot}/config.json" "gate-wiring reads tracked config from projectArtifactsRoot"
+
+echo ""
+echo "--- Protocols keep tracked and runtime surfaces split ---"
+assert_contains "$RECOVERY_PROTOCOL" "{projectArtifactsRoot}/CHARTER.md" "recovery reads charter from projectArtifactsRoot"
+assert_contains "$RECOVERY_PROTOCOL" "{projectArtifactsRoot}/CONSTITUTION.md" "recovery reads constitution from projectArtifactsRoot"
+assert_contains "$RECOVERY_PROTOCOL" "{projectArtifactsRoot}/TESTING.md" "recovery reads TESTING from projectArtifactsRoot"
+assert_contains "$TESTING_STRATEGY_PROTOCOL" "{projectArtifactsRoot}/TESTING.md" "testing strategy defines the tracked TESTING path"
+assert_contains "$DECISION_PROTOCOL" "{projectArtifactsRoot}/TESTING.md" "decision protocol promotes testing learnings to projectArtifactsRoot"
+assert_contains "$DECISION_PROTOCOL" "{workArtifactsRoot}/{id}/" "decision protocol stores assumptions under workArtifactsRoot"
+assert_contains "$BACKLOG_PROTOCOL" "{projectArtifactsRoot}/BACKLOG.md" "backlog protocol writes markdown backlog under projectArtifactsRoot"
+assert_contains "$RESEARCH_PROTOCOL" "{projectArtifactsRoot}/research/" "research protocol uses tracked research root"
+assert_contains "$AUDIT_PROTOCOL" "{projectArtifactsRoot}/AUDIT.md" "audit protocol uses tracked AUDIT root"
+assert_contains "$LANDSCAPE_PROTOCOL" "{projectArtifactsRoot}/LANDSCAPE.md" "landscape protocol uses tracked LANDSCAPE root"
+assert_contains "$LEARNING_LIFECYCLE_PROTOCOL" "{projectArtifactsRoot}/CONSTITUTION.md" "learning lifecycle uses tracked constitution path"
+assert_contains "$LEARNING_LIFECYCLE_PROTOCOL" "{projectArtifactsRoot}/patterns.md" "learning lifecycle uses tracked patterns path"
+assert_contains "$LEARNING_LIFECYCLE_PROTOCOL" "{projectArtifactsRoot}/learnings/{work-id}.json" "learning lifecycle uses tracked learnings path"
+assert_contains "$GUARDRAILS_DETECTION_PROTOCOL" "{projectArtifactsRoot}/config.json" "guardrails detection reads tracked config path"
+assert_contains "$BUILD_CONTEXT_PROTOCOL" "{worktreeStateRoot}/continuation.md" "build-context writes continuation to worktreeStateRoot"
+assert_contains "$HEADLESS_PROTOCOL" "{worktreeStateRoot}/continuation.md" "headless protocol writes continuation to worktreeStateRoot"
+assert_contains "$EVIDENCE_PROTOCOL" "{projectArtifactsRoot}/learnings/" "evidence protocol reads calibration from tracked learnings"
+
+echo ""
+echo "--- Agents consume tracked project artifacts ---"
+assert_contains "$TESTER_AGENT" "{projectArtifactsRoot}/TESTING.md" "tester agent reads TESTING from projectArtifactsRoot"
+assert_contains "$INTEGRATION_TESTER_AGENT" "{projectArtifactsRoot}/config.json" "integration tester reads config from projectArtifactsRoot"
+assert_contains "$INTEGRATION_TESTER_AGENT" "{projectArtifactsRoot}/TESTING.md" "integration tester reads TESTING from projectArtifactsRoot"
+
+echo ""
+echo "--- Legacy path guards ---"
+assert_not_contains "$AUDIT_SKILL" ".specwright/AUDIT.md" "sw-audit no longer hardcodes legacy AUDIT path"
+assert_not_contains "$RESEARCH_SKILL" ".specwright/research/" "sw-research no longer hardcodes legacy research path"
+assert_not_contains "$DEBUG_SKILL" ".specwright/work/" "sw-debug no longer hardcodes legacy work path"
+assert_not_contains "$GATE_BUILD_SKILL" ".specwright/config.json" "gate-build no longer hardcodes legacy config path"
+assert_not_contains "$GATE_SECURITY_SKILL" ".specwright/config.json" "gate-security no longer hardcodes legacy config path"
+assert_not_contains "$GATE_TESTS_SKILL" ".specwright/TESTING.md" "gate-tests no longer hardcodes legacy TESTING path"
+assert_not_contains "$GATE_WIRING_SKILL" ".specwright/config.json" "gate-wiring no longer hardcodes legacy config path"
+assert_not_contains "$BACKLOG_PROTOCOL" ".specwright/BACKLOG.md" "backlog protocol no longer hardcodes legacy backlog path"
+assert_not_contains "$RESEARCH_PROTOCOL" ".specwright/research/" "research protocol no longer hardcodes legacy research path"
+assert_not_contains "$AUDIT_PROTOCOL" ".specwright/AUDIT.md" "audit protocol no longer hardcodes legacy AUDIT path"
+assert_not_contains "$LANDSCAPE_PROTOCOL" ".specwright/LANDSCAPE.md" "landscape protocol no longer hardcodes legacy LANDSCAPE path"
+assert_not_contains "$BUILD_CONTEXT_PROTOCOL" ".specwright/state/continuation.md" "build-context no longer hardcodes legacy continuation path"
+assert_not_contains "$HEADLESS_PROTOCOL" ".specwright/state/continuation.md" "headless protocol no longer hardcodes legacy continuation path"
+assert_not_contains "$EVIDENCE_PROTOCOL" ".specwright/learnings/" "evidence protocol no longer hardcodes legacy learnings path"
+assert_not_contains "$TESTER_AGENT" ".specwright/TESTING.md" "tester agent no longer hardcodes legacy TESTING path"
+assert_not_contains "$INTEGRATION_TESTER_AGENT" ".specwright/TESTING.md" "integration tester no longer hardcodes legacy TESTING path"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+emit_coverage_marker "audit-chain.migration-surfaces"

--- a/tests/test-audit-chain-workflow-proof.sh
+++ b/tests/test-audit-chain-workflow-proof.sh
@@ -95,8 +95,14 @@ assert_contains "$SHIP_SKILL" "{workDir}/review-packet.md" "sw-ship consumes rev
 
 echo ""
 echo "--- Approval and stale-chain proof ---"
-HELPER_OUTPUT="$(
-  APPROVALS_HELPER="$APPROVALS_HELPER" TEST_TMPDIR="$TEST_TMPDIR" node --input-type=module <<'EOF'
+HELPER_OUTPUT=""
+HELPER_EXIT=0
+
+if ! command -v node >/dev/null 2>&1; then
+  fail "node is required for the approval-helper proof but was not found"
+else
+  HELPER_OUTPUT="$(
+    APPROVALS_HELPER="$APPROVALS_HELPER" TEST_TMPDIR="$TEST_TMPDIR" node --input-type=module <<'EOF'
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
@@ -188,14 +194,20 @@ process.stdout.write(JSON.stringify({
   rationaleArtifactHashPresent: Boolean(rationaleHash.artifactSetHash)
 }));
 EOF
-)"
-assert_output_contains "$HELPER_OUTPUT" '"designStatus":"APPROVED"' "design approval stays approved when artifact set matches"
-assert_output_contains "$HELPER_OUTPUT" '"unitStatusBefore":"APPROVED"' "unit-spec approval stays approved when artifact set matches"
-assert_output_contains "$HELPER_OUTPUT" '"unitStatusAfter":"STALE"' "unit-spec approval becomes stale when spec changes"
-assert_output_contains "$HELPER_OUTPUT" '"missingDesignStatus":"MISSING"' "missing design lineage is distinguishable from stale lineage"
-assert_output_contains "$HELPER_OUTPUT" '"headlessApprovedRejected":true' "headless approval fabrication is rejected"
-assert_output_contains "$HELPER_OUTPUT" '"roundTripEntries":2' "approvals ledger round-trips both design and unit approvals"
-assert_output_contains "$HELPER_OUTPUT" '"rationaleArtifactHashPresent":true' "workflow proof fixture includes rationale as an auditable artifact"
+  )" || HELPER_EXIT=$?
+
+  if [ "$HELPER_EXIT" -ne 0 ]; then
+    fail "approvals helper node script exited with code $HELPER_EXIT"
+  else
+    assert_output_contains "$HELPER_OUTPUT" '"designStatus":"APPROVED"' "design approval stays approved when artifact set matches"
+    assert_output_contains "$HELPER_OUTPUT" '"unitStatusBefore":"APPROVED"' "unit-spec approval stays approved when artifact set matches"
+    assert_output_contains "$HELPER_OUTPUT" '"unitStatusAfter":"STALE"' "unit-spec approval becomes stale when spec changes"
+    assert_output_contains "$HELPER_OUTPUT" '"missingDesignStatus":"MISSING"' "missing design lineage is distinguishable from stale lineage"
+    assert_output_contains "$HELPER_OUTPUT" '"headlessApprovedRejected":true' "headless approval fabrication is rejected"
+    assert_output_contains "$HELPER_OUTPUT" '"roundTripEntries":2' "approvals ledger round-trips both design and unit approvals"
+    assert_output_contains "$HELPER_OUTPUT" '"rationaleArtifactHashPresent":true' "workflow proof fixture includes rationale as an auditable artifact"
+  fi
+fi
 
 echo ""
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test-audit-chain-workflow-proof.sh
+++ b/tests/test-audit-chain-workflow-proof.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Integrated workflow proof for the audit-chain lifecycle and approval policy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+APPROVALS_PROTOCOL="$ROOT_DIR/core/protocols/approvals.md"
+REVIEW_PACKET_PROTOCOL="$ROOT_DIR/core/protocols/review-packet.md"
+DESIGN_SKILL="$ROOT_DIR/core/skills/sw-design/SKILL.md"
+PLAN_SKILL="$ROOT_DIR/core/skills/sw-plan/SKILL.md"
+BUILD_SKILL="$ROOT_DIR/core/skills/sw-build/SKILL.md"
+VERIFY_SKILL="$ROOT_DIR/core/skills/sw-verify/SKILL.md"
+SHIP_SKILL="$ROOT_DIR/core/skills/sw-ship/SKILL.md"
+APPROVALS_HELPER="$ROOT_DIR/adapters/shared/specwright-approvals.mjs"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local path="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$path"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+assert_output_contains() {
+  local output="$1" needle="$2" label="$3"
+  if printf '%s' "$output" | grep -Fq -- "$needle"; then
+    pass "$label"
+  else
+    fail "$label (not found: '$needle')"
+  fi
+}
+
+emit_coverage_marker() {
+  printf 'COVERAGE: %s\n' "$1"
+}
+
+echo "=== audit-chain workflow proof ==="
+echo ""
+
+for file in \
+  "$APPROVALS_PROTOCOL" \
+  "$REVIEW_PACKET_PROTOCOL" \
+  "$DESIGN_SKILL" \
+  "$PLAN_SKILL" \
+  "$BUILD_SKILL" \
+  "$VERIFY_SKILL" \
+  "$SHIP_SKILL" \
+  "$APPROVALS_HELPER"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#"$ROOT_DIR"/}"
+  else
+    fail "exists: ${file#"$ROOT_DIR"/}"
+  fi
+done
+
+echo ""
+echo "--- Lifecycle chain contract ---"
+assert_contains "$DESIGN_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-design loads constitution from projectArtifactsRoot"
+assert_contains "$DESIGN_SKILL" "{projectArtifactsRoot}/CHARTER.md" "sw-design loads charter from projectArtifactsRoot"
+assert_contains "$DESIGN_SKILL" "{projectArtifactsRoot}/config.json" "sw-design loads config from projectArtifactsRoot"
+assert_contains "$PLAN_SKILL" "Interactive \`/sw-plan\` runs may write an \`APPROVED\` \`design\` entry" "sw-plan records design approval on entry"
+assert_contains "$PLAN_SKILL" "headless runs must validate existing human approval" "sw-plan keeps headless approval fail-closed"
+assert_contains "$PLAN_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-plan loads constitution from projectArtifactsRoot"
+assert_contains "$PLAN_SKILL" "{projectArtifactsRoot}/config.json" "sw-plan loads config from projectArtifactsRoot"
+assert_contains "$BUILD_SKILL" "Interactive \`/sw-build\` runs may record an \`APPROVED\` \`unit-spec\` entry" "sw-build records unit-spec approval on entry"
+assert_contains "$BUILD_SKILL" "{workDir}/implementation-rationale.md" "sw-build produces implementation rationale"
+assert_contains "$BUILD_SKILL" "{projectArtifactsRoot}/CONSTITUTION.md" "sw-build loads constitution from projectArtifactsRoot"
+assert_contains "$BUILD_SKILL" "{projectArtifactsRoot}/config.json" "sw-build loads config from projectArtifactsRoot"
+assert_contains "$VERIFY_SKILL" "Approval Lineage" "sw-verify reports approval lineage separately"
+assert_contains "$VERIFY_SKILL" "Missing, \`STALE\`, or" "sw-verify surfaces incomplete or stale approval lineage"
+assert_contains "$VERIFY_SKILL" "never create \`APPROVED\` entries" "sw-verify keeps headless verification fail-closed"
+assert_contains "$VERIFY_SKILL" "{workDir}/review-packet.md" "sw-verify synthesizes review-packet.md"
+assert_contains "$VERIFY_SKILL" "{projectArtifactsRoot}/config.json" "sw-verify loads config from projectArtifactsRoot"
+assert_contains "$REVIEW_PACKET_PROTOCOL" "reviewer-facing PR body" "review-packet protocol makes ship a live consumer"
+assert_contains "$SHIP_SKILL" "{workDir}/review-packet.md" "sw-ship consumes review-packet.md"
+
+echo ""
+echo "--- Approval and stale-chain proof ---"
+HELPER_OUTPUT="$(
+  APPROVALS_HELPER="$APPROVALS_HELPER" TEST_TMPDIR="$TEST_TMPDIR" node --input-type=module <<'EOF'
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const helperPath = pathToFileURL(process.env.APPROVALS_HELPER).href;
+const tmpDir = process.env.TEST_TMPDIR;
+const helper = await import(helperPath);
+const {
+  assessApprovalEntry,
+  createApprovalEntry,
+  hashApprovalArtifacts,
+  loadApprovalsFile,
+  recordApproval,
+  writeApprovalsFile
+} = helper;
+
+const workRoot = join(tmpDir, 'audit-chain');
+const unitRoot = join(workRoot, 'units', '05-workflow-proof-and-migration');
+mkdirSync(unitRoot, { recursive: true });
+
+writeFileSync(join(workRoot, 'design.md'), 'design v1\n', 'utf8');
+writeFileSync(join(workRoot, 'context.md'), 'design context v1\n', 'utf8');
+writeFileSync(join(workRoot, 'decisions.md'), 'decision v1\n', 'utf8');
+writeFileSync(join(unitRoot, 'spec.md'), 'spec v1\n', 'utf8');
+writeFileSync(join(unitRoot, 'plan.md'), 'plan v1\n', 'utf8');
+writeFileSync(join(unitRoot, 'context.md'), 'unit context v1\n', 'utf8');
+writeFileSync(join(unitRoot, 'implementation-rationale.md'), 'rationale v1\n', 'utf8');
+
+let doc = recordApproval(null, {
+  baseDir: workRoot,
+  scope: 'design',
+  artifacts: ['design.md', 'context.md', 'decisions.md'],
+  sourceClassification: 'command',
+  sourceRef: '/sw-plan',
+  approvedAt: '2026-04-16T00:00:00Z'
+});
+
+doc = recordApproval(doc, {
+  baseDir: unitRoot,
+  scope: 'unit-spec',
+  unitId: '05-workflow-proof-and-migration',
+  artifacts: ['spec.md', 'plan.md', 'context.md'],
+  sourceClassification: 'command',
+  sourceRef: '/sw-build',
+  approvedAt: '2026-04-16T00:10:00Z'
+});
+
+const approvalsPath = join(workRoot, 'approvals.md');
+writeApprovalsFile(approvalsPath, doc);
+const loaded = loadApprovalsFile(approvalsPath);
+
+const designEntry = loaded.entries.find((entry) => entry.scope === 'design');
+const unitEntry = loaded.entries.find((entry) => entry.scope === 'unit-spec');
+
+const designStatus = assessApprovalEntry(designEntry, { baseDir: workRoot }).status;
+const unitStatusBefore = assessApprovalEntry(unitEntry, { baseDir: unitRoot }).status;
+
+writeFileSync(join(unitRoot, 'spec.md'), 'spec v2\n', 'utf8');
+const unitStatusAfter = assessApprovalEntry(unitEntry, { baseDir: unitRoot }).status;
+const missingDesignStatus = assessApprovalEntry(null, {
+  baseDir: workRoot,
+  artifacts: ['design.md', 'context.md', 'decisions.md']
+}).status;
+
+let headlessApprovedRejected = false;
+try {
+  createApprovalEntry({
+    baseDir: unitRoot,
+    scope: 'unit-spec',
+    unitId: '05-workflow-proof-and-migration',
+    artifacts: ['spec.md', 'plan.md', 'context.md'],
+    sourceClassification: 'headless-check',
+    sourceRef: 'ci',
+    approvedAt: '2026-04-16T00:20:00Z'
+  });
+} catch {
+  headlessApprovedRejected = true;
+}
+
+const rationaleHash = hashApprovalArtifacts(unitRoot, ['implementation-rationale.md']);
+
+process.stdout.write(JSON.stringify({
+  designStatus,
+  unitStatusBefore,
+  unitStatusAfter,
+  missingDesignStatus,
+  headlessApprovedRejected,
+  roundTripEntries: loaded.entries.length,
+  rationaleArtifactHashPresent: Boolean(rationaleHash.artifactSetHash)
+}));
+EOF
+)"
+assert_output_contains "$HELPER_OUTPUT" '"designStatus":"APPROVED"' "design approval stays approved when artifact set matches"
+assert_output_contains "$HELPER_OUTPUT" '"unitStatusBefore":"APPROVED"' "unit-spec approval stays approved when artifact set matches"
+assert_output_contains "$HELPER_OUTPUT" '"unitStatusAfter":"STALE"' "unit-spec approval becomes stale when spec changes"
+assert_output_contains "$HELPER_OUTPUT" '"missingDesignStatus":"MISSING"' "missing design lineage is distinguishable from stale lineage"
+assert_output_contains "$HELPER_OUTPUT" '"headlessApprovedRejected":true' "headless approval fabrication is rejected"
+assert_output_contains "$HELPER_OUTPUT" '"roundTripEntries":2' "approvals ledger round-trips both design and unit approvals"
+assert_output_contains "$HELPER_OUTPUT" '"rationaleArtifactHashPresent":true' "workflow proof fixture includes rationale as an auditable artifact"
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+emit_coverage_marker "audit-chain.workflow-proof"

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -37,6 +37,8 @@ LIFECYCLE_FRESHNESS_TEST="$ROOT_DIR/tests/test-lifecycle-freshness-checkpoints.s
 WORKFLOW_PROOF_TEST="$ROOT_DIR/tests/test-workflow-proof.sh"
 CONFIG_VISIBILITY_DOCS_TEST="$ROOT_DIR/tests/test-config-validation-visibility-docs.sh"
 AUDIT_CHAIN_ROOT_MODEL_TEST="$ROOT_DIR/tests/test-audit-chain-root-model.sh"
+AUDIT_CHAIN_WORKFLOW_PROOF_TEST="$ROOT_DIR/tests/test-audit-chain-workflow-proof.sh"
+AUDIT_CHAIN_MIGRATION_SURFACES_TEST="$ROOT_DIR/tests/test-audit-chain-migration-surfaces.sh"
 APPROVAL_LIFECYCLE_TEST="$ROOT_DIR/tests/test-approval-lifecycle-docs.sh"
 REVIEW_PACKET_DOCS_TEST="$ROOT_DIR/tests/test-review-packet-docs.sh"
 SUPPORT_SURFACE_CUTOVER_TEST="$ROOT_DIR/tests/test-support-surface-cutover-docs.sh"
@@ -214,6 +216,16 @@ run_smoke_checks() {
     "approval lifecycle" \
     "SPECWRIGHT_APPROVAL_LIFECYCLE_MODE=smoke bash \"$APPROVAL_LIFECYCLE_TEST\"" \
     "COVERAGE: approval-lifecycle.fail-closed"
+
+  run_smoke_regression \
+    "audit-chain workflow proof" \
+    "bash \"$AUDIT_CHAIN_WORKFLOW_PROOF_TEST\"" \
+    "COVERAGE: audit-chain.workflow-proof"
+
+  run_smoke_regression \
+    "audit-chain migration surfaces" \
+    "bash \"$AUDIT_CHAIN_MIGRATION_SURFACES_TEST\"" \
+    "COVERAGE: audit-chain.migration-surfaces"
 
   run_smoke_regression \
     "support-surface cutover" \
@@ -1232,7 +1244,7 @@ HARNESS_EXIT=0
 HARNESS_OUTPUT="$(bash "$MULTI_WORKTREE_RUNTIME_TEST" 2>&1)" || HARNESS_EXIT=$?
 
 if [ "$HARNESS_EXIT" -ne 0 ]; then
-  fail "tests/test-multi-worktree-state.sh passes under the configured test path"
+  fail "tests/test-multi-worktree-state.sh fails under the configured test path"
   echo "  Harness output:"
   printf '    %s\n' "${HARNESS_OUTPUT//$'\n'/$'\n    '}"
 else
@@ -1262,7 +1274,7 @@ TARGET_MODEL_EXIT=0
 TARGET_MODEL_OUTPUT="$(bash "$TARGET_MODEL_DOCS_TEST" 2>&1)" || TARGET_MODEL_EXIT=$?
 
 if [ "$TARGET_MODEL_EXIT" -ne 0 ]; then
-  fail "tests/test-branch-freshness-target-model-docs.sh passes under the configured test path"
+  fail "tests/test-branch-freshness-target-model-docs.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${TARGET_MODEL_OUTPUT//$'\n'/$'\n    '}"
 else
@@ -1287,7 +1299,7 @@ GIT_FRESHNESS_EXIT=0
 GIT_FRESHNESS_OUTPUT="$(bash "$GIT_FRESHNESS_ENGINE_TEST" 2>&1)" || GIT_FRESHNESS_EXIT=$?
 
 if [ "$GIT_FRESHNESS_EXIT" -ne 0 ]; then
-  fail "tests/test-git-freshness-engine.sh passes under the configured test path"
+  fail "tests/test-git-freshness-engine.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${GIT_FRESHNESS_OUTPUT//$'\n'/$'\n    '}"
 else
@@ -1312,7 +1324,7 @@ LIFECYCLE_FRESHNESS_EXIT=0
 LIFECYCLE_FRESHNESS_OUTPUT="$(bash "$LIFECYCLE_FRESHNESS_TEST" 2>&1)" || LIFECYCLE_FRESHNESS_EXIT=$?
 
 if [ "$LIFECYCLE_FRESHNESS_EXIT" -ne 0 ]; then
-  fail "tests/test-lifecycle-freshness-checkpoints.sh passes under the configured test path"
+  fail "tests/test-lifecycle-freshness-checkpoints.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${LIFECYCLE_FRESHNESS_OUTPUT//$'\n'/$'\n    '}"
 else
@@ -1389,7 +1401,7 @@ AUDIT_CHAIN_ROOT_MODEL_EXIT=0
 AUDIT_CHAIN_ROOT_MODEL_OUTPUT="$(bash "$AUDIT_CHAIN_ROOT_MODEL_TEST" 2>&1)" || AUDIT_CHAIN_ROOT_MODEL_EXIT=$?
 
 if [ "$AUDIT_CHAIN_ROOT_MODEL_EXIT" -ne 0 ]; then
-  fail "tests/test-audit-chain-root-model.sh passes under the configured test path"
+  fail "tests/test-audit-chain-root-model.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${AUDIT_CHAIN_ROOT_MODEL_OUTPUT//$'\n'/$'\n    '}"
 else
@@ -1399,6 +1411,56 @@ if echo "$AUDIT_CHAIN_ROOT_MODEL_OUTPUT" | grep -Fq "PASS: tracked mode routes s
   pass "audit-chain root-model regression output includes tracked-root coverage"
 else
   fail "audit-chain root-model regression output missing tracked-root coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Audit-chain workflow proof ==="
+
+if [ -x "$AUDIT_CHAIN_WORKFLOW_PROOF_TEST" ]; then
+  pass "tests/test-audit-chain-workflow-proof.sh is executable"
+else
+  fail "tests/test-audit-chain-workflow-proof.sh is missing or not executable"
+fi
+
+AUDIT_CHAIN_WORKFLOW_EXIT=0
+AUDIT_CHAIN_WORKFLOW_OUTPUT="$(bash "$AUDIT_CHAIN_WORKFLOW_PROOF_TEST" 2>&1)" || AUDIT_CHAIN_WORKFLOW_EXIT=$?
+
+if [ "$AUDIT_CHAIN_WORKFLOW_EXIT" -ne 0 ]; then
+  fail "tests/test-audit-chain-workflow-proof.sh fails under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${AUDIT_CHAIN_WORKFLOW_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-audit-chain-workflow-proof.sh passes under the configured test path"
+fi
+if [ "$AUDIT_CHAIN_WORKFLOW_EXIT" -eq 0 ] && echo "$AUDIT_CHAIN_WORKFLOW_OUTPUT" | grep -Fq "COVERAGE: audit-chain.workflow-proof"; then
+  pass "audit-chain workflow proof output includes lifecycle coverage"
+else
+  fail "audit-chain workflow proof output missing lifecycle coverage"
+fi
+
+echo ""
+echo "=== Supplemental regression: Audit-chain migration surfaces ==="
+
+if [ -x "$AUDIT_CHAIN_MIGRATION_SURFACES_TEST" ]; then
+  pass "tests/test-audit-chain-migration-surfaces.sh is executable"
+else
+  fail "tests/test-audit-chain-migration-surfaces.sh is missing or not executable"
+fi
+
+AUDIT_CHAIN_MIGRATION_EXIT=0
+AUDIT_CHAIN_MIGRATION_OUTPUT="$(bash "$AUDIT_CHAIN_MIGRATION_SURFACES_TEST" 2>&1)" || AUDIT_CHAIN_MIGRATION_EXIT=$?
+
+if [ "$AUDIT_CHAIN_MIGRATION_EXIT" -ne 0 ]; then
+  fail "tests/test-audit-chain-migration-surfaces.sh fails under the configured test path"
+  echo "  Regression output:"
+  printf '    %s\n' "${AUDIT_CHAIN_MIGRATION_OUTPUT//$'\n'/$'\n    '}"
+else
+  pass "tests/test-audit-chain-migration-surfaces.sh passes under the configured test path"
+fi
+if [ "$AUDIT_CHAIN_MIGRATION_EXIT" -eq 0 ] && echo "$AUDIT_CHAIN_MIGRATION_OUTPUT" | grep -Fq "COVERAGE: audit-chain.migration-surfaces"; then
+  pass "audit-chain migration surfaces output includes publication-mode coverage"
+else
+  fail "audit-chain migration surfaces output missing publication-mode coverage"
 fi
 
 echo ""
@@ -1439,7 +1501,7 @@ REVIEW_PACKET_EXIT=0
 REVIEW_PACKET_OUTPUT="$(bash "$REVIEW_PACKET_DOCS_TEST" 2>&1)" || REVIEW_PACKET_EXIT=$?
 
 if [ "$REVIEW_PACKET_EXIT" -ne 0 ]; then
-  fail "tests/test-review-packet-docs.sh passes under the configured test path"
+  fail "tests/test-review-packet-docs.sh fails under the configured test path"
   echo "  Regression output:"
   printf '    %s\n' "${REVIEW_PACKET_OUTPUT//$'\n'/$'\n    '}"
 else

--- a/tests/test-opencode-build.sh
+++ b/tests/test-opencode-build.sh
@@ -348,7 +348,7 @@ else
 fi
 
 if grep -Fq ".specwright/state/continuation.md" "$OC_DIST/protocols/build-context.md"; then
-  fail "dist build-context removes legacy continuation path"
+  fail "dist build-context still contains legacy continuation path (.specwright/state/continuation.md)"
 else
   pass "dist build-context removes legacy continuation path"
 fi

--- a/tests/test-opencode-build.sh
+++ b/tests/test-opencode-build.sh
@@ -315,6 +315,44 @@ if [ -d "$OC_DIST/protocols" ]; then
   done
 fi
 
+echo "--- Audit-chain root split spot-checks ---"
+
+if grep -Fq "{projectArtifactsRoot}/config.json" "$OC_DIST/skills/sw-sync/SKILL.md"; then
+  pass "dist sw-sync preserves projectArtifactsRoot config path"
+else
+  fail "dist sw-sync preserves projectArtifactsRoot config path"
+fi
+
+if grep -Fq "{projectArtifactsRoot}/research/" "$OC_DIST/skills/sw-research/SKILL.md"; then
+  pass "dist sw-research preserves tracked research root"
+else
+  fail "dist sw-research preserves tracked research root"
+fi
+
+if grep -Fq "{worktreeStateRoot}/continuation.md" "$OC_DIST/protocols/build-context.md"; then
+  pass "dist build-context preserves worktree-local continuation path"
+else
+  fail "dist build-context preserves worktree-local continuation path"
+fi
+
+if grep -Fq "{projectArtifactsRoot}/learnings/" "$OC_DIST/protocols/evidence.md"; then
+  pass "dist evidence protocol preserves tracked learnings path"
+else
+  fail "dist evidence protocol preserves tracked learnings path"
+fi
+
+if grep -Fq "{projectArtifactsRoot}/TESTING.md" "$OC_DIST/agents/specwright-integration-tester.md"; then
+  pass "dist integration tester preserves tracked TESTING path"
+else
+  fail "dist integration tester preserves tracked TESTING path"
+fi
+
+if grep -Fq ".specwright/state/continuation.md" "$OC_DIST/protocols/build-context.md"; then
+  fail "dist build-context removes legacy continuation path"
+else
+  pass "dist build-context removes legacy continuation path"
+fi
+
 # ─── README.md ────────────────────────────────────────────────────────
 
 echo "--- README.md ---"

--- a/tests/test-sw-sync-skill.sh
+++ b/tests/test-sw-sync-skill.sh
@@ -118,7 +118,7 @@ done
 
 echo ""
 echo "--- Shared/session inputs ---"
-assert_contains "$SKILL_FILE" '{repoStateRoot}/config.json' "uses shared config path"
+assert_contains "$SKILL_FILE" '{projectArtifactsRoot}/config.json' "uses tracked project config path"
 assert_contains "$SKILL_FILE" '{worktreeStateRoot}/session.json' "uses per-worktree session path"
 assert_contains "$SKILL_FILE" '{repoStateRoot}/work/*/workflow.json' "uses per-work workflow enumeration"
 
@@ -136,6 +136,7 @@ assert_contains "$SKILL_FILE" 'skip deletion and report candidates only' "docume
 
 echo ""
 echo "--- Singleton drift guards ---"
+assert_not_contains "$SKILL_FILE" '.specwright/config.json' "does not reference legacy tracked config path directly"
 assert_not_contains "$SKILL_FILE" '.specwright/state/workflow.json' "does not reference legacy singleton workflow path"
 assert_not_contains "$SKILL_FILE" 'currentWork.branch' "does not rely on currentWork.branch"
 assert_not_contains "$SKILL_FILE" 'active feature branch reference' "does not describe the old active-feature-branch shortcut"


### PR DESCRIPTION
## Summary

This final unit closes the `agentic-audit-chain` work by proving the full audit lifecycle for agentic SWE: approved intent, durable unit approvals, curated implementation rationale, verify-time review-packet synthesis, and adapter validation on the repo's normal build paths.

## Approval Lineage

- `design`: `MISSING`. No durable design approval entry exists for the current `design.md` / `context.md` / `decisions.md` artifact set.
- `unit-spec`: `STALE`. The `/sw-build` approval recorded at `2026-04-16T06:54:35Z` no longer matches the current `spec.md` / `plan.md` / `context.md` artifact set.
- Publication mode: `clone-local`. Reviewer-critical audit details are inlined here instead of relying on local-only artifact links.

## What Changed

- Added an integrated workflow proof so the audit chain is validated as a lifecycle: approved design and unit-spec inputs, build-time rationale capture, verify-time review-packet synthesis, and fail-closed approval handling.
- Finished the remaining migration surfaces across support skills, shared protocols, and agent prompts so tracked project artifacts resolve from `projectArtifactsRoot`, auditable work artifacts stay under `workArtifactsRoot`, and runtime continuation stays local to `worktreeStateRoot`.
- Wired the new workflow-proof and migration-surface regressions into the default Claude validation path, the Claude smoke path, and Opencode packaging spot checks.

## Why The Agent Implemented It This Way

- The workflow proof is centralized in one integrated regression because reviewers need proof of the audit chain as a lifecycle, not as disconnected surface assertions.
- The migration pass targets skills, protocols, and agent prompts together because the main usability risk is drift between tracked project guidance, auditable work artifacts, and clone-local runtime state across different entry points.
- Adapter validation is done through the existing Claude and Opencode harnesses so the proof travels through the same packaging and CI paths users actually rely on.

## Acceptance Criteria

- `AC-1` `PASS` — deterministic migration coverage now runs through the normal validation path via `tests/test-audit-chain-migration-surfaces.sh`, `tests/test-claude-code-build.sh`, and `tests/test-opencode-build.sh`.
- `AC-2` `PASS` — the integrated workflow proof covers approval capture, rationale generation, packet synthesis, and stale-chain failure modes via `tests/test-audit-chain-workflow-proof.sh`.
- `AC-3` `PASS` — headless and policy checks prove Specwright does not fabricate human approval and explicitly surfaces missing or stale lineage.
- `AC-4` `PASS` — Claude and Opencode packaging harnesses remain green with the new root and audit-chain terminology.
- `AC-5` `PASS` — runtime-only state remains local; `workflow.json`, `session.json`, locks, attachments, continuation, and `stage-report.md` are not treated as remotely auditable artifacts.

## Spec Conformance

- All five unit acceptance criteria passed with implementation and regression evidence.
- Final-unit deliverable verification also passed all behavioral criteria: `IC-B1` through `IC-B5` are proven for design approval capture, unit-spec freshness, rationale and packet reviewability, ship publication behavior, and review-context grounding.
- Deliverable verification still surfaced two non-blocking configuration warnings: `commands.test:integration` and `commands.test:e2e` are not configured in shared project config.

## Gate Summary

| Gate | Status | Notes |
|---|---|---|
| build | PASS | `bash build/build.sh` rebuilt `claude-code`, `opencode`, and `codex` successfully |
| tests | PASS | `python -m pytest evals/tests/ -v && bash tests/test-claude-code-build.sh` passed; `pytest` reported `902 passed, 1 skipped, 3 deselected`, Claude harness `260 passed, 0 failed` |
| security | PASS | No secrets, credential files, or risky shell patterns introduced |
| wiring | PASS | Lifecycle skills, migration surfaces, and adapter validation paths align on the same root split and audit-chain model |
| semantic | PASS | No candidate semantic findings in the changed executable shell paths |
| spec | PASS | All unit ACs and final behavioral ICs have proof |

## Remaining Attention

- Durable `design` approval is still missing.
- Current `unit-spec` approval is stale against the latest unit artifact set.
- `commands.test:integration` is not configured for final deliverable verification.
- `commands.test:e2e` is not configured for final deliverable verification.
- No gate-level BLOCK or FAIL findings remain.

## Evidence Links

- Clone-local mode: reviewer-critical audit details are inlined above.
- Standard validation path:
  - `bash build/build.sh`
  - `python -m pytest evals/tests/ -v && bash tests/test-claude-code-build.sh`
- Canonical evidence sources during terminal review:
  - `units/05-workflow-proof-and-migration/evidence/build-report.md`
  - `units/05-workflow-proof-and-migration/evidence/test-quality.md`
  - `units/05-workflow-proof-and-migration/evidence/security-report.md`
  - `units/05-workflow-proof-and-migration/evidence/wiring-report.md`
  - `units/05-workflow-proof-and-migration/evidence/semantic-report.md`
  - `units/05-workflow-proof-and-migration/evidence/spec-compliance.md`
