### PR TITLE
feat(mutation): add tiered mutation analysis

### DIFF
--- a/core/agents/specwright-tester.md
+++ b/core/agents/specwright-tester.md
@@ -73,7 +73,17 @@ that don't exist yet. Note the test type and rationale for each test.
 
 ## Structured mutation analysis
 
-Apply during test authoring and as post-hoc audit. Evaluate three bypass classes:
+Apply during test authoring and as post-hoc audit. Use the same mutation tiers
+as `gate-tests`:
+
+- **T1**: tool-backed mutation run when a configured mutation tool is available
+- **T2**: LLM-generated mutation check when T1 is uninformative or the fallback path is active
+- **T3**: qualitative floor when tool-backed or fallback analysis cannot produce a reliable result
+
+Before reporting survivors, preprocess equivalent-mutant candidates so the
+review stays focused on actionable defects rather than impossible kills.
+
+Evaluate three bypass classes:
 
 1. **Hardcoded returns**: Could a lookup table or hardcoded values pass?
 2. **Partial implementations**: Could implementing half the requirements pass?
@@ -83,6 +93,15 @@ Per class, report:
 - **PASS**: cite specific tests that catch this bypass (file:line)
 - **WARN**: gap exists but low-risk
 - **BLOCK**: construct a concrete bypassing implementation; no test catches it
+
+When surfacing verify-time survivor evidence, use the restricted record only:
+operator, location, before/after, defect category, and action. No test bodies.
+No assertion literals.
+
+During RED phase, build-time mutation pressure is advisory only. If tool-backed
+mutation analysis runs, keep it scoped to the test-in-progress or current
+change. Tool-backed mutation errors do not block TDD completion; report them as
+notes for the orchestrator so `/sw-verify` can rerun the authoritative pass.
 
 Overall mutation resistance = worst of the three verdicts.
 

--- a/core/skills/gate-tests/SKILL.md
+++ b/core/skills/gate-tests/SKILL.md
@@ -49,8 +49,8 @@ test quality, not just pass/fail.
   - **Error paths**: Are failure scenarios tested? (network down, invalid input)
   - **Behavior focus**: Do tests verify behavior or implementation details?
   - **Mutation resistance**: Keep mutation analysis inside the existing tests gate; do not invent a separate mutation gate or let missing tools short-circuit the audit. Route missing-tool cases through T2 or T3. Use T1 / T2 / T3 as the only mutation tiers:
-    - **T1**: configured tool-backed mutation run. Report concrete file:line evidence plus mutation score or survivor details when available.
-    - **T2**: LLM-generated mutation check when zero applicable mutants make T1 uninformative or when the configured LLM fallback is the active path. Report concrete file:line evidence plus the generated survivor details.
+    - **T1**: configured tool-backed mutation run. Report concrete file:line evidence plus mutation score or restricted survivor details when available: operator, location, before/after, defect category, and action.
+    - **T2**: LLM-generated mutation check when zero applicable mutants make T1 uninformative or when the configured LLM fallback is the active path. Report concrete file:line evidence plus the same restricted survivor details: operator, location, before/after, defect category, and action.
     - **T3**: qualitative floor when T1 errors, T2 errors, or fallback unavailable would otherwise leave the gate blind. Audit the three bypass classes: hardcoded returns, partial implementations, boundary skips.
     - Honor accepted-mutant lineage through the shared approval record and config contract instead of silently waiving survivors.
   - **Boundary test approach**: Validate mock-vs-integration decisions against TESTING.md boundary classifications per `protocols/testing-strategy.md`. WARN if internal boundary is mocked. INFO if TESTING.md absent.

--- a/core/skills/gate-tests/SKILL.md
+++ b/core/skills/gate-tests/SKILL.md
@@ -48,7 +48,7 @@ test quality, not just pass/fail.
   - **Mock discipline**: Are mocks justified? Are integration boundaries real?
   - **Error paths**: Are failure scenarios tested? (network down, invalid input)
   - **Behavior focus**: Do tests verify behavior or implementation details?
-  - **Mutation resistance**: Keep mutation analysis inside the existing tests gate; do not invent a separate mutation gate or let missing tools short-circuit the audit. Route missing-tool cases through T2 or T3. Use T1 / T2 / T3 as the only mutation tiers:
+  - **Mutation resistance**: Tiered analysis (T1/T2/T3) stays inside this gate; missing tools route to T2/T3, never a skip.
     - **T1**: configured tool-backed mutation run. Report concrete file:line evidence plus mutation score or restricted survivor details when available: operator, location, before/after, defect category, and action.
     - **T2**: LLM-generated mutation check when zero applicable mutants make T1 uninformative or when the configured LLM fallback is the active path. Report concrete file:line evidence plus the same restricted survivor details: operator, location, before/after, defect category, and action.
     - **T3**: qualitative floor when T1 errors, T2 errors, or fallback unavailable would otherwise leave the gate blind. Audit the three bypass classes: hardcoded returns, partial implementations, boundary skips.

--- a/core/skills/gate-tests/SKILL.md
+++ b/core/skills/gate-tests/SKILL.md
@@ -48,7 +48,11 @@ test quality, not just pass/fail.
   - **Mock discipline**: Are mocks justified? Are integration boundaries real?
   - **Error paths**: Are failure scenarios tested? (network down, invalid input)
   - **Behavior focus**: Do tests verify behavior or implementation details?
-  - **Mutation resistance**: Could a trivially wrong implementation pass? Test against three bypass classes: hardcoded returns, partial implementations, boundary skips.
+  - **Mutation resistance**: Keep mutation analysis inside the existing tests gate; do not invent a separate mutation gate or let missing tools short-circuit the audit. Route missing-tool cases through T2 or T3. Use T1 / T2 / T3 as the only mutation tiers:
+    - **T1**: configured tool-backed mutation run. Report concrete file:line evidence plus mutation score or survivor details when available.
+    - **T2**: LLM-generated mutation check when zero applicable mutants make T1 uninformative or when the configured LLM fallback is the active path. Report concrete file:line evidence plus the generated survivor details.
+    - **T3**: qualitative floor when T1 errors, T2 errors, or fallback unavailable would otherwise leave the gate blind. Audit the three bypass classes: hardcoded returns, partial implementations, boundary skips.
+    - Honor accepted-mutant lineage through the shared approval record and config contract instead of silently waiving survivors.
   - **Boundary test approach**: Validate mock-vs-integration decisions against TESTING.md boundary classifications per `protocols/testing-strategy.md`. WARN if internal boundary is mocked. INFO if TESTING.md absent.
   - **Tier distribution**: For each AC tagged with `[tier: integration]`, `[tier: contract]`, or `[tier: e2e]`, check whether corresponding tests exist at that tier. Use heuristics: integration tests touch multiple modules and use real infrastructure (Testcontainers, real DB, httptest with real handler); contract tests validate schema or shape at a boundary; E2E tests exercise a full flow. Verdicts: non-unit ACs with matching tier tests that pass → PASS. Non-unit ACs with tier-appropriate tests that fail → BLOCK (forces user decision at gate). Non-unit ACs with only unit-tier tests → BLOCK. Zero non-unit ACs in spec → PASS (nothing to check). When no tier-tagged ACs exist and TESTING.md is absent → INFO (no data to validate, no false positives).
 - Each weakness is a finding with severity and file:line reference.

--- a/evals/tests/_text_helpers.py
+++ b/evals/tests/_text_helpers.py
@@ -1,0 +1,22 @@
+"""Shared helpers for markdown contract tests."""
+
+import re
+
+
+def load_text(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def assert_multiline_regex(testcase, text, pattern):
+    testcase.assertIsNotNone(
+        re.search(pattern, text, re.DOTALL),
+        f"pattern not found: {pattern}",
+    )
+
+
+def assert_not_multiline_regex(testcase, text, pattern):
+    testcase.assertIsNone(
+        re.search(pattern, text, re.DOTALL),
+        f"unexpected pattern found: {pattern}",
+    )

--- a/evals/tests/test_mutation_contract_foundation.py
+++ b/evals/tests/test_mutation_contract_foundation.py
@@ -7,8 +7,9 @@ supported mutation tools and three detection states.
 
 import json
 import os
-import re
 import unittest
+
+from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -22,20 +23,8 @@ _BUILD_QUALITY_PATH = os.path.join(
 
 
 def _load_json(path):
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
-
-
-def _load_text(path):
-    with open(path, "r") as f:
-        return f.read()
-
-
-def _assert_multiline_regex(testcase, text, pattern):
-    testcase.assertIsNotNone(
-        re.search(pattern, text, re.DOTALL),
-        f"pattern not found: {pattern}",
-    )
 
 
 class TestMutationConfigExists(unittest.TestCase):
@@ -115,7 +104,7 @@ class TestMutationDetectionProtocol(unittest.TestCase):
     """AC-2 + AC-6: detection protocol names supported tools and states."""
 
     def setUp(self):
-        self.content = _load_text(_DETECTION_PATH)
+        self.content = load_text(_DETECTION_PATH)
         self.lower = self.content.lower()
 
     def test_lists_supported_mutation_tools(self):
@@ -132,21 +121,21 @@ class TestMutationDetectionProtocol(unittest.TestCase):
                 self.assertIn(tool, self.lower)
 
     def test_mentions_configured_state(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(installed|tool).{0,40}(config|configured).{0,80}(t1|tool-backed|mutation)",
         )
 
     def test_mentions_installed_but_unconfigured_state(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(installed|binary).{0,80}(no config|unconfigured|without config)",
         )
 
     def test_mentions_absent_state(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(no tool|tool absent|neither present|not installed)",
@@ -159,10 +148,10 @@ class TestMutationDetectionProtocol(unittest.TestCase):
             r"(no tool|tool absent|neither present|not installed)",
         ]
         for pattern in patterns:
-            _assert_multiline_regex(self, self.lower, pattern)
+            assert_multiline_regex(self, self.lower, pattern)
 
     def test_t3_fallback_names_the_qualitative_bypass_classes(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t3.{0,80}hardcoded returns.+partial implementations.+boundary skips",
@@ -173,35 +162,35 @@ class TestMutationEvidenceProtocol(unittest.TestCase):
     """AC-3 + AC-6: evidence protocol documents tiered mutation disclosures."""
 
     def setUp(self):
-        self.content = _load_text(_EVIDENCE_PATH)
+        self.content = load_text(_EVIDENCE_PATH)
         self.lower = self.content.lower()
 
     def test_removes_r2_not_implemented_carve_out(self):
         self.assertNotIn("r2 is not implemented", self.lower)
 
     def test_documents_tier_aware_escalation_signal(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"mutation resistance.+50%\+ of test files.+t1/t2.+2\+\s+bypass classes.+t3",
         )
 
     def test_requires_mutation_evidence_to_disclose_the_tier(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"mutation evidence.+disclose.+tier",
         )
 
     def test_t2_disclosure_notes_redaction_without_secret_values(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t2.+redact.+without.+reveal.+secret",
         )
 
     def test_t3_definition_names_preserved_bypass_classes(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t3.+hardcoded returns.+partial.+implementations.+boundary skips",
@@ -212,7 +201,7 @@ class TestMutationApprovalProtocol(unittest.TestCase):
     """AC-4 + AC-6: approvals protocol captures accepted-mutant lineage."""
 
     def setUp(self):
-        self.content = _load_text(_APPROVALS_PATH)
+        self.content = load_text(_APPROVALS_PATH)
         self.lower = self.content.lower()
 
     def test_preserves_standard_status_vocabulary(self):
@@ -221,21 +210,21 @@ class TestMutationApprovalProtocol(unittest.TestCase):
                 self.assertIn(status, self.content)
 
     def test_defines_accepted_mutant_lineage_as_auditable_record(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"accepted[- ]mutant.+approval record",
         )
 
     def test_accepted_mutant_records_expire(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"accepted[- ]mutant.{0,200}(?:90 days|expires? at|expires?)",
         )
 
     def test_accepted_mutants_are_not_silent_config_waivers(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"accepted[- ]mutant.+not.+silent.+waiver",
@@ -250,25 +239,25 @@ class TestBuildTimeMutationSignalProtocol(unittest.TestCase):
     """AC-5 + AC-6: build-quality protocol keeps mutation advisory during build."""
 
     def setUp(self):
-        self.content = _load_text(_BUILD_QUALITY_PATH)
+        self.content = load_text(_BUILD_QUALITY_PATH)
         self.lower = self.content.lower()
 
     def test_build_time_mutation_signal_is_advisory_only(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"build-time mutation.+advisory",
         )
 
     def test_tool_backed_mutation_errors_do_not_block_red_to_green(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"tool-backed mutation errors?.+cannot block.+red.?to.?green",
         )
 
     def test_build_time_mutation_notes_are_recorded(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"mutation.+recorded.+(?:as-built notes|build-time notes)",
@@ -280,9 +269,9 @@ class TestMutationContractDrift(unittest.TestCase):
 
     def setUp(self):
         self.config = _load_json(_CONFIG_PATH)["gates"]["tests"]["mutation"]
-        self.detection = _load_text(_DETECTION_PATH)
-        self.evidence = _load_text(_EVIDENCE_PATH)
-        self.approvals = _load_text(_APPROVALS_PATH)
+        self.detection = load_text(_DETECTION_PATH)
+        self.evidence = load_text(_EVIDENCE_PATH)
+        self.approvals = load_text(_APPROVALS_PATH)
 
     def test_approvals_name_the_accepted_mutants_config_key(self):
         self.assertIn("acceptedMutants", self.config)
@@ -292,7 +281,7 @@ class TestMutationContractDrift(unittest.TestCase):
         # `guardrails-detection.md` uses the canonical phrase "silently skipping";
         # `evidence.md` documents the same contract as "silent skip".
         self.assertIn("silently skipping", self.detection)
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.evidence.lower(),
             r"mutation.+never.+silent skip",

--- a/evals/tests/test_tiered_mutation_alignment.py
+++ b/evals/tests/test_tiered_mutation_alignment.py
@@ -1,0 +1,83 @@
+"""Regression coverage for WU-02 Task 3: tier alignment across gate and tester.
+
+RED phase: these tests must fail until gate-tests and specwright-tester stay
+aligned on the restricted survivor format and the T3 qualitative floor.
+"""
+
+import os
+import re
+import unittest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_GATE_TESTS_PATH = os.path.join(_REPO_ROOT, "core", "skills", "gate-tests", "SKILL.md")
+_TESTER_PATH = os.path.join(_REPO_ROOT, "core", "agents", "specwright-tester.md")
+_RESTRICTED_FIELDS = ["operator", "location", "before/after", "defect category", "action"]
+_T3_FLOOR = ["hardcoded returns", "partial implementations", "boundary skips"]
+
+
+def _load_text(path):
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _assert_multiline_regex(testcase, text, pattern):
+    testcase.assertIsNotNone(
+        re.search(pattern, text, re.DOTALL),
+        f"pattern not found: {pattern}",
+    )
+
+
+class TestTierVocabularyAlignment(unittest.TestCase):
+    """AC-6: gate-tests and tester stay aligned on the tier vocabulary."""
+
+    def setUp(self):
+        self.gate = _load_text(_GATE_TESTS_PATH)
+        self.tester = _load_text(_TESTER_PATH)
+
+    def test_both_surfaces_name_t1_t2_t3_in_order(self):
+        for content in (self.gate, self.tester):
+            _assert_multiline_regex(
+                self,
+                content,
+                r"T1.+T2.+T3",
+            )
+
+    def test_both_surfaces_preserve_the_t3_floor_classes(self):
+        for content in (self.gate.lower(), self.tester.lower()):
+            for label in _T3_FLOOR:
+                with self.subTest(label=label, content=content[:24]):
+                    self.assertIn(label, content)
+
+
+class TestRestrictedSurvivorFormatAlignment(unittest.TestCase):
+    """AC-6: verify-time survivor details stay restricted and aligned."""
+
+    def setUp(self):
+        self.gate = _load_text(_GATE_TESTS_PATH).lower()
+        self.tester = _load_text(_TESTER_PATH).lower()
+
+    def test_gate_tests_names_the_restricted_survivor_fields(self):
+        _assert_multiline_regex(
+            self,
+            self.gate,
+            r"survivor details?.+operator.+location.+before/after.+defect category.+action",
+        )
+
+    def test_tester_names_the_same_restricted_survivor_fields(self):
+        _assert_multiline_regex(
+            self,
+            self.tester,
+            r"operator.+location.+before/after.+defect category.+action",
+        )
+
+    def test_tester_still_excludes_test_bodies_and_assertion_literals(self):
+        _assert_multiline_regex(
+            self,
+            self.tester,
+            r"no test bodies?.+no assertion literals|no assertion literals.+no test bodies?",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/tests/test_tiered_mutation_alignment.py
+++ b/evals/tests/test_tiered_mutation_alignment.py
@@ -5,8 +5,9 @@ aligned on the restricted survivor format and the T3 qualitative floor.
 """
 
 import os
-import re
 import unittest
+
+from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -16,37 +17,25 @@ _RESTRICTED_FIELDS = ["operator", "location", "before/after", "defect category",
 _T3_FLOOR = ["hardcoded returns", "partial implementations", "boundary skips"]
 
 
-def _load_text(path):
-    with open(path, "r") as f:
-        return f.read()
-
-
-def _assert_multiline_regex(testcase, text, pattern):
-    testcase.assertIsNotNone(
-        re.search(pattern, text, re.DOTALL),
-        f"pattern not found: {pattern}",
-    )
-
-
 class TestTierVocabularyAlignment(unittest.TestCase):
     """AC-6: gate-tests and tester stay aligned on the tier vocabulary."""
 
     def setUp(self):
-        self.gate = _load_text(_GATE_TESTS_PATH)
-        self.tester = _load_text(_TESTER_PATH)
+        self.gate = load_text(_GATE_TESTS_PATH)
+        self.tester = load_text(_TESTER_PATH)
 
     def test_both_surfaces_name_t1_t2_t3_in_order(self):
         for content in (self.gate, self.tester):
-            _assert_multiline_regex(
+            assert_multiline_regex(
                 self,
                 content,
                 r"T1.+T2.+T3",
             )
 
     def test_both_surfaces_preserve_the_t3_floor_classes(self):
-        for content in (self.gate.lower(), self.tester.lower()):
+        for surface, content in (("gate", self.gate.lower()), ("tester", self.tester.lower())):
             for label in _T3_FLOOR:
-                with self.subTest(label=label, content=content[:24]):
+                with self.subTest(surface=surface, label=label):
                     self.assertIn(label, content)
 
 
@@ -54,25 +43,25 @@ class TestRestrictedSurvivorFormatAlignment(unittest.TestCase):
     """AC-6: verify-time survivor details stay restricted and aligned."""
 
     def setUp(self):
-        self.gate = _load_text(_GATE_TESTS_PATH).lower()
-        self.tester = _load_text(_TESTER_PATH).lower()
+        self.gate = load_text(_GATE_TESTS_PATH).lower()
+        self.tester = load_text(_TESTER_PATH).lower()
 
     def test_gate_tests_names_the_restricted_survivor_fields(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.gate,
             r"survivor details?.+operator.+location.+before/after.+defect category.+action",
         )
 
     def test_tester_names_the_same_restricted_survivor_fields(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.tester,
             r"operator.+location.+before/after.+defect category.+action",
         )
 
     def test_tester_still_excludes_test_bodies_and_assertion_literals(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.tester,
             r"no test bodies?.+no assertion literals|no assertion literals.+no test bodies?",

--- a/evals/tests/test_tiered_mutation_gate_tests.py
+++ b/evals/tests/test_tiered_mutation_gate_tests.py
@@ -6,77 +6,71 @@ evidence requirements for verify-time reporting.
 """
 
 import os
-import re
 import unittest
+
+from evals.tests._text_helpers import (
+    assert_multiline_regex,
+    assert_not_multiline_regex,
+    load_text,
+)
 
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _GATE_TESTS_PATH = os.path.join(_REPO_ROOT, "core", "skills", "gate-tests", "SKILL.md")
 
 
-def _load_text(path):
-    with open(path, "r") as f:
-        return f.read()
-
-
-def _assert_multiline_regex(testcase, text, pattern):
-    testcase.assertIsNotNone(
-        re.search(pattern, text, re.DOTALL),
-        f"pattern not found: {pattern}",
-    )
-
-
 class TestTieredMutationModel(unittest.TestCase):
     """AC-1: gate-tests keeps mutation analysis inside the tests gate."""
 
     def setUp(self):
-        self.content = _load_text(_GATE_TESTS_PATH)
+        self.content = load_text(_GATE_TESTS_PATH)
         self.lower = self.content.lower()
 
-    def test_names_t1_t2_t3_as_the_only_mutation_tiers(self):
-        _assert_multiline_regex(
+    def test_names_t1_t2_t3_mutation_tiers(self):
+        assert_multiline_regex(
             self,
             self.lower,
             r"mutation resistance.+t1.+t2.+t3",
         )
 
     def test_describes_t1_as_tool_backed(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t1.+tool[- ]backed",
         )
 
     def test_describes_t2_as_llm_generated(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t2.+llm[- ]generated",
         )
 
     def test_describes_t3_as_the_qualitative_floor(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t3.+qualitative.+floor",
         )
 
     def test_does_not_allow_missing_tool_to_become_skip(self):
-        self.assertNotRegex(
+        assert_not_multiline_regex(
+            self,
             self.lower,
             r"missing tool.{0,80}gate skip|gate skip.{0,80}missing tool",
         )
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"missing tool.+t2.+t3|t2.+t3.+missing tool",
         )
 
     def test_keeps_mutation_analysis_inside_existing_tests_gate(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
-            r"(inside|within).{0,40}(existing|tests) gate",
+            r"(inside|within).{0,40}(this|existing|tests) gate",
         )
 
 
@@ -84,45 +78,45 @@ class TestTierTransitions(unittest.TestCase):
     """AC-2: gate-tests defines the approved T1 / T2 / T3 transitions."""
 
     def setUp(self):
-        self.lower = _load_text(_GATE_TESTS_PATH).lower()
+        self.lower = load_text(_GATE_TESTS_PATH).lower()
 
     def test_configured_tool_runs_use_t1(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"configured.+tool[- ]backed.+t1|t1.+configured.+tool[- ]backed",
         )
 
     def test_zero_applicable_mutants_drop_to_t2(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"zero applicable mutants?.+t2|t2.+zero applicable mutants?",
         )
 
     def test_configured_llm_fallback_uses_t2(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"configured.+llm fallback.+t2|t2.+configured.+llm fallback",
         )
 
     def test_t1_errors_drop_to_t3(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t1.+errors?.+t3|t3.+t1.+errors?",
         )
 
     def test_t2_errors_drop_to_t3(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t2.+errors?.+t3|t3.+t2.+errors?",
         )
 
     def test_unavailable_fallback_drops_to_t3(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(fallback unavailable|unavailable fallback).+t3|t3.+(fallback unavailable|unavailable fallback)",
@@ -133,24 +127,24 @@ class TestMutationEvidenceRequirements(unittest.TestCase):
     """AC-3: T1 / T2 findings preserve useful verify-time evidence."""
 
     def setUp(self):
-        self.lower = _load_text(_GATE_TESTS_PATH).lower()
+        self.lower = load_text(_GATE_TESTS_PATH).lower()
 
     def test_t1_t2_findings_require_file_line_evidence(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t1.+file:line|t2.+file:line|file:line.+t1/t2",
         )
 
     def test_t1_t2_findings_require_score_or_survivor_details(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(mutation score|survivor details).+(t1|t2)|(t1|t2).+(mutation score|survivor details)",
         )
 
     def test_honors_accepted_mutant_lineage(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"accepted[- ]mutant.+(approval|config)|(approval|config).+accepted[- ]mutant",

--- a/evals/tests/test_tiered_mutation_gate_tests.py
+++ b/evals/tests/test_tiered_mutation_gate_tests.py
@@ -1,0 +1,161 @@
+"""Tests for WU-02 Task 1: gate-tests adopts the tiered mutation model.
+
+RED phase: these tests must fail until `core/skills/gate-tests/SKILL.md`
+documents the T1 / T2 / T3 mutation flow, its fallback rules, and the
+evidence requirements for verify-time reporting.
+"""
+
+import os
+import re
+import unittest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_GATE_TESTS_PATH = os.path.join(_REPO_ROOT, "core", "skills", "gate-tests", "SKILL.md")
+
+
+def _load_text(path):
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _assert_multiline_regex(testcase, text, pattern):
+    testcase.assertIsNotNone(
+        re.search(pattern, text, re.DOTALL),
+        f"pattern not found: {pattern}",
+    )
+
+
+class TestTieredMutationModel(unittest.TestCase):
+    """AC-1: gate-tests keeps mutation analysis inside the tests gate."""
+
+    def setUp(self):
+        self.content = _load_text(_GATE_TESTS_PATH)
+        self.lower = self.content.lower()
+
+    def test_names_t1_t2_t3_as_the_only_mutation_tiers(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"mutation resistance.+t1.+t2.+t3",
+        )
+
+    def test_describes_t1_as_tool_backed(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t1.+tool[- ]backed",
+        )
+
+    def test_describes_t2_as_llm_generated(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t2.+llm[- ]generated",
+        )
+
+    def test_describes_t3_as_the_qualitative_floor(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t3.+qualitative.+floor",
+        )
+
+    def test_does_not_allow_missing_tool_to_become_skip(self):
+        self.assertNotRegex(
+            self.lower,
+            r"missing tool.{0,80}gate skip|gate skip.{0,80}missing tool",
+        )
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"missing tool.+t2.+t3|t2.+t3.+missing tool",
+        )
+
+    def test_keeps_mutation_analysis_inside_existing_tests_gate(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"(inside|within).{0,40}(existing|tests) gate",
+        )
+
+
+class TestTierTransitions(unittest.TestCase):
+    """AC-2: gate-tests defines the approved T1 / T2 / T3 transitions."""
+
+    def setUp(self):
+        self.lower = _load_text(_GATE_TESTS_PATH).lower()
+
+    def test_configured_tool_runs_use_t1(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"configured.+tool[- ]backed.+t1|t1.+configured.+tool[- ]backed",
+        )
+
+    def test_zero_applicable_mutants_drop_to_t2(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"zero applicable mutants?.+t2|t2.+zero applicable mutants?",
+        )
+
+    def test_configured_llm_fallback_uses_t2(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"configured.+llm fallback.+t2|t2.+configured.+llm fallback",
+        )
+
+    def test_t1_errors_drop_to_t3(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t1.+errors?.+t3|t3.+t1.+errors?",
+        )
+
+    def test_t2_errors_drop_to_t3(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t2.+errors?.+t3|t3.+t2.+errors?",
+        )
+
+    def test_unavailable_fallback_drops_to_t3(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"(fallback unavailable|unavailable fallback).+t3|t3.+(fallback unavailable|unavailable fallback)",
+        )
+
+
+class TestMutationEvidenceRequirements(unittest.TestCase):
+    """AC-3: T1 / T2 findings preserve useful verify-time evidence."""
+
+    def setUp(self):
+        self.lower = _load_text(_GATE_TESTS_PATH).lower()
+
+    def test_t1_t2_findings_require_file_line_evidence(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t1.+file:line|t2.+file:line|file:line.+t1/t2",
+        )
+
+    def test_t1_t2_findings_require_score_or_survivor_details(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"(mutation score|survivor details).+(t1|t2)|(t1|t2).+(mutation score|survivor details)",
+        )
+
+    def test_honors_accepted_mutant_lineage(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"accepted[- ]mutant.+(approval|config)|(approval|config).+accepted[- ]mutant",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/tests/test_tiered_mutation_tester_prompt.py
+++ b/evals/tests/test_tiered_mutation_tester_prompt.py
@@ -6,56 +6,45 @@ format, and advisory-only mutation pressure during RED.
 """
 
 import os
-import re
 import unittest
+
+from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _TESTER_PATH = os.path.join(_REPO_ROOT, "core", "agents", "specwright-tester.md")
 
 
-def _load_text(path):
-    with open(path, "r") as f:
-        return f.read()
-
-
-def _assert_multiline_regex(testcase, text, pattern):
-    testcase.assertIsNotNone(
-        re.search(pattern, text, re.DOTALL),
-        f"pattern not found: {pattern}",
-    )
-
-
 class TestTieredMutationTriage(unittest.TestCase):
     """AC-4: tester prompt keeps tier names and survivor triage aligned."""
 
     def setUp(self):
-        self.content = _load_text(_TESTER_PATH)
+        self.content = load_text(_TESTER_PATH)
         self.lower = self.content.lower()
 
     def test_names_t1_t2_t3(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"t1.+t2.+t3",
         )
 
     def test_requires_equivalent_mutant_preprocessing(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"equivalent[- ]mutant.+preprocess|preprocess.+equivalent[- ]mutant",
         )
 
     def test_verify_time_survivor_output_has_restricted_fields_only(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"operator.+location.+before/after.+defect category.+action",
         )
 
     def test_verify_time_survivor_output_excludes_test_bodies_and_assertion_literals(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"no test bodies?.+no assertion literals|no assertion literals.+no test bodies?",
@@ -66,24 +55,24 @@ class TestAdvisoryRedPhaseMutationPressure(unittest.TestCase):
     """AC-5: build-time mutation pressure stays lightweight and non-blocking."""
 
     def setUp(self):
-        self.lower = _load_text(_TESTER_PATH).lower()
+        self.lower = load_text(_TESTER_PATH).lower()
 
     def test_red_phase_limits_tool_backed_scope(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"red phase.+(test-in-progress|current change)|(test-in-progress|current change).+red phase",
         )
 
     def test_build_time_mutation_signal_is_advisory(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"(build-time|red-phase).+mutation.+advisory|advisory.+(build-time|red-phase).+mutation",
         )
 
     def test_tool_errors_do_not_block_tdd_completion(self):
-        _assert_multiline_regex(
+        assert_multiline_regex(
             self,
             self.lower,
             r"tool[- ]backed.+errors?.+do not block|do not block.+tool[- ]backed.+errors?",

--- a/evals/tests/test_tiered_mutation_tester_prompt.py
+++ b/evals/tests/test_tiered_mutation_tester_prompt.py
@@ -1,0 +1,94 @@
+"""Tests for WU-02 Task 2: specwright-tester adopts tiered mutation triage.
+
+RED phase: these tests must fail until `core/agents/specwright-tester.md`
+documents equivalent-mutant preprocessing, the restricted verify-time survivor
+format, and advisory-only mutation pressure during RED.
+"""
+
+import os
+import re
+import unittest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_TESTER_PATH = os.path.join(_REPO_ROOT, "core", "agents", "specwright-tester.md")
+
+
+def _load_text(path):
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _assert_multiline_regex(testcase, text, pattern):
+    testcase.assertIsNotNone(
+        re.search(pattern, text, re.DOTALL),
+        f"pattern not found: {pattern}",
+    )
+
+
+class TestTieredMutationTriage(unittest.TestCase):
+    """AC-4: tester prompt keeps tier names and survivor triage aligned."""
+
+    def setUp(self):
+        self.content = _load_text(_TESTER_PATH)
+        self.lower = self.content.lower()
+
+    def test_names_t1_t2_t3(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"t1.+t2.+t3",
+        )
+
+    def test_requires_equivalent_mutant_preprocessing(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"equivalent[- ]mutant.+preprocess|preprocess.+equivalent[- ]mutant",
+        )
+
+    def test_verify_time_survivor_output_has_restricted_fields_only(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"operator.+location.+before/after.+defect category.+action",
+        )
+
+    def test_verify_time_survivor_output_excludes_test_bodies_and_assertion_literals(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"no test bodies?.+no assertion literals|no assertion literals.+no test bodies?",
+        )
+
+
+class TestAdvisoryRedPhaseMutationPressure(unittest.TestCase):
+    """AC-5: build-time mutation pressure stays lightweight and non-blocking."""
+
+    def setUp(self):
+        self.lower = _load_text(_TESTER_PATH).lower()
+
+    def test_red_phase_limits_tool_backed_scope(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"red phase.+(test-in-progress|current change)|(test-in-progress|current change).+red phase",
+        )
+
+    def test_build_time_mutation_signal_is_advisory(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"(build-time|red-phase).+mutation.+advisory|advisory.+(build-time|red-phase).+mutation",
+        )
+
+    def test_tool_errors_do_not_block_tdd_completion(self):
+        _assert_multiline_regex(
+            self,
+            self.lower,
+            r"tool[- ]backed.+errors?.+do not block|do not block.+tool[- ]backed.+errors?",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This unit upgrades Specwright's existing test-quality mutation analysis so `gate-tests` and `specwright-tester` share the same T1 / T2 / T3 model at build time and verify time. It keeps mutation analysis inside the tests gate, makes RED-phase mutation pressure advisory only, and adds regression coverage that prevents drift between the gate and tester prompt.

## Approval Lineage
- Design approval: **STALE** from `/sw-plan`.
- Unit-spec approval (`02-tiered-mutation-analysis`): **STALE** from `/sw-build`.
- Reviewer note: approval truth is recorded in `approvals.md`; this PR intentionally carries the stale-lineage warning forward rather than masking it.

## What Changed
- Updated `core/skills/gate-tests/SKILL.md` to define the T1 / T2 / T3 mutation path, fallback behavior, accepted-mutant handling, and the restricted verify-time survivor field set.
- Updated `core/agents/specwright-tester.md` to preprocess equivalent mutants, emit verify-safe survivor summaries, and keep RED-phase mutation analysis advisory and non-blocking.
- Added regression coverage in `evals/tests/test_tiered_mutation_gate_tests.py`, `evals/tests/test_tiered_mutation_tester_prompt.py`, and `evals/tests/test_tiered_mutation_alignment.py`.

## Why The Agent Implemented It This Way
- The mutation-tier contract lives in `gate-tests` so verify-time behavior remains part of the existing tests gate rather than becoming a seventh gate.
- The existing tester agent was extended instead of introducing a new agent, preserving one prompt surface for RED-phase test authoring and verify-time mutation triage.
- A cross-surface alignment regression was added once the gate contract needed the restricted survivor fields named explicitly; that regression now prevents one-sided drift between the gate and tester surfaces.

## Acceptance Criteria
- AC-1: PASS. `core/skills/gate-tests/SKILL.md:51-55`; `TestTieredMutationModel::test_names_t1_t2_t3_as_the_only_mutation_tiers` at `evals/tests/test_tiered_mutation_gate_tests.py:36`; `TestTieredMutationModel::test_does_not_allow_missing_tool_to_become_skip` at `evals/tests/test_tiered_mutation_gate_tests.py:64`.
- AC-2: PASS. `core/skills/gate-tests/SKILL.md:51-54`; `TestTierTransitions::test_zero_applicable_mutants_drop_to_t2` at `evals/tests/test_tiered_mutation_gate_tests.py:96`; `TestTierTransitions::test_t1_errors_drop_to_t3` at `evals/tests/test_tiered_mutation_gate_tests.py:110`; `TestTierTransitions::test_unavailable_fallback_drops_to_t3` at `evals/tests/test_tiered_mutation_gate_tests.py:124`.
- AC-3: PASS. `core/skills/gate-tests/SKILL.md:52-55`; `TestMutationEvidenceRequirements::test_t1_t2_findings_require_file_line_evidence` at `evals/tests/test_tiered_mutation_gate_tests.py:138`; `TestMutationEvidenceRequirements::test_honors_accepted_mutant_lineage` at `evals/tests/test_tiered_mutation_gate_tests.py:152`.
- AC-4: PASS. `core/agents/specwright-tester.md:76-99`; `TestTieredMutationTriage::test_requires_equivalent_mutant_preprocessing` at `evals/tests/test_tiered_mutation_tester_prompt.py:43`; `TestTieredMutationTriage::test_verify_time_survivor_output_excludes_test_bodies_and_assertion_literals` at `evals/tests/test_tiered_mutation_tester_prompt.py:57`.
- AC-5: PASS. `core/agents/specwright-tester.md:101-104`; `TestAdvisoryRedPhaseMutationPressure::test_red_phase_limits_tool_backed_scope` at `evals/tests/test_tiered_mutation_tester_prompt.py:71`; `TestAdvisoryRedPhaseMutationPressure::test_tool_errors_do_not_block_tdd_completion` at `evals/tests/test_tiered_mutation_tester_prompt.py:85`.
- AC-6: PASS. `evals/tests/test_tiered_mutation_gate_tests.py:29-157`; `evals/tests/test_tiered_mutation_tester_prompt.py:29-90`; `evals/tests/test_tiered_mutation_alignment.py:31-79`; `TestTierVocabularyAlignment::test_both_surfaces_name_t1_t2_t3_in_order` at `evals/tests/test_tiered_mutation_alignment.py:38`; `TestRestrictedSurvivorFormatAlignment::test_gate_tests_names_the_restricted_survivor_fields` at `evals/tests/test_tiered_mutation_alignment.py:60`.

## Spec Conformance
- `gate-spec`: PASS. AC-1 through AC-6 all have implementation evidence and dedicated regression coverage.
- Behavioral integration criteria were not applicable for this unit because unit 02 is not the final work unit.

## Gate Summary
| Gate | Status | Findings (B/W/I) |
|---|---|---|
| build | PASS | 0/0/2 |
| tests | PASS | 0/0/2 |
| security | PASS | 0/0/0 |
| wiring | PASS | 0/0/0 |
| semantic | PASS | 0/0/1 |
| spec | PASS | 0/0/0 |

## Remaining Attention
- No residual gate WARN or FAIL findings remain.
- Approval-lineage staleness remains a reviewer-visible manual review item.
- The design still carries 13 auto-accepted assumptions; verify did not find contradictions, but the attention flag remains visible.

## Evidence Links
Clone-local work-artifact mode is active, so reviewer-usable evidence is inlined above instead of linking to local-only files.
Canonical local artifacts for the owning checkout:
- `review-packet.md`
- `evidence/build-report.md`
- `evidence/test-quality.md`
- `evidence/security-report.md`
- `evidence/wiring-report.md`
- `evidence/semantic-report.md`
- `evidence/spec-compliance.md`
