### PR TITLE
feat(closeout): add approval and handoff foundations

### DIFF
--- a/adapters/shared/specwright-approvals.mjs
+++ b/adapters/shared/specwright-approvals.mjs
@@ -9,6 +9,13 @@ export const APPROVAL_SOURCE_CLASSIFICATIONS = [
   'external-record',
   'headless-check'
 ];
+export const APPROVAL_REASON_CODES = [
+  'missing-entry',
+  'artifact-set-changed',
+  'missing-lineage',
+  'expired',
+  'superseded'
+];
 export const DEFAULT_ACCEPTED_MUTANT_EXPIRY_DAYS = 90;
 export const APPROVAL_ASSESSMENT_STATUS_VALUES = [
   ...APPROVAL_STATUS_VALUES,
@@ -104,6 +111,22 @@ function normalizeAcceptedMutantLineage(entry) {
     configPath: normalizeString(entry?.configPath),
     approvedAt: normalizeString(entry?.approvedAt),
     expiresAt: normalizeString(entry?.expiresAt)
+  };
+}
+
+function createAssessmentResult({
+  status,
+  reasonCode = null,
+  artifactSetHash = null,
+  approvedArtifactSetHash = null,
+  currentArtifactSetHash = null
+}) {
+  return {
+    status,
+    reasonCode,
+    artifactSetHash,
+    approvedArtifactSetHash,
+    currentArtifactSetHash
   };
 }
 
@@ -245,11 +268,20 @@ export function recordApproval(document, options = {}) {
 }
 
 export function assessApprovalEntry(entry, options = {}) {
+  const baseDir = options.baseDir ?? process.cwd();
+  const artifacts = Array.isArray(options.artifacts)
+    ? options.artifacts
+    : (Array.isArray(entry?.artifacts) ? entry.artifacts : []);
+  const current = hashApprovalArtifacts(baseDir, artifacts);
+
   if (entry == null) {
-    return {
+    return createAssessmentResult({
       status: 'MISSING',
-      artifactSetHash: null
-    };
+      reasonCode: 'missing-entry',
+      artifactSetHash: null,
+      approvedArtifactSetHash: null,
+      currentArtifactSetHash: current.artifactSetHash
+    });
   }
 
   const normalizedStatus = normalizeEnumValue(
@@ -262,17 +294,14 @@ export function assessApprovalEntry(entry, options = {}) {
   }
 
   if (normalizedStatus === 'SUPERSEDED') {
-    return {
+    return createAssessmentResult({
       status: 'SUPERSEDED',
-      artifactSetHash: entry?.artifactSetHash ?? null
-    };
+      reasonCode: 'superseded',
+      artifactSetHash: entry?.artifactSetHash ?? null,
+      approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+      currentArtifactSetHash: current.artifactSetHash
+    });
   }
-
-  const baseDir = options.baseDir ?? process.cwd();
-  const artifacts = Array.isArray(options.artifacts)
-    ? options.artifacts
-    : (Array.isArray(entry?.artifacts) ? entry.artifacts : []);
-  const current = hashApprovalArtifacts(baseDir, artifacts);
 
   if (isAcceptedMutantScope(entry?.scope)) {
     const acceptedMutantLineage = normalizeAcceptedMutantLineage(entry);
@@ -284,40 +313,54 @@ export function assessApprovalEntry(entry, options = {}) {
       !acceptedMutantLineage.approvedAt ||
       !acceptedMutantLineage.expiresAt
     ) {
-      return {
+      return createAssessmentResult({
         status: 'STALE',
-        artifactSetHash: current.artifactSetHash
-      };
+        reasonCode: 'missing-lineage',
+        artifactSetHash: current.artifactSetHash,
+        approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+        currentArtifactSetHash: current.artifactSetHash
+      });
     }
 
     const approvedDate = new Date(acceptedMutantLineage.approvedAt);
     const expiryDate = new Date(acceptedMutantLineage.expiresAt);
     if (Number.isNaN(approvedDate.getTime())) {
-      return {
+      return createAssessmentResult({
         status: 'STALE',
-        artifactSetHash: current.artifactSetHash
-      };
+        reasonCode: 'missing-lineage',
+        artifactSetHash: current.artifactSetHash,
+        approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+        currentArtifactSetHash: current.artifactSetHash
+      });
     }
 
     if (Number.isNaN(expiryDate.getTime()) || expiryDate.getTime() <= Date.now()) {
-      return {
+      return createAssessmentResult({
         status: 'STALE',
-        artifactSetHash: current.artifactSetHash
-      };
+        reasonCode: 'expired',
+        artifactSetHash: current.artifactSetHash,
+        approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+        currentArtifactSetHash: current.artifactSetHash
+      });
     }
   }
 
   if (current.artifactSetHash !== entry?.artifactSetHash) {
-    return {
+    return createAssessmentResult({
       status: 'STALE',
-      artifactSetHash: current.artifactSetHash
-    };
+      reasonCode: 'artifact-set-changed',
+      artifactSetHash: current.artifactSetHash,
+      approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+      currentArtifactSetHash: current.artifactSetHash
+    });
   }
 
-  return {
+  return createAssessmentResult({
     status: 'APPROVED',
-    artifactSetHash: current.artifactSetHash
-  };
+    artifactSetHash: current.artifactSetHash,
+    approvedArtifactSetHash: entry?.artifactSetHash ?? null,
+    currentArtifactSetHash: current.artifactSetHash
+  });
 }
 
 export function serializeApprovalsMarkdown(document) {

--- a/adapters/shared/specwright-closeout.mjs
+++ b/adapters/shared/specwright-closeout.mjs
@@ -1,0 +1,127 @@
+import { existsSync, readFileSync } from 'fs';
+
+const STAGE_REPORT_SECTIONS = [
+  'What I did',
+  'Decisions digest',
+  'Quality Checks',
+  'Postcondition State',
+  'Recommendation'
+];
+const REVIEW_PACKET_SECTIONS = [
+  'Approval Lineage',
+  'What Changed',
+  'Why The Agent Implemented It This Way',
+  'Spec Conformance',
+  'Gate Summary',
+  'Remaining Attention'
+];
+
+function readMarkdownIfPresent(path) {
+  if (typeof path !== 'string' || !path.trim() || !existsSync(path)) {
+    return null;
+  }
+
+  return readFileSync(path, 'utf8');
+}
+
+function collectSections(markdown) {
+  const sections = new Map();
+  let currentSection = null;
+
+  for (const rawLine of markdown.split(/\r?\n/u)) {
+    const headingMatch = rawLine.match(/^##\s+(.+?)\s*$/u);
+    if (headingMatch) {
+      currentSection = headingMatch[1].trim();
+      if (!sections.has(currentSection)) {
+        sections.set(currentSection, []);
+      }
+      continue;
+    }
+
+    if (!currentSection) {
+      continue;
+    }
+
+    const line = rawLine.trim();
+    if (!line || /^```/u.test(line) || /^#/u.test(line)) {
+      continue;
+    }
+
+    sections.get(currentSection).push(line);
+  }
+
+  return sections;
+}
+
+function extractBullets(sections, names) {
+  const bullets = [];
+  const seen = new Set();
+
+  for (const name of names) {
+    for (const line of sections.get(name) ?? []) {
+      const bullet = line.replace(/^[-*]\s+/u, '').replace(/^\d+\.\s+/u, '').trim();
+      if (!bullet || seen.has(bullet)) {
+        continue;
+      }
+      seen.add(bullet);
+      bullets.push(bullet);
+    }
+  }
+
+  return bullets;
+}
+
+export function parseStageReportDigest(markdown) {
+  if (typeof markdown !== 'string' || !markdown.trim()) {
+    return null;
+  }
+
+  const firstLine = markdown
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!firstLine || !firstLine.startsWith('Attention required:')) {
+    return null;
+  }
+
+  return {
+    source: 'stage-report',
+    headline: firstLine,
+    bullets: extractBullets(collectSections(markdown), STAGE_REPORT_SECTIONS)
+  };
+}
+
+export function parseReviewPacketDigest(markdown) {
+  if (typeof markdown !== 'string' || !markdown.trim()) {
+    return null;
+  }
+
+  const bullets = extractBullets(collectSections(markdown), REVIEW_PACKET_SECTIONS);
+  if (bullets.length === 0) {
+    return null;
+  }
+
+  return {
+    source: 'review-packet',
+    headline: `Attention required: ${bullets[0]}`,
+    bullets
+  };
+}
+
+export function loadCloseoutDigest(options = {}) {
+  const stageReportDigest = parseStageReportDigest(readMarkdownIfPresent(options.stageReportPath));
+  if (stageReportDigest) {
+    return stageReportDigest;
+  }
+
+  const reviewPacketDigest = parseReviewPacketDigest(readMarkdownIfPresent(options.reviewPacketPath));
+  if (reviewPacketDigest) {
+    return reviewPacketDigest;
+  }
+
+  return {
+    source: null,
+    headline: null,
+    bullets: []
+  };
+}

--- a/adapters/shared/specwright-closeout.mjs
+++ b/adapters/shared/specwright-closeout.mjs
@@ -15,6 +15,8 @@ const REVIEW_PACKET_SECTIONS = [
   'Gate Summary',
   'Remaining Attention'
 ];
+const FENCED_BLOCK_MARKER_PATTERN = /^```/u;
+const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s/u;
 
 function readMarkdownIfPresent(path) {
   if (typeof path !== 'string' || !path.trim() || !existsSync(path)) {
@@ -27,8 +29,19 @@ function readMarkdownIfPresent(path) {
 function collectSections(markdown) {
   const sections = new Map();
   let currentSection = null;
+  let inFencedBlock = false;
 
   for (const rawLine of markdown.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (FENCED_BLOCK_MARKER_PATTERN.test(line)) {
+      inFencedBlock = !inFencedBlock;
+      continue;
+    }
+
+    if (inFencedBlock) {
+      continue;
+    }
+
     const headingMatch = rawLine.match(/^##\s+(.+?)\s*$/u);
     if (headingMatch) {
       currentSection = headingMatch[1].trim();
@@ -42,8 +55,7 @@ function collectSections(markdown) {
       continue;
     }
 
-    const line = rawLine.trim();
-    if (!line || /^```/u.test(line) || /^#/u.test(line)) {
+    if (!line || MARKDOWN_HEADING_PATTERN.test(line)) {
       continue;
     }
 
@@ -71,6 +83,19 @@ function extractBullets(sections, names) {
   return bullets;
 }
 
+function selectReviewPacketHeadline(sections, bullets) {
+  const remainingAttentionBullets = extractBullets(sections, ['Remaining Attention']);
+  const prioritizedBullet = remainingAttentionBullets.find(
+    (bullet) => bullet.toLowerCase() !== 'none'
+  ) ?? bullets[0] ?? null;
+
+  if (!prioritizedBullet) {
+    return null;
+  }
+
+  return `Attention required: ${prioritizedBullet}`;
+}
+
 export function parseStageReportDigest(markdown) {
   if (typeof markdown !== 'string' || !markdown.trim()) {
     return null;
@@ -96,14 +121,15 @@ export function parseReviewPacketDigest(markdown) {
     return null;
   }
 
-  const bullets = extractBullets(collectSections(markdown), REVIEW_PACKET_SECTIONS);
+  const sections = collectSections(markdown);
+  const bullets = extractBullets(sections, REVIEW_PACKET_SECTIONS);
   if (bullets.length === 0) {
     return null;
   }
 
   return {
     source: 'review-packet',
-    headline: `Attention required: ${bullets[0]}`,
+    headline: selectReviewPacketHeadline(sections, bullets),
     bullets
   };
 }

--- a/core/protocols/approvals.md
+++ b/core/protocols/approvals.md
@@ -83,6 +83,23 @@ Approval freshness is determined by a deterministic artifact-set hash:
 The resulting `artifactSetHash` is the approval fingerprint. If any approved
 artifact changes or disappears, the approval becomes `STALE`.
 
+## Compact Freshness Reason Codes
+
+Human-readable closeout and reviewer-facing approval summaries use one compact
+reason-code vocabulary when approval lineage is not current:
+
+- `missing-entry` — no approval entry exists for the required scope
+- `artifact-set-changed` — the approved artifact set hash no longer matches the
+  current artifacts
+- `missing-lineage` — an `accepted-mutant` entry is missing required lineage
+  fields or carries an invalid `approvedAt`
+- `expired` — an `accepted-mutant` entry has an invalid or elapsed `expiresAt`
+- `superseded` — the entry was replaced by a newer approval in the same slot
+
+These reason codes keep terminal and packet summaries compact. Full hashes,
+artifact manifests, and accepted-mutant lineage remain in the approval ledger
+or deeper evidence artifacts instead of the terminal-first digest.
+
 ## File Shape
 
 `approvals.md` stays human-readable, but the machine-readable source of truth is
@@ -160,5 +177,7 @@ Shared approval helpers must provide deterministic support for:
 - recording or refreshing `accepted-mutant` entries without collapsing them
   into a silent config-only waiver
 - validating approval freshness against current artifacts
+- returning structured freshness assessment with status, compact reason code,
+  and approved/current artifact hashes when applicable
 - rejecting any attempt to create `APPROVED` approval state from
   `headless-check`

--- a/core/protocols/decision.md
+++ b/core/protocols/decision.md
@@ -313,7 +313,12 @@ can see the risk signal without scrolling.
 
 ## Gate Handoff
 
-When a pipeline skill finishes, emit exactly three lines:
+When a pipeline skill finishes, render a human closeout digest above the exact
+three-line footer when a stage report or review packet summary is available.
+The human closeout digest is derived from durable artifacts; it is not bespoke
+terminal-only prose.
+
+The exact footer remains the final three lines:
 
 ```text
 Done. {one-line outcome}.
@@ -321,7 +326,9 @@ Artifacts: {stageReportPath}
 Next: /sw-{next-skill}
 ```
 
-The detail lives in the artifact files. Terminal output is the pointer, not the report.
+The detail lives in the artifact files. Terminal output is the pointer, not the
+report, but the digest above the exact three-line footer keeps the user-facing
+closeout legible without changing the machine-readable trailer.
 
 ## Precedence
 

--- a/core/protocols/review-packet.md
+++ b/core/protocols/review-packet.md
@@ -72,6 +72,10 @@ digest is derived from the review-packet structure; it must not become a second 
 
 - Report both `design` and current `unit-spec` lineage when available.
 - Distinguish `APPROVED`, `STALE`, `SUPERSEDED`, and missing approval clearly.
+- When lineage is not current, use the compact reason vocabulary from
+  `protocols/approvals.md` (`missing-entry`, `artifact-set-changed`,
+  `missing-lineage`, `expired`, `superseded`) instead of dumping hashes into
+  the reviewer-facing summary.
 - Include the human approval source reference when present.
 - Never imply approval truth comes from `workflow.json`.
 

--- a/core/protocols/review-packet.md
+++ b/core/protocols/review-packet.md
@@ -36,6 +36,12 @@ once to understand an agent-authored change.
 The packet synthesizes those sources. It does not create a second source of
 truth for gate execution or approval state.
 
+## Closeout Digest Reuse
+
+`review-packet.md` may feed a closeout digest when a lifecycle surface needs a
+human-readable summary and no fresher stage report is available. That closeout
+digest is derived from the review-packet structure; it must not become a second free-form summary surface with bespoke wording that drifts from the packet.
+
 ## Canonical Structure
 
 ```markdown

--- a/evals/tests/test_closeout_digest_contract.py
+++ b/evals/tests/test_closeout_digest_contract.py
@@ -53,6 +53,22 @@ class TestDecisionProtocolDigestContract(unittest.TestCase):
             ),
         )
 
+    def test_gate_handoff_footer_block_stays_exact(self):
+        match = re.search(
+            r"## Gate Handoff[\s\S]*?```text\n(?P<footer>[\s\S]*?)```",
+            self.decision_text,
+        )
+        self.assertIsNotNone(match, "decision protocol must include the footer code block")
+        footer_lines = match.group("footer").strip().splitlines()
+        self.assertEqual(
+            footer_lines,
+            [
+                "Done. {one-line outcome}.",
+                "Artifacts: {stageReportPath}",
+                "Next: /sw-{next-skill}",
+            ],
+        )
+
 
 class TestReviewPacketDigestReuse(unittest.TestCase):
     """Task 1 RED: review-packet must describe how closeout reuse works."""
@@ -95,6 +111,29 @@ class TestApprovalsReasonVocabulary(unittest.TestCase):
         ):
             with self.subTest(reason_code=reason_code):
                 self.assertIn(reason_code, self.approvals_text)
+
+    def test_reason_code_vocabulary_stays_aligned_across_protocols_and_helper(self):
+        output = _run_node_json(
+            """
+            import { APPROVAL_REASON_CODES } from './adapters/shared/specwright-approvals.mjs';
+            console.log(JSON.stringify({ reasonCodes: APPROVAL_REASON_CODES }));
+            """
+        )
+
+        expected_codes = [
+            "missing-entry",
+            "artifact-set-changed",
+            "missing-lineage",
+            "expired",
+            "superseded",
+        ]
+        self.assertEqual(output["reasonCodes"], expected_codes)
+
+        review_text = REVIEW_PACKET_PROTOCOL.read_text(encoding="utf-8")
+        for reason_code in expected_codes:
+            with self.subTest(reason_code=reason_code):
+                self.assertIn(reason_code, self.approvals_text)
+                self.assertIn(reason_code, review_text)
 
 
 class TestCloseoutHelperContract(unittest.TestCase):
@@ -195,6 +234,59 @@ class TestCloseoutHelperContract(unittest.TestCase):
             self.assertTrue(output["headline"].startswith("Attention required:"))
             self.assertTrue(any("design: APPROVED" in bullet for bullet in output["bullets"]))
 
+    def test_helper_keeps_digest_artifact_derived(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            review_packet = Path(tmpdir) / "review-packet.md"
+            review_packet.write_text(
+                dedent(
+                    """
+                    # Review Packet
+
+                    This stray introduction should not become a digest bullet.
+
+                    ## Approval Lineage
+                    - design: STALE (artifact-set-changed)
+
+                    ## What Changed
+                    - Added shared closeout parsing
+
+                    ## Narrative
+                    - bespoke prose that should not leak into the digest
+
+                    ## Remaining Attention
+                    - rerun verify after the next task
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output = _run_node_json(
+                f"""
+                import {{ loadCloseoutDigest }} from './adapters/shared/specwright-closeout.mjs';
+                const digest = loadCloseoutDigest({{
+                  reviewPacketPath: {json.dumps(str(review_packet))}
+                }});
+                console.log(JSON.stringify(digest));
+                """
+            )
+
+            self.assertEqual(
+                output["headline"],
+                "Attention required: design: STALE (artifact-set-changed)",
+            )
+            self.assertIn("design: STALE (artifact-set-changed)", output["bullets"])
+            self.assertIn("Added shared closeout parsing", output["bullets"])
+            self.assertIn("rerun verify after the next task", output["bullets"])
+            self.assertNotIn(
+                "This stray introduction should not become a digest bullet.",
+                output["bullets"],
+            )
+            self.assertNotIn(
+                "bespoke prose that should not leak into the digest",
+                output["bullets"],
+            )
+
 
 class TestApprovalAssessmentReasons(unittest.TestCase):
     """Task 2 RED: assessment must explain why approval is not current."""
@@ -280,12 +372,21 @@ class TestApprovalAssessmentReasons(unittest.TestCase):
             )
 
             self.assertEqual(output["missing"]["reasonCode"], "missing-entry")
+            self.assertEqual(output["missing"]["status"], "MISSING")
             self.assertEqual(output["changed"]["reasonCode"], "artifact-set-changed")
+            self.assertEqual(output["changed"]["status"], "STALE")
             self.assertEqual(output["expired"]["reasonCode"], "expired")
+            self.assertEqual(output["expired"]["status"], "STALE")
             self.assertEqual(output["missingLineage"]["reasonCode"], "missing-lineage")
+            self.assertEqual(output["missingLineage"]["status"], "STALE")
             self.assertEqual(output["superseded"]["reasonCode"], "superseded")
+            self.assertEqual(output["superseded"]["status"], "SUPERSEDED")
             self.assertIn("approvedArtifactSetHash", output["changed"])
             self.assertIn("currentArtifactSetHash", output["changed"])
+            self.assertNotEqual(
+                output["changed"]["approvedArtifactSetHash"],
+                output["changed"]["currentArtifactSetHash"],
+            )
 
 
 if __name__ == "__main__":

--- a/evals/tests/test_closeout_digest_contract.py
+++ b/evals/tests/test_closeout_digest_contract.py
@@ -1,13 +1,32 @@
 """Regression tests for Unit 01 — closeout digest and approval foundation."""
 
+import json
 from pathlib import Path
 import re
+import subprocess
+import tempfile
+from textwrap import dedent
 import unittest
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 DECISION_PROTOCOL = ROOT_DIR / "core" / "protocols" / "decision.md"
 REVIEW_PACKET_PROTOCOL = ROOT_DIR / "core" / "protocols" / "review-packet.md"
+APPROVALS_PROTOCOL = ROOT_DIR / "core" / "protocols" / "approvals.md"
+
+
+def _run_node_json(script: str) -> dict:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "node execution failed")
+    return json.loads(result.stdout)
 
 
 class TestDecisionProtocolDigestContract(unittest.TestCase):
@@ -58,6 +77,215 @@ class TestReviewPacketDigestReuse(unittest.TestCase):
                 re.IGNORECASE,
             ),
         )
+
+
+class TestApprovalsReasonVocabulary(unittest.TestCase):
+    """Task 2 RED: approvals protocol and helper must agree on reason codes."""
+
+    def setUp(self):
+        self.approvals_text = APPROVALS_PROTOCOL.read_text(encoding="utf-8")
+
+    def test_approvals_protocol_lists_reason_code_vocabulary(self):
+        for reason_code in (
+            "missing-entry",
+            "artifact-set-changed",
+            "missing-lineage",
+            "expired",
+            "superseded",
+        ):
+            with self.subTest(reason_code=reason_code):
+                self.assertIn(reason_code, self.approvals_text)
+
+
+class TestCloseoutHelperContract(unittest.TestCase):
+    """Task 2 RED: a shared helper must derive digests from durable artifacts."""
+
+    def test_helper_prefers_stage_report_when_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stage_report = Path(tmpdir) / "stage-report.md"
+            review_packet = Path(tmpdir) / "review-packet.md"
+            stage_report.write_text(
+                dedent(
+                    """
+                    Attention required: Stage report summary
+
+                    ## What I did
+                    - Added the digest contract
+
+                    ## Decisions digest
+                    - Kept the footer exact
+
+                    ## Recommendation
+                    - Continue to the next task
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            review_packet.write_text(
+                dedent(
+                    """
+                    # Review Packet
+
+                    ## Approval Lineage
+                    - design: APPROVED
+
+                    ## What Changed
+                    - Protocol wording changed
+
+                    ## Remaining Attention
+                    - none
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output = _run_node_json(
+                f"""
+                import {{ loadCloseoutDigest }} from './adapters/shared/specwright-closeout.mjs';
+                const digest = loadCloseoutDigest({{
+                  stageReportPath: {json.dumps(str(stage_report))},
+                  reviewPacketPath: {json.dumps(str(review_packet))}
+                }});
+                console.log(JSON.stringify(digest));
+                """
+            )
+
+            self.assertEqual(output["source"], "stage-report")
+            self.assertEqual(output["headline"], "Attention required: Stage report summary")
+            self.assertIn("Added the digest contract", output["bullets"])
+
+    def test_helper_falls_back_to_review_packet(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            review_packet = Path(tmpdir) / "review-packet.md"
+            review_packet.write_text(
+                dedent(
+                    """
+                    # Review Packet
+
+                    ## Approval Lineage
+                    - design: APPROVED via /sw-plan
+
+                    ## What Changed
+                    - Protocol wording changed
+
+                    ## Gate Summary
+                    - build: PASS
+
+                    ## Remaining Attention
+                    - reviewer should confirm the wording
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output = _run_node_json(
+                f"""
+                import {{ loadCloseoutDigest }} from './adapters/shared/specwright-closeout.mjs';
+                const digest = loadCloseoutDigest({{
+                  reviewPacketPath: {json.dumps(str(review_packet))}
+                }});
+                console.log(JSON.stringify(digest));
+                """
+            )
+
+            self.assertEqual(output["source"], "review-packet")
+            self.assertTrue(output["headline"].startswith("Attention required:"))
+            self.assertTrue(any("design: APPROVED" in bullet for bullet in output["bullets"]))
+
+
+class TestApprovalAssessmentReasons(unittest.TestCase):
+    """Task 2 RED: assessment must explain why approval is not current."""
+
+    def test_assessment_returns_reason_codes_and_hashes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_root = Path(tmpdir)
+            (artifact_root / "design.md").write_text("design v1\n", encoding="utf-8")
+            (artifact_root / "context.md").write_text("context v1\n", encoding="utf-8")
+
+            output = _run_node_json(
+                f"""
+                import {{
+                  assessApprovalEntry,
+                  createApprovalEntry
+                }} from './adapters/shared/specwright-approvals.mjs';
+                import fs from 'fs';
+
+                const baseDir = {json.dumps(str(artifact_root))};
+                const approved = createApprovalEntry({{
+                  baseDir,
+                  scope: 'design',
+                  artifacts: ['design.md', 'context.md'],
+                  sourceClassification: 'command',
+                  sourceRef: '/sw-plan',
+                  approvedAt: '2026-04-20T00:00:00Z'
+                }});
+
+                const missing = assessApprovalEntry(null, {{
+                  baseDir,
+                  artifacts: ['design.md', 'context.md']
+                }});
+
+                fs.writeFileSync(`${{baseDir}}/design.md`, 'design v2\\n', 'utf8');
+                const changed = assessApprovalEntry(approved, {{ baseDir }});
+
+                const expired = assessApprovalEntry({{
+                  ...createApprovalEntry({{
+                    baseDir,
+                    scope: 'accepted-mutant',
+                    unitId: 'u1',
+                    mutantId: 'mut-1',
+                    reason: 'equivalent',
+                    configPath: 'gates.tests.mutation.acceptedMutants',
+                    artifacts: ['design.md', 'context.md'],
+                    sourceClassification: 'command',
+                    sourceRef: '/sw-verify --accept-mutant mut-1 --reason \"equivalent\"',
+                    approvedAt: '2026-04-20T00:00:00Z',
+                    expiresAt: '2020-01-01T00:00:00Z'
+                  }})
+                }}, {{ baseDir }});
+
+                const missingLineage = assessApprovalEntry({{
+                  ...createApprovalEntry({{
+                    baseDir,
+                    scope: 'accepted-mutant',
+                    unitId: 'u1',
+                    mutantId: 'mut-2',
+                    reason: 'log-only branch',
+                    configPath: 'gates.tests.mutation.acceptedMutants',
+                    artifacts: ['design.md', 'context.md'],
+                    sourceClassification: 'command',
+                    sourceRef: '/sw-verify --accept-mutant mut-2 --reason \"log-only branch\"',
+                    approvedAt: '2026-04-20T00:00:00Z',
+                    expiresAt: '2026-07-01T00:00:00Z'
+                  }}),
+                  reason: null
+                }}, {{ baseDir }});
+
+                const superseded = assessApprovalEntry({{
+                  ...approved,
+                  status: 'SUPERSEDED'
+                }}, {{ baseDir }});
+
+                console.log(JSON.stringify({{
+                  missing,
+                  changed,
+                  expired,
+                  missingLineage,
+                  superseded
+                }}));
+                """
+            )
+
+            self.assertEqual(output["missing"]["reasonCode"], "missing-entry")
+            self.assertEqual(output["changed"]["reasonCode"], "artifact-set-changed")
+            self.assertEqual(output["expired"]["reasonCode"], "expired")
+            self.assertEqual(output["missingLineage"]["reasonCode"], "missing-lineage")
+            self.assertEqual(output["superseded"]["reasonCode"], "superseded")
+            self.assertIn("approvedArtifactSetHash", output["changed"])
+            self.assertIn("currentArtifactSetHash", output["changed"])
 
 
 if __name__ == "__main__":

--- a/evals/tests/test_closeout_digest_contract.py
+++ b/evals/tests/test_closeout_digest_contract.py
@@ -132,7 +132,6 @@ class TestApprovalsReasonVocabulary(unittest.TestCase):
         review_text = REVIEW_PACKET_PROTOCOL.read_text(encoding="utf-8")
         for reason_code in expected_codes:
             with self.subTest(reason_code=reason_code):
-                self.assertIn(reason_code, self.approvals_text)
                 self.assertIn(reason_code, review_text)
 
 
@@ -231,7 +230,10 @@ class TestCloseoutHelperContract(unittest.TestCase):
             )
 
             self.assertEqual(output["source"], "review-packet")
-            self.assertTrue(output["headline"].startswith("Attention required:"))
+            self.assertEqual(
+                output["headline"],
+                "Attention required: reviewer should confirm the wording",
+            )
             self.assertTrue(any("design: APPROVED" in bullet for bullet in output["bullets"]))
 
     def test_helper_keeps_digest_artifact_derived(self):
@@ -273,7 +275,7 @@ class TestCloseoutHelperContract(unittest.TestCase):
 
             self.assertEqual(
                 output["headline"],
-                "Attention required: design: STALE (artifact-set-changed)",
+                "Attention required: rerun verify after the next task",
             )
             self.assertIn("design: STALE (artifact-set-changed)", output["bullets"])
             self.assertIn("Added shared closeout parsing", output["bullets"])
@@ -286,6 +288,51 @@ class TestCloseoutHelperContract(unittest.TestCase):
                 "bespoke prose that should not leak into the digest",
                 output["bullets"],
             )
+
+    def test_helper_excludes_fenced_block_contents_and_keeps_literal_hash_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            review_packet = Path(tmpdir) / "review-packet.md"
+            review_packet.write_text(
+                dedent(
+                    """
+                    # Review Packet
+
+                    ## What Changed
+                    - Added shared closeout parsing
+                    #literal-marker should stay visible
+                    ```text
+                    - hidden code bullet
+                    ### hidden fenced heading
+                    hidden snippet line
+                    ```
+
+                    ## Remaining Attention
+                    - reviewer should confirm the wording
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output = _run_node_json(
+                f"""
+                import {{ loadCloseoutDigest }} from './adapters/shared/specwright-closeout.mjs';
+                const digest = loadCloseoutDigest({{
+                  reviewPacketPath: {json.dumps(str(review_packet))}
+                }});
+                console.log(JSON.stringify(digest));
+                """
+            )
+
+            self.assertEqual(
+                output["headline"],
+                "Attention required: reviewer should confirm the wording",
+            )
+            self.assertIn("Added shared closeout parsing", output["bullets"])
+            self.assertIn("#literal-marker should stay visible", output["bullets"])
+            self.assertNotIn("hidden code bullet", output["bullets"])
+            self.assertNotIn("### hidden fenced heading", output["bullets"])
+            self.assertNotIn("hidden snippet line", output["bullets"])
 
 
 class TestApprovalAssessmentReasons(unittest.TestCase):

--- a/evals/tests/test_closeout_digest_contract.py
+++ b/evals/tests/test_closeout_digest_contract.py
@@ -1,0 +1,64 @@
+"""Regression tests for Unit 01 — closeout digest and approval foundation."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+DECISION_PROTOCOL = ROOT_DIR / "core" / "protocols" / "decision.md"
+REVIEW_PACKET_PROTOCOL = ROOT_DIR / "core" / "protocols" / "review-packet.md"
+
+
+class TestDecisionProtocolDigestContract(unittest.TestCase):
+    """Task 1 RED: the stage handoff contract must describe the human digest."""
+
+    def setUp(self):
+        self.decision_text = DECISION_PROTOCOL.read_text(encoding="utf-8")
+
+    def test_gate_handoff_defines_digest_above_exact_footer(self):
+        self.assertRegex(
+            self.decision_text,
+            re.compile(
+                r"human(?:-facing)? closeout digest[\s\S]*above the exact three-line footer",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_gate_handoff_keeps_footer_as_final_three_lines(self):
+        self.assertRegex(
+            self.decision_text,
+            re.compile(
+                r"exact footer remains the final three lines",
+                re.IGNORECASE,
+            ),
+        )
+
+
+class TestReviewPacketDigestReuse(unittest.TestCase):
+    """Task 1 RED: review-packet must describe how closeout reuse works."""
+
+    def setUp(self):
+        self.review_text = REVIEW_PACKET_PROTOCOL.read_text(encoding="utf-8")
+
+    def test_review_packet_declares_it_can_feed_closeout_digest(self):
+        self.assertRegex(
+            self.review_text,
+            re.compile(
+                r"closeout digest[\s\S]*derived from.*review-packet|review-packet[\s\S]*closeout digest",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_review_packet_forbids_bespoke_duplicate_summary_surface(self):
+        self.assertRegex(
+            self.review_text,
+            re.compile(
+                r"must not become a second free-form summary surface",
+                re.IGNORECASE,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This unit establishes the first closeout and approval-lineage foundation for the workflow-legibility/devex workstream. It defines the shared closeout digest contract, aligns stale-approval reason codes across protocol and helper surfaces, and locks the behavior with regression coverage without weakening verify strictness.

Because this repository uses clone-local work artifacts, the reviewer-usable audit summary is inlined below instead of depending on local-only `.git/specwright/...` paths.

## Approval Lineage
- Design approval: **APPROVED** from `/sw-plan`. The current design artifact set still matches the recorded approval hash.
- Unit-spec approval for `01-closeout-and-approval-foundation`: **STALE** (`artifact-set-changed`) from `/sw-build`. `plan.md` changed after approval when build appended the as-built note.
- Accepted-mutant lineage: none recorded in this verify run.

## What Changed
- `core/protocols/decision.md` now defines stage handoff as a compact human digest above the exact three-line footer.
- `core/protocols/approvals.md` and `core/protocols/review-packet.md` now share the compact stale-reason vocabulary: `missing-entry`, `artifact-set-changed`, `missing-lineage`, `expired`, and `superseded`.
- `adapters/shared/specwright-approvals.mjs` now returns structured freshness assessments with status, reason code, and approved/current artifact hashes.
- `adapters/shared/specwright-closeout.mjs` now derives compact digests from `stage-report.md` and `review-packet.md`.
- `evals/tests/test_closeout_digest_contract.py` now locks the footer block, digest derivation, stale-reason alignment, and accepted-mutant expiry semantics in regression coverage.

## Why The Agent Implemented It This Way
- Task 1 defined the closeout contract in shared protocols first so later surfaces can reuse one explicit model instead of inferring it from scattered wording.
- Task 2 moved stale-reason vocabulary and digest parsing into shared protocol/helper surfaces so later lifecycle commands can reuse one artifact-derived explanation path.
- Task 3 stayed test-only so the unit finished by proving the contract cannot drift without a targeted regression failure.

## Acceptance Criteria
- **AC-1 — PASS**  
  Implementation: `core/protocols/decision.md:316-326`  
  Evidence: `evals/tests/test_closeout_digest_contract.py:38-70` (`TestDecisionProtocolDigestContract::test_gate_handoff_defines_digest_above_exact_footer`, `::test_gate_handoff_keeps_footer_as_final_three_lines`, `::test_gate_handoff_footer_block_stays_exact`)
- **AC-2 — PASS**  
  Implementation: `core/protocols/approvals.md:86-101,169-183`; `core/protocols/review-packet.md:41-43,73-78`  
  Evidence: `evals/tests/test_closeout_digest_contract.py:104-136` (`TestApprovalsReasonVocabulary::test_approvals_protocol_lists_reason_code_vocabulary`, `::test_reason_code_vocabulary_stays_aligned_across_protocols_and_helper`)
- **AC-3 — PASS**  
  Implementation: `adapters/shared/specwright-closeout.mjs:74-127`  
  Evidence: `evals/tests/test_closeout_digest_contract.py:142-288` (`TestCloseoutHelperContract::test_helper_prefers_stage_report_when_present`, `::test_helper_falls_back_to_review_packet`, `::test_helper_keeps_digest_artifact_derived`)
- **AC-4 — PASS**  
  Implementation: `adapters/shared/specwright-approvals.mjs:117-130,140-167,169-236,270-360`  
  Evidence: `evals/tests/test_closeout_digest_contract.py:291-389` (`TestApprovalAssessmentReasons::test_assessment_returns_reason_codes_and_hashes`)
- **AC-5 — PASS**  
  Implementation: `evals/tests/test_closeout_digest_contract.py:56-389`  
  Evidence: the eleven passing assertions in `evals/tests/test_closeout_digest_contract.py`, executed in the recorded passing verify test tier alongside the full eval and Claude Code build regressions.

## Spec Conformance
- `gate-spec`: **PASS**. AC-1 through AC-5 passed in the canonical compliance matrix for this unit.
- Behavioral IC mapping was inactive for this verify run because this is not the final work unit in the design.

## Gate Summary
| Gate | Status | Evidence-grounded summary |
|---|---|---|
| build | PASS | `bash build/build.sh` passed; the configured test tier also passed with `988 passed, 1 skipped, 3 deselected` plus `263 passed, 0 failed` in the Claude Code build regression suite. |
| tests | PASS | The changed regression uses exact footer/reason-code assertions, real temp files, real Node execution, and a T3 mutation-resistance floor with all bypass classes passing. |
| security | PASS | No secrets or injection/data-exposure concerns were introduced; the diff stays in local markdown/protocol/helper/test surfaces. |
| wiring | WARN | `adapters/shared/specwright-closeout.mjs` is still only consumed by the regression suite in this foundation unit; live adapter/status wiring is deferred to later units. |
| semantic | PASS | The changed helper logic remains fail-closed on stale approval lineage and does not introduce unchecked-error or error-data-leakage regressions. |
| spec | PASS | The acceptance-criteria matrix maps each AC to implementation and test evidence with no WARN or BLOCK findings. |

## Remaining Attention
- The current `unit-spec` approval lineage is stale because `plan.md` changed after `/sw-build` recorded approval.
- `adapters/shared/specwright-closeout.mjs` is only exercised through regression tests in this foundation unit; later units should wire it into live adapter/status surfaces to clear the wiring warning.

## Evidence Links
- Implementation surfaces: `core/protocols/decision.md`, `core/protocols/approvals.md`, `core/protocols/review-packet.md`, `adapters/shared/specwright-approvals.mjs`, `adapters/shared/specwright-closeout.mjs`
- Regression proof: `evals/tests/test_closeout_digest_contract.py`
- Clone-local audit artifacts from `/sw-verify` were generated under local Specwright state and are summarized inline above for reviewer use.