### PR TITLE
feat(runtime): add project-visible runtime roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.specwright/state/
 /.specwright/work/
 /.specwright/worktrees/
+/.specwright-local/
 .claude/
 !.claude/commands/
 

--- a/.specwright/config.json
+++ b/.specwright/config.json
@@ -37,6 +37,10 @@
         "ship": "require"
       }
     },
+    "runtime": {
+      "mode": "git-admin",
+      "projectVisibleRoot": ".specwright-local"
+    },
     "workArtifacts": {
       "mode": "clone-local",
       "trackedRoot": null

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -120,11 +120,14 @@ function deriveWorktreeId(gitDir, gitCommonDir) {
   }
 
   if (dirname(gitDir) === join(gitCommonDir, 'worktrees')) {
-    return basename(gitDir);
+    const linkedWorktreeId = basename(gitDir);
+    if (linkedWorktreeId && linkedWorktreeId !== PRIMARY_WORKTREE_ID) {
+      return linkedWorktreeId;
+    }
   }
 
   const tail = basename(gitDir);
-  if (tail && tail !== '.git') {
+  if (tail && tail !== '.git' && tail !== PRIMARY_WORKTREE_ID) {
     return tail;
   }
 
@@ -269,6 +272,11 @@ function resolveProjectVisibleRoots({
   const sharedRuntimeRoot = resolve(runtimeParent, projectVisibleRoot);
   const effectiveSharedRuntimeRoot = resolvePathThroughExistingAncestors(runtimeParent, sharedRuntimeRoot);
   const effectiveProjectArtifactsRoot = resolvePathThroughExistingAncestors(projectRoot, projectArtifactsRoot);
+  const primaryProjectArtifactsRoot = join(runtimeParent, PROJECT_ARTIFACTS_DIR);
+  const effectivePrimaryProjectArtifactsRoot = resolvePathThroughExistingAncestors(
+    runtimeParent,
+    primaryProjectArtifactsRoot
+  );
   const effectiveGitDir = realpathIfPossible(gitDir);
   const effectiveGitCommonDir = realpathIfPossible(gitCommonDir);
 
@@ -308,8 +316,11 @@ function resolveProjectVisibleRoots({
 
   if (
     pathsOverlap(sharedRuntimeRoot, projectArtifactsRoot) ||
+    pathsOverlap(sharedRuntimeRoot, primaryProjectArtifactsRoot) ||
     pathsOverlap(effectiveSharedRuntimeRoot, projectArtifactsRoot) ||
-    pathsOverlap(effectiveSharedRuntimeRoot, effectiveProjectArtifactsRoot)
+    pathsOverlap(effectiveSharedRuntimeRoot, effectiveProjectArtifactsRoot) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, primaryProjectArtifactsRoot) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, effectivePrimaryProjectArtifactsRoot)
   ) {
     return buildInvalidRuntimeRootFailure(
       'config.git.runtime.projectVisibleRoot',
@@ -318,17 +329,19 @@ function resolveProjectVisibleRoots({
       {
         sharedRuntimeRoot,
         effectiveSharedRuntimeRoot,
-        projectArtifactsRoot
+        projectArtifactsRoot,
+        primaryProjectArtifactsRoot
       }
     );
   }
 
+  const repoStateRoot = join(sharedRuntimeRoot, 'repo');
   return {
     ok: true,
     sharedRuntimeRoot,
-    repoStateRoot: join(sharedRuntimeRoot, 'repo'),
+    repoStateRoot,
     worktreeStateRoot: join(sharedRuntimeRoot, 'worktrees', worktreeId),
-    cloneLocalWorkArtifactsRoot: join(sharedRuntimeRoot, 'work')
+    cloneLocalWorkArtifactsRoot: join(repoStateRoot, 'work')
   };
 }
 

--- a/adapters/shared/specwright-state-paths.mjs
+++ b/adapters/shared/specwright-state-paths.mjs
@@ -4,10 +4,13 @@ import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 
 const FAILURE_CODE = 'GIT_RESOLUTION_FAILED';
+const INVALID_RUNTIME_ROOT_CODE = 'INVALID_RUNTIME_ROOT';
 const PRIMARY_WORKTREE_ID = 'main-worktree';
 const PROJECT_ARTIFACTS_DIR = '.specwright';
 const LEGACY_STATE_SEGMENTS = ['.specwright', 'state'];
 const SHARED_CONFIG_FILE = 'config.json';
+const DEFAULT_RUNTIME_MODE = 'git-admin';
+const DEFAULT_PROJECT_VISIBLE_ROOT = '.specwright-local';
 const FALLBACK_REPO_LOCAL_GIT_ENV_VARS = new Set([
   // Tracks `git rev-parse --local-env-vars` plus config-injection vars that
   // Git does not report but are still unsafe to inherit across repositories.
@@ -86,6 +89,18 @@ function buildFailure(root, cwd, args, error) {
   };
 }
 
+function buildInvalidRuntimeRootFailure(root, cwd, message, details = {}) {
+  return {
+    ok: false,
+    code: INVALID_RUNTIME_ROOT_CODE,
+    root,
+    cwd,
+    command: null,
+    message,
+    ...details
+  };
+}
+
 function resolveGitRoot(cwd, root, args) {
   try {
     const value = runGit(args, cwd);
@@ -114,45 +129,6 @@ function deriveWorktreeId(gitDir, gitCommonDir) {
   }
 
   return `worktree-${createHash('sha256').update(gitDir).digest('hex').slice(0, 12)}`;
-}
-
-export function resolveSpecwrightRoots(options = {}) {
-  const cwd = resolve(options.cwd ?? process.cwd());
-
-  const projectRootResult = resolveGitRoot(cwd, 'projectRoot', ['rev-parse', '--show-toplevel']);
-  if (!projectRootResult.ok) {
-    return projectRootResult;
-  }
-
-  const projectRoot = resolve(projectRootResult.value);
-  const projectArtifactsRoot = join(projectRoot, PROJECT_ARTIFACTS_DIR);
-
-  const gitDirResult = resolveGitRoot(projectRoot, 'gitDir', ['rev-parse', '--git-dir']);
-  if (!gitDirResult.ok) {
-    return gitDirResult;
-  }
-
-  const gitCommonDirResult = resolveGitRoot(projectRoot, 'gitCommonDir', ['rev-parse', '--git-common-dir']);
-  if (!gitCommonDirResult.ok) {
-    return gitCommonDirResult;
-  }
-
-  const gitDir = resolve(projectRoot, gitDirResult.value);
-  const gitCommonDir = resolve(projectRoot, gitCommonDirResult.value);
-  const repoStateRoot = join(gitCommonDir, 'specwright');
-  const worktreeStateRoot = join(gitDir, 'specwright');
-
-  return {
-    ok: true,
-    projectRoot,
-    projectArtifactsRoot,
-    gitDir,
-    gitCommonDir,
-    repoStateRoot,
-    worktreeStateRoot,
-    workArtifactsRoot: resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot, worktreeStateRoot),
-    worktreeId: deriveWorktreeId(gitDir, gitCommonDir)
-  };
 }
 
 export function resolveLegacyStatePaths(options = {}) {
@@ -225,6 +201,14 @@ function resolvePathThroughExistingAncestors(basePath, targetPath) {
   return currentPath;
 }
 
+function realpathIfPossible(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 function loadResolvedConfig(projectArtifactsRoot, repoStateRoot) {
   const candidates = [
     join(projectArtifactsRoot, SHARED_CONFIG_FILE),
@@ -251,7 +235,148 @@ function loadResolvedConfig(projectArtifactsRoot, repoStateRoot) {
   };
 }
 
-function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRoot, worktreeStateRoot) {
+function normalizeRuntimeMode(value) {
+  return value === 'project-visible' ? 'project-visible' : DEFAULT_RUNTIME_MODE;
+}
+
+function normalizeProjectVisibleRoot(value) {
+  return normalizeTrackedRoot(value) ?? DEFAULT_PROJECT_VISIBLE_ROOT;
+}
+
+function resolveRuntimePolicy(projectArtifactsRoot, gitCommonDir) {
+  const gitAdminRepoStateRoot = join(gitCommonDir, 'specwright');
+  const { path, config } = loadResolvedConfig(projectArtifactsRoot, gitAdminRepoStateRoot);
+  const runtimeConfig = config?.git?.runtime ?? {};
+
+  return {
+    configPath: path,
+    config,
+    runtimeMode: normalizeRuntimeMode(runtimeConfig?.mode),
+    projectVisibleRoot: normalizeProjectVisibleRoot(runtimeConfig?.projectVisibleRoot)
+  };
+}
+
+function resolveProjectVisibleRoots({
+  cwd,
+  projectRoot,
+  projectArtifactsRoot,
+  gitDir,
+  gitCommonDir,
+  worktreeId,
+  projectVisibleRoot
+}) {
+  const runtimeParent = dirname(gitCommonDir);
+  const sharedRuntimeRoot = resolve(runtimeParent, projectVisibleRoot);
+  const effectiveSharedRuntimeRoot = resolvePathThroughExistingAncestors(runtimeParent, sharedRuntimeRoot);
+  const effectiveProjectArtifactsRoot = resolvePathThroughExistingAncestors(projectRoot, projectArtifactsRoot);
+  const effectiveGitDir = realpathIfPossible(gitDir);
+  const effectiveGitCommonDir = realpathIfPossible(gitCommonDir);
+
+  if (!isPathWithin(runtimeParent, sharedRuntimeRoot) || !isPathWithin(runtimeParent, effectiveSharedRuntimeRoot)) {
+    return buildInvalidRuntimeRootFailure(
+      'config.git.runtime.projectVisibleRoot',
+      cwd,
+      'project-visible runtime root must stay under the git common-dir parent.',
+      {
+        runtimeParent,
+        sharedRuntimeRoot,
+        effectiveSharedRuntimeRoot
+      }
+    );
+  }
+
+  if (
+    pathsOverlap(sharedRuntimeRoot, gitDir) ||
+    pathsOverlap(sharedRuntimeRoot, gitCommonDir) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, gitDir) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, gitCommonDir) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, effectiveGitDir) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, effectiveGitCommonDir)
+  ) {
+    return buildInvalidRuntimeRootFailure(
+      'config.git.runtime.projectVisibleRoot',
+      cwd,
+      'project-visible runtime root must not resolve inside .git or a symlinked git mirror.',
+      {
+        sharedRuntimeRoot,
+        effectiveSharedRuntimeRoot,
+        gitDir,
+        gitCommonDir
+      }
+    );
+  }
+
+  if (
+    pathsOverlap(sharedRuntimeRoot, projectArtifactsRoot) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, projectArtifactsRoot) ||
+    pathsOverlap(effectiveSharedRuntimeRoot, effectiveProjectArtifactsRoot)
+  ) {
+    return buildInvalidRuntimeRootFailure(
+      'config.git.runtime.projectVisibleRoot',
+      cwd,
+      'project-visible runtime root must stay separate from tracked project artifacts.',
+      {
+        sharedRuntimeRoot,
+        effectiveSharedRuntimeRoot,
+        projectArtifactsRoot
+      }
+    );
+  }
+
+  return {
+    ok: true,
+    sharedRuntimeRoot,
+    repoStateRoot: join(sharedRuntimeRoot, 'repo'),
+    worktreeStateRoot: join(sharedRuntimeRoot, 'worktrees', worktreeId),
+    cloneLocalWorkArtifactsRoot: join(sharedRuntimeRoot, 'work')
+  };
+}
+
+function resolveRuntimeRoots({ cwd, projectRoot, projectArtifactsRoot, gitDir, gitCommonDir, worktreeId }) {
+  const runtimePolicy = resolveRuntimePolicy(projectArtifactsRoot, gitCommonDir);
+
+  if (runtimePolicy.runtimeMode === 'project-visible') {
+    const projectVisibleRoots = resolveProjectVisibleRoots({
+      cwd,
+      projectRoot,
+      projectArtifactsRoot,
+      gitDir,
+      gitCommonDir,
+      worktreeId,
+      projectVisibleRoot: runtimePolicy.projectVisibleRoot
+    });
+
+    if (!projectVisibleRoots.ok) {
+      return projectVisibleRoots;
+    }
+
+    return {
+      ok: true,
+      ...runtimePolicy,
+      ...projectVisibleRoots
+    };
+  }
+
+  const repoStateRoot = join(gitCommonDir, 'specwright');
+  const worktreeStateRoot = join(gitDir, 'specwright');
+
+  return {
+    ok: true,
+    ...runtimePolicy,
+    sharedRuntimeRoot: repoStateRoot,
+    repoStateRoot,
+    worktreeStateRoot,
+    cloneLocalWorkArtifactsRoot: join(repoStateRoot, 'work')
+  };
+}
+
+function resolveWorkArtifactsRoot(
+  projectRoot,
+  projectArtifactsRoot,
+  repoStateRoot,
+  worktreeStateRoot,
+  cloneLocalWorkArtifactsRoot
+) {
   const { config } = loadResolvedConfig(projectArtifactsRoot, repoStateRoot);
   const workArtifacts = config?.git?.workArtifacts ?? {};
   const mode = workArtifacts?.mode === 'tracked' ? 'tracked' : 'clone-local';
@@ -269,14 +394,75 @@ function resolveWorkArtifactsRoot(projectRoot, projectArtifactsRoot, repoStateRo
       firstSegment !== '.git' &&
       !pathsOverlap(trackedPath, repoStateRoot) &&
       !pathsOverlap(trackedPath, worktreeStateRoot) &&
+      !pathsOverlap(trackedPath, cloneLocalWorkArtifactsRoot) &&
       !pathsOverlap(effectiveTrackedPath, repoStateRoot) &&
-      !pathsOverlap(effectiveTrackedPath, worktreeStateRoot)
+      !pathsOverlap(effectiveTrackedPath, worktreeStateRoot) &&
+      !pathsOverlap(effectiveTrackedPath, cloneLocalWorkArtifactsRoot)
     ) {
       return trackedPath;
     }
   }
 
-  return join(repoStateRoot, 'work');
+  return cloneLocalWorkArtifactsRoot;
+}
+
+export function resolveSpecwrightRoots(options = {}) {
+  const cwd = resolve(options.cwd ?? process.cwd());
+
+  const projectRootResult = resolveGitRoot(cwd, 'projectRoot', ['rev-parse', '--show-toplevel']);
+  if (!projectRootResult.ok) {
+    return projectRootResult;
+  }
+
+  const projectRoot = resolve(projectRootResult.value);
+  const projectArtifactsRoot = join(projectRoot, PROJECT_ARTIFACTS_DIR);
+
+  const gitDirResult = resolveGitRoot(projectRoot, 'gitDir', ['rev-parse', '--git-dir']);
+  if (!gitDirResult.ok) {
+    return gitDirResult;
+  }
+
+  const gitCommonDirResult = resolveGitRoot(projectRoot, 'gitCommonDir', ['rev-parse', '--git-common-dir']);
+  if (!gitCommonDirResult.ok) {
+    return gitCommonDirResult;
+  }
+
+  const gitDir = resolve(projectRoot, gitDirResult.value);
+  const gitCommonDir = resolve(projectRoot, gitCommonDirResult.value);
+  const worktreeId = deriveWorktreeId(gitDir, gitCommonDir);
+  const runtimeRoots = resolveRuntimeRoots({
+    cwd,
+    projectRoot,
+    projectArtifactsRoot,
+    gitDir,
+    gitCommonDir,
+    worktreeId
+  });
+
+  if (!runtimeRoots.ok) {
+    return runtimeRoots;
+  }
+
+  return {
+    ok: true,
+    projectRoot,
+    projectArtifactsRoot,
+    gitDir,
+    gitCommonDir,
+    worktreeId,
+    runtimeMode: runtimeRoots.runtimeMode,
+    projectVisibleRoot: runtimeRoots.projectVisibleRoot,
+    sharedRuntimeRoot: runtimeRoots.sharedRuntimeRoot,
+    repoStateRoot: runtimeRoots.repoStateRoot,
+    worktreeStateRoot: runtimeRoots.worktreeStateRoot,
+    workArtifactsRoot: resolveWorkArtifactsRoot(
+      projectRoot,
+      projectArtifactsRoot,
+      runtimeRoots.repoStateRoot,
+      runtimeRoots.worktreeStateRoot,
+      runtimeRoots.cloneLocalWorkArtifactsRoot
+    )
+  };
 }
 
 function normalizeAttachedWorkId(value) {
@@ -422,7 +608,9 @@ function parseWorktreeList(text) {
 
 function listSessionFiles(roots) {
   const sessionFiles = [];
-  const primarySessionPath = join(roots.gitCommonDir, 'specwright', 'session.json');
+  const primarySessionPath = roots.runtimeMode === 'project-visible'
+    ? join(roots.sharedRuntimeRoot, 'worktrees', PRIMARY_WORKTREE_ID, 'session.json')
+    : join(roots.gitCommonDir, 'specwright', 'session.json');
   if (existsSync(primarySessionPath)) {
     sessionFiles.push({
       worktreeId: PRIMARY_WORKTREE_ID,
@@ -430,7 +618,9 @@ function listSessionFiles(roots) {
     });
   }
 
-  const linkedWorktreesDir = join(roots.gitCommonDir, 'worktrees');
+  const linkedWorktreesDir = roots.runtimeMode === 'project-visible'
+    ? join(roots.sharedRuntimeRoot, 'worktrees')
+    : join(roots.gitCommonDir, 'worktrees');
   if (!existsSync(linkedWorktreesDir)) {
     return sessionFiles;
   }
@@ -440,7 +630,12 @@ function listSessionFiles(roots) {
       continue;
     }
 
-    const sessionPath = join(linkedWorktreesDir, entry.name, 'specwright', 'session.json');
+    const sessionPath = roots.runtimeMode === 'project-visible'
+      ? join(linkedWorktreesDir, entry.name, 'session.json')
+      : join(linkedWorktreesDir, entry.name, 'specwright', 'session.json');
+    if (sessionPath === primarySessionPath) {
+      continue;
+    }
     if (!existsSync(sessionPath)) {
       continue;
     }

--- a/core/protocols/context.md
+++ b/core/protocols/context.md
@@ -9,12 +9,49 @@ invocation:
 |---|---|---|
 | `projectRoot` | `git rev-parse --show-toplevel` | source tree and user-facing cwd |
 | `projectArtifactsRoot` | `{projectRoot}/.specwright` | tracked project artifacts and shared agent guidance |
-| `repoStateRoot` | `git rev-parse --git-common-dir` + `/specwright` | shared clone-local runtime state |
-| `worktreeStateRoot` | `git rev-parse --git-dir` + `/specwright` | per-worktree session and continuation state |
-| `workArtifactsRoot` | `{repoStateRoot}/work` by default; `{projectRoot}/{config.git.workArtifacts.trackedRoot}` when tracked mode is configured | auditable work artifacts |
+| `repoStateRoot` | depends on `config.git.runtime.mode`: `git-admin` -> `git rev-parse --git-common-dir` + `/specwright`; `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/repo` | shared clone-local runtime state |
+| `worktreeStateRoot` | depends on `config.git.runtime.mode`: `git-admin` -> `git rev-parse --git-dir` + `/specwright`; `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/worktrees/{worktreeId}` | per-worktree session and continuation state |
+| `workArtifactsRoot` | clone-local mode follows the runtime mode: `git-admin` -> `{repoStateRoot}/work`, `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/work`; tracked publication uses `{projectRoot}/{config.git.workArtifacts.trackedRoot}` when configured | auditable work artifacts |
 
 Callers must prefer those logical roots over hardcoded `.specwright/...` or
 `.git/specwright/...` path concatenation.
+
+## Runtime Mode Policy
+
+The runtime-root policy surface lives under tracked config:
+
+- `config.git.runtime.mode` — `git-admin` or `project-visible`
+- `config.git.runtime.projectVisibleRoot` — repo-visible clone-local runtime
+  root name, default `.specwright-local`
+
+If the `runtime` block is absent, callers must default to `git-admin` for
+backward compatibility with existing installs.
+
+Runtime mode governs clone-local runtime placement only. Work-artifact
+publication remains separate from runtime mode and is still controlled by
+`config.git.workArtifacts`.
+
+### Runtime Mode Mapping
+
+| Mode | Runtime mapping |
+|---|---|
+| `git-admin` | `repoStateRoot = {gitCommonDir}/specwright`, `worktreeStateRoot = {gitDir}/specwright`, clone-local `workArtifactsRoot = {repoStateRoot}/work` |
+| `project-visible` | shared runtime root = `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}`, `repoStateRoot = {sharedRuntimeRoot}/repo`, `worktreeStateRoot = {sharedRuntimeRoot}/worktrees/{worktreeId}`, clone-local `workArtifactsRoot = {sharedRuntimeRoot}/work` |
+
+Guardrails for `project-visible` mode:
+
+In `project-visible` mode, the repo state root, worktree state root, and work
+artifacts root all move under the shared runtime root instead of `.git`.
+Project-visible maps the repo state root to `{sharedRuntimeRoot}/repo`, the
+worktree state root to `{sharedRuntimeRoot}/worktrees/{worktreeId}`, and the
+work artifacts root to `{sharedRuntimeRoot}/work`.
+
+- the resolved `projectVisibleRoot` must stay clone-local and untracked by
+  default
+- it must resolve from the Git common-dir parent, not from `.git/`
+- tracked project artifacts remain under `projectArtifactsRoot`
+- tracked work-artifact publication, when enabled, remains independent from the
+  runtime-mode root
 
 ## Standard Context Documents
 
@@ -71,12 +108,15 @@ Run this sequence before loading Specwright state:
 2. derive `projectArtifactsRoot`
 3. resolve `gitDir`
 4. resolve `gitCommonDir`
-5. derive `repoStateRoot`
-6. derive `worktreeStateRoot`
-7. resolve `workArtifactsRoot`: read `config.git.workArtifacts` from
+5. read `config.git.runtime` from `{projectArtifactsRoot}/config.json` when
+   present; if the block is absent, default to `git-admin`
+6. derive `repoStateRoot` and `worktreeStateRoot` from the resolved runtime
+   mode and `worktreeId`
+7. resolve `workArtifactsRoot`: keep tracked publication separate from runtime
+   mode by reading `config.git.workArtifacts` from
    `{projectArtifactsRoot}/config.json` when present, else from
-   `{repoStateRoot}/config.json`; default to `{repoStateRoot}/work` when
-   neither config exists or the mode is not `tracked`
+   `{repoStateRoot}/config.json`; default the clone-local path from the active
+   runtime mode when the tracked mode is not configured
 
 If Git root resolution fails, report which root failed and whether the problem
 is local to this worktree or repo-wide.

--- a/core/protocols/context.md
+++ b/core/protocols/context.md
@@ -11,7 +11,7 @@ invocation:
 | `projectArtifactsRoot` | `{projectRoot}/.specwright` | tracked project artifacts and shared agent guidance |
 | `repoStateRoot` | depends on `config.git.runtime.mode`: `git-admin` -> `git rev-parse --git-common-dir` + `/specwright`; `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/repo` | shared clone-local runtime state |
 | `worktreeStateRoot` | depends on `config.git.runtime.mode`: `git-admin` -> `git rev-parse --git-dir` + `/specwright`; `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/worktrees/{worktreeId}` | per-worktree session and continuation state |
-| `workArtifactsRoot` | clone-local mode follows the runtime mode: `git-admin` -> `{repoStateRoot}/work`, `project-visible` -> `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}/work`; tracked publication uses `{projectRoot}/{config.git.workArtifacts.trackedRoot}` when configured | auditable work artifacts |
+| `workArtifactsRoot` | clone-local mode stays anchored under repo state: `git-admin` -> `{repoStateRoot}/work`, `project-visible` -> `{repoStateRoot}/work` where `repoStateRoot = <git common-dir parent>/{config.git.runtime.projectVisibleRoot}/repo`; tracked publication uses `{projectRoot}/{config.git.workArtifacts.trackedRoot}` when configured | auditable work artifacts |
 
 Callers must prefer those logical roots over hardcoded `.specwright/...` or
 `.git/specwright/...` path concatenation.
@@ -36,7 +36,7 @@ publication remains separate from runtime mode and is still controlled by
 | Mode | Runtime mapping |
 |---|---|
 | `git-admin` | `repoStateRoot = {gitCommonDir}/specwright`, `worktreeStateRoot = {gitDir}/specwright`, clone-local `workArtifactsRoot = {repoStateRoot}/work` |
-| `project-visible` | shared runtime root = `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}`, `repoStateRoot = {sharedRuntimeRoot}/repo`, `worktreeStateRoot = {sharedRuntimeRoot}/worktrees/{worktreeId}`, clone-local `workArtifactsRoot = {sharedRuntimeRoot}/work` |
+| `project-visible` | shared runtime root = `<git common-dir parent>/{config.git.runtime.projectVisibleRoot}`, `repoStateRoot = {sharedRuntimeRoot}/repo`, `worktreeStateRoot = {sharedRuntimeRoot}/worktrees/{worktreeId}`, clone-local `workArtifactsRoot = {repoStateRoot}/work` |
 
 Guardrails for `project-visible` mode:
 
@@ -44,7 +44,7 @@ In `project-visible` mode, the repo state root, worktree state root, and work
 artifacts root all move under the shared runtime root instead of `.git`.
 Project-visible maps the repo state root to `{sharedRuntimeRoot}/repo`, the
 worktree state root to `{sharedRuntimeRoot}/worktrees/{worktreeId}`, and the
-work artifacts root to `{sharedRuntimeRoot}/work`.
+work artifacts root to `{repoStateRoot}/work`.
 
 - the resolved `projectVisibleRoot` must stay clone-local and untracked by
   default

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -1,0 +1,113 @@
+"""Contract tests for Unit 02 - runtime mode config and path model.
+
+Task 1 starts with the tracked config and context protocol surface. Later tasks
+extend this module with resolver and migration-safety proofs.
+"""
+
+import json
+import os
+import unittest
+
+from evals.tests._text_helpers import assert_multiline_regex, load_text
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CONFIG_PATH = os.path.join(_REPO_ROOT, ".specwright", "config.json")
+_CONTEXT_PROTOCOL_PATH = os.path.join(_REPO_ROOT, "core", "protocols", "context.md")
+
+
+def _load_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestRuntimeModeConfigDefaults(unittest.TestCase):
+    """AC-1: tracked config defines runtime mode without changing artifact mode."""
+
+    def setUp(self):
+        self.config = _load_json(_CONFIG_PATH)
+        self.git_config = self.config["git"]
+
+    def test_git_config_has_runtime_block(self):
+        self.assertIn(
+            "runtime",
+            self.git_config,
+            "config.git must define a runtime block",
+        )
+
+    def test_runtime_block_has_required_keys(self):
+        runtime = self.git_config["runtime"]
+        expected_keys = {"mode", "projectVisibleRoot"}
+        self.assertTrue(
+            expected_keys.issubset(runtime.keys()),
+            f"runtime block missing keys: {sorted(expected_keys - set(runtime.keys()))}",
+        )
+
+    def test_runtime_mode_defaults_to_git_admin(self):
+        self.assertEqual(
+            self.git_config["runtime"]["mode"],
+            "git-admin",
+            "existing installs should stay on git-admin until they opt in",
+        )
+
+    def test_project_visible_root_defaults_to_dot_specwright_local(self):
+        self.assertEqual(
+            self.git_config["runtime"]["projectVisibleRoot"],
+            ".specwright-local",
+        )
+
+    def test_work_artifacts_block_remains_separate_from_runtime_block(self):
+        self.assertIn("workArtifacts", self.git_config)
+        self.assertIn("runtime", self.git_config)
+        self.assertIsInstance(self.git_config["workArtifacts"], dict)
+        self.assertIsInstance(self.git_config["runtime"], dict)
+
+
+class TestRuntimeModeContextProtocol(unittest.TestCase):
+    """AC-1: context protocol documents the runtime-mode vocabulary and split."""
+
+    def setUp(self):
+        self.content = load_text(_CONTEXT_PROTOCOL_PATH)
+        self.lower = self.content.lower()
+
+    def test_protocol_mentions_runtime_mode_keys(self):
+        self.assertIn("git.runtime.mode", self.content)
+        self.assertIn("git.runtime.projectVisibleRoot", self.content)
+
+    def test_protocol_names_both_runtime_modes(self):
+        self.assertIn("git-admin", self.lower)
+        self.assertIn("project-visible", self.lower)
+
+    def test_project_visible_root_is_described_as_git_common_dir_parent_relative(self):
+        assert_multiline_regex(
+            self,
+            self.lower,
+            r"project-visible.{0,200}git common-dir parent|git common-dir parent.{0,200}project-visible",
+        )
+
+    def test_protocol_describes_project_visible_runtime_split(self):
+        for needle in (
+            "repoStateRoot",
+            "worktreeStateRoot",
+            "workArtifactsRoot",
+            ".specwright-local",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.content)
+
+        assert_multiline_regex(
+            self,
+            self.lower,
+            r"project-visible.{0,240}repo state root.{0,120}worktree state root.{0,120}work artifacts root",
+        )
+
+    def test_work_artifact_publication_remains_independent(self):
+        assert_multiline_regex(
+            self,
+            self.lower,
+            r"work-artifact publication.+separate.+runtime mode|runtime mode.+separate.+work-artifact publication",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -17,6 +17,7 @@ from evals.tests._text_helpers import assert_multiline_regex, load_text
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _CONFIG_PATH = os.path.join(_REPO_ROOT, ".specwright", "config.json")
 _CONTEXT_PROTOCOL_PATH = os.path.join(_REPO_ROOT, "core", "protocols", "context.md")
+_GITIGNORE_PATH = os.path.join(_REPO_ROOT, ".gitignore")
 _STATE_PATHS_MODULE_PATH = os.path.join(
     _REPO_ROOT, "adapters", "shared", "specwright-state-paths.mjs"
 )
@@ -72,27 +73,30 @@ def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
 def _write_config(
     repo_path: Path,
     *,
-    runtime_mode: str,
+    runtime_mode: str | None,
     project_visible_root: str = ".specwright-local",
     work_artifacts_mode: str = "clone-local",
     tracked_root: str | None = None,
 ) -> None:
+    git_config = {
+        "workArtifacts": {
+            "mode": work_artifacts_mode,
+            "trackedRoot": tracked_root,
+        },
+    }
+    if runtime_mode is not None:
+        git_config["runtime"] = {
+            "mode": runtime_mode,
+            "projectVisibleRoot": project_visible_root,
+        }
+
     config_path = repo_path / ".specwright" / "config.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
         json.dumps(
             {
                 "version": "2.0",
-                "git": {
-                    "runtime": {
-                        "mode": runtime_mode,
-                        "projectVisibleRoot": project_visible_root,
-                    },
-                    "workArtifacts": {
-                        "mode": work_artifacts_mode,
-                        "trackedRoot": tracked_root,
-                    },
-                },
+                "git": git_config,
             },
             indent=2,
         )
@@ -211,6 +215,25 @@ process.stdout.write(JSON.stringify({
   artifactsRoot: work?.artifactsRoot ?? null,
   workDirPath: work?.workDirPath ?? null
 }));
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH,
+        },
+    )
+    return json.loads(completed.stdout)
+
+
+def _resolve_roots(repo_path: Path) -> dict:
+    script = """
+const { resolveSpecwrightRoots } = await import(process.env.STATE_PATHS_MODULE);
+process.stdout.write(JSON.stringify(resolveSpecwrightRoots({ cwd: process.cwd() })));
 """
     completed = subprocess.run(
         ["node", "--input-type=module", "-e", script],
@@ -424,6 +447,78 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
             self.assertEqual(
                 data["workDirPath"],
                 str((repo_path / ".specwright" / "audit-work" / "runtime-proof").resolve()),
+            )
+
+
+class TestRuntimeModeSafetyProof(unittest.TestCase):
+    """AC-4/AC-5: unsafe project-visible roots fail closed and git-admin remains compatible."""
+
+    def test_gitignore_excludes_project_visible_runtime_root_by_default(self):
+        self.assertIn("/.specwright-local/", load_text(_GITIGNORE_PATH))
+
+    def test_project_visible_root_inside_git_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "inside-git-repo"
+            _init_git_repo(repo_path)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                project_visible_root=".git/specwright-local",
+            )
+
+            roots = _resolve_roots(repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
+    def test_project_visible_root_inside_project_artifacts_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "inside-artifacts-repo"
+            _init_git_repo(repo_path)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                project_visible_root=".specwright/local-runtime",
+            )
+
+            roots = _resolve_roots(repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
+    def test_project_visible_root_symlinked_into_git_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "symlink-git-repo"
+            _init_git_repo(repo_path)
+            (repo_path / "runtime-link").symlink_to(repo_path / ".git", target_is_directory=True)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                project_visible_root="runtime-link",
+            )
+
+            roots = _resolve_roots(repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
+    def test_legacy_git_admin_install_still_loads_when_runtime_block_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "legacy-git-admin-repo"
+            _init_git_repo(repo_path)
+            _write_config(repo_path, runtime_mode=None)
+            _write_shared_state(repo_path, runtime_mode="git-admin")
+
+            data = _inspect_runtime_state(repo_path)
+
+            self.assertEqual(data["layout"], "shared")
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str((repo_path / ".git" / "specwright").resolve()),
+            )
+            self.assertEqual(
+                data["workflowPath"],
+                str((repo_path / ".git" / "specwright" / "work" / "runtime-proof" / "workflow.json").resolve()),
             )
 
 

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -4,6 +4,7 @@ Task 1 starts with the tracked config and context protocol surface. Later tasks
 extend this module with resolver and migration-safety proofs.
 """
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -62,12 +63,13 @@ def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
         return "main-worktree"
 
     if git_dir.parent == git_common_dir / "worktrees":
+        if git_dir.name and git_dir.name != "main-worktree":
+            return git_dir.name
+
+    if git_dir.name and git_dir.name not in {".git", "main-worktree"}:
         return git_dir.name
 
-    if git_dir.name and git_dir.name != ".git":
-        return git_dir.name
-
-    raise AssertionError(f"Unable to derive worktree id for {git_dir}")
+    return "worktree-" + hashlib.sha256(str(git_dir).encode("utf-8")).hexdigest()[:12]
 
 
 def _write_config(
@@ -119,7 +121,7 @@ def _runtime_roots(
         shared_runtime_root = git_common_dir.parent / project_visible_root
         repo_state_root = shared_runtime_root / "repo"
         worktree_state_root = shared_runtime_root / "worktrees" / worktree_id
-        clone_local_work_artifacts_root = shared_runtime_root / "work"
+        clone_local_work_artifacts_root = repo_state_root / "work"
     else:
         shared_runtime_root = git_common_dir / "specwright"
         repo_state_root = git_common_dir / "specwright"
@@ -318,6 +320,7 @@ class TestRuntimeModeContextProtocol(unittest.TestCase):
             "repoStateRoot",
             "worktreeStateRoot",
             "workArtifactsRoot",
+            "{repoStateRoot}/work",
             ".specwright-local",
         ):
             with self.subTest(needle=needle):
@@ -386,11 +389,19 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
             )
             self.assertEqual(
                 data["roots"]["workArtifactsRoot"],
-                str(visible_root / "work"),
+                str(visible_root / "repo" / "work"),
             )
             self.assertEqual(
                 data["workflowPath"],
                 str(visible_root / "repo" / "work" / "runtime-proof" / "workflow.json"),
+            )
+            self.assertEqual(
+                data["artifactsRoot"],
+                str(visible_root / "repo" / "work"),
+            )
+            self.assertEqual(
+                data["workDirPath"],
+                str(visible_root / "repo" / "work" / "runtime-proof"),
             )
 
     def test_project_visible_linked_worktree_keys_state_by_worktree_id(self):
@@ -416,6 +427,35 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
                 str(visible_root / "worktrees" / "linked-repo"),
             )
             self.assertEqual(data["roots"]["worktreeId"], "linked-repo")
+            self.assertEqual(
+                data["roots"]["workArtifactsRoot"],
+                str(visible_root / "repo" / "work"),
+            )
+
+    def test_project_visible_linked_worktree_named_main_worktree_uses_non_primary_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main_repo_path = Path(tmp) / "main-repo"
+            linked_repo_path = Path(tmp) / "main-worktree"
+            _init_git_repo(main_repo_path)
+            _run(
+                ["git", "worktree", "add", "-b", "runtime-main-worktree", str(linked_repo_path), "HEAD"],
+                cwd=main_repo_path,
+            )
+            _write_config(linked_repo_path, runtime_mode="project-visible")
+
+            data = _inspect_runtime_state(linked_repo_path)
+            visible_root = (main_repo_path / ".specwright-local").resolve()
+
+            self.assertTrue(data["roots"]["worktreeId"].startswith("worktree-"))
+            self.assertNotEqual(data["roots"]["worktreeId"], "main-worktree")
+            self.assertEqual(
+                data["roots"]["worktreeStateRoot"],
+                str(visible_root / "worktrees" / data["roots"]["worktreeId"]),
+            )
+            self.assertNotEqual(
+                data["roots"]["worktreeStateRoot"],
+                str(visible_root / "worktrees" / "main-worktree"),
+            )
 
     def test_tracked_work_artifacts_override_stays_independent_in_project_visible_mode(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -486,6 +526,26 @@ class TestRuntimeModeSafetyProof(unittest.TestCase):
             self.assertFalse(roots["ok"])
             self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
 
+    def test_project_visible_root_matching_primary_checkout_project_artifacts_is_rejected_for_linked_worktree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main_repo_path = Path(tmp) / "main-repo"
+            linked_repo_path = Path(tmp) / "linked-repo"
+            _init_git_repo(main_repo_path)
+            _run(
+                ["git", "worktree", "add", "-b", "runtime-linked", str(linked_repo_path), "HEAD"],
+                cwd=main_repo_path,
+            )
+            _write_config(
+                linked_repo_path,
+                runtime_mode="project-visible",
+                project_visible_root=".specwright",
+            )
+
+            roots = _resolve_roots(linked_repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
     def test_project_visible_root_symlinked_into_git_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo_path = Path(tmp) / "symlink-git-repo"
@@ -495,6 +555,36 @@ class TestRuntimeModeSafetyProof(unittest.TestCase):
                 repo_path,
                 runtime_mode="project-visible",
                 project_visible_root="runtime-link",
+            )
+
+            roots = _resolve_roots(repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
+    def test_project_visible_root_with_parent_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "traversal-repo"
+            _init_git_repo(repo_path)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                project_visible_root="../outside-runtime",
+            )
+
+            roots = _resolve_roots(repo_path)
+
+            self.assertFalse(roots["ok"])
+            self.assertEqual(roots["code"], "INVALID_RUNTIME_ROOT")
+
+    def test_project_visible_root_absolute_path_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "absolute-root-repo"
+            _init_git_repo(repo_path)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                project_visible_root=str((Path(tmp) / "absolute-runtime").resolve()),
             )
 
             roots = _resolve_roots(repo_path)

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -6,6 +6,9 @@ extend this module with resolver and migration-safety proofs.
 
 import json
 import os
+from pathlib import Path
+import subprocess
+import tempfile
 import unittest
 
 from evals.tests._text_helpers import assert_multiline_regex, load_text
@@ -14,11 +17,213 @@ from evals.tests._text_helpers import assert_multiline_regex, load_text
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _CONFIG_PATH = os.path.join(_REPO_ROOT, ".specwright", "config.json")
 _CONTEXT_PROTOCOL_PATH = os.path.join(_REPO_ROOT, "core", "protocols", "context.md")
+_STATE_PATHS_MODULE_PATH = os.path.join(
+    _REPO_ROOT, "adapters", "shared", "specwright-state-paths.mjs"
+)
 
 
 def _load_json(path):
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def _run(args, cwd):
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init"], cwd=path)
+    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path)
+    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path)
+    _run(["git", "branch", "-M", "main"], cwd=path)
+    (path / "README.md").write_text("fixture\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=path)
+    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path)
+
+
+def _git_path(repo_path: Path, *args: str) -> Path:
+    output = _run(["git", *args], cwd=repo_path).stdout.strip()
+    candidate = Path(output)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (repo_path / candidate).resolve()
+
+
+def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
+    if git_dir == git_common_dir:
+        return "main-worktree"
+
+    if git_dir.parent == git_common_dir / "worktrees":
+        return git_dir.name
+
+    if git_dir.name and git_dir.name != ".git":
+        return git_dir.name
+
+    raise AssertionError(f"Unable to derive worktree id for {git_dir}")
+
+
+def _write_config(
+    repo_path: Path,
+    *,
+    runtime_mode: str,
+    project_visible_root: str = ".specwright-local",
+    work_artifacts_mode: str = "clone-local",
+    tracked_root: str | None = None,
+) -> None:
+    config_path = repo_path / ".specwright" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "2.0",
+                "git": {
+                    "runtime": {
+                        "mode": runtime_mode,
+                        "projectVisibleRoot": project_visible_root,
+                    },
+                    "workArtifacts": {
+                        "mode": work_artifacts_mode,
+                        "trackedRoot": tracked_root,
+                    },
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _runtime_roots(
+    repo_path: Path,
+    *,
+    runtime_mode: str,
+    project_visible_root: str = ".specwright-local",
+) -> dict[str, Path | str]:
+    git_dir = _git_path(repo_path, "rev-parse", "--git-dir")
+    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir")
+    worktree_id = _derive_worktree_id(git_dir, git_common_dir)
+
+    if runtime_mode == "project-visible":
+        shared_runtime_root = git_common_dir.parent / project_visible_root
+        repo_state_root = shared_runtime_root / "repo"
+        worktree_state_root = shared_runtime_root / "worktrees" / worktree_id
+        clone_local_work_artifacts_root = shared_runtime_root / "work"
+    else:
+        shared_runtime_root = git_common_dir / "specwright"
+        repo_state_root = git_common_dir / "specwright"
+        worktree_state_root = git_dir / "specwright"
+        clone_local_work_artifacts_root = repo_state_root / "work"
+
+    return {
+        "gitDir": git_dir,
+        "gitCommonDir": git_common_dir,
+        "worktreeId": worktree_id,
+        "sharedRuntimeRoot": shared_runtime_root,
+        "repoStateRoot": repo_state_root,
+        "worktreeStateRoot": worktree_state_root,
+        "cloneLocalWorkArtifactsRoot": clone_local_work_artifacts_root,
+    }
+
+
+def _write_shared_state(
+    repo_path: Path,
+    *,
+    runtime_mode: str,
+    work_id: str = "runtime-proof",
+    work_dir: str = "runtime-proof",
+) -> None:
+    roots = _runtime_roots(repo_path, runtime_mode=runtime_mode)
+    repo_state_root = roots["repoStateRoot"]
+    worktree_state_root = roots["worktreeStateRoot"]
+    branch = _run(["git", "branch", "--show-current"], cwd=repo_path).stdout.strip()
+
+    workflow_path = repo_state_root / "work" / work_id / "workflow.json"
+    session_path = worktree_state_root / "session.json"
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+
+    workflow_path.write_text(
+        json.dumps(
+            {
+                "version": "3.0",
+                "id": work_id,
+                "status": "building",
+                "workDir": work_dir,
+                "unitId": "02-project-visible-runtime-foundation",
+                "tasksCompleted": [],
+                "tasksTotal": 3,
+                "currentTask": "task-1",
+                "branch": branch,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session_path.write_text(
+        json.dumps(
+            {
+                "version": "3.0",
+                "worktreeId": roots["worktreeId"],
+                "worktreePath": str(repo_path.resolve()),
+                "branch": branch,
+                "attachedWorkId": work_id,
+                "mode": "top-level",
+                "lastSeenAt": "2026-04-20T00:00:00Z",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _inspect_runtime_state(repo_path: Path) -> dict:
+    script = """
+const { resolveSpecwrightRoots, loadSpecwrightState, normalizeActiveWork } =
+  await import(process.env.STATE_PATHS_MODULE);
+
+const roots = resolveSpecwrightRoots({ cwd: process.cwd() });
+const state = loadSpecwrightState({ cwd: process.cwd() });
+const work = normalizeActiveWork(state);
+
+process.stdout.write(JSON.stringify({
+  roots: roots.ok ? {
+    projectRoot: roots.projectRoot,
+    gitDir: roots.gitDir,
+    gitCommonDir: roots.gitCommonDir,
+    repoStateRoot: roots.repoStateRoot,
+    worktreeStateRoot: roots.worktreeStateRoot,
+    workArtifactsRoot: roots.workArtifactsRoot,
+    worktreeId: roots.worktreeId
+  } : roots,
+  layout: state.layout,
+  sharedConfigPath: state.sharedConfigPath ?? null,
+  workflowPath: state.workflowPath ?? null,
+  artifactsRoot: work?.artifactsRoot ?? null,
+  workDirPath: work?.workDirPath ?? null
+}));
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH,
+        },
+    )
+    return json.loads(completed.stdout)
 
 
 class TestRuntimeModeConfigDefaults(unittest.TestCase):
@@ -107,6 +312,119 @@ class TestRuntimeModeContextProtocol(unittest.TestCase):
             self.lower,
             r"work-artifact publication.+separate.+runtime mode|runtime mode.+separate.+work-artifact publication",
         )
+
+
+class TestRuntimeModeResolverPaths(unittest.TestCase):
+    """AC-2/AC-3: resolver supports git-admin and project-visible runtime roots."""
+
+    def test_git_admin_primary_worktree_keeps_runtime_under_git_admin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "git-admin-repo"
+            _init_git_repo(repo_path)
+            _write_config(repo_path, runtime_mode="git-admin")
+            _write_shared_state(repo_path, runtime_mode="git-admin")
+
+            data = _inspect_runtime_state(repo_path)
+
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str((repo_path / ".git" / "specwright").resolve()),
+            )
+            self.assertEqual(
+                data["roots"]["worktreeStateRoot"],
+                str((repo_path / ".git" / "specwright").resolve()),
+            )
+            self.assertEqual(
+                data["roots"]["workArtifactsRoot"],
+                str((repo_path / ".git" / "specwright" / "work").resolve()),
+            )
+            self.assertEqual(
+                data["workflowPath"],
+                str((repo_path / ".git" / "specwright" / "work" / "runtime-proof" / "workflow.json").resolve()),
+            )
+
+    def test_project_visible_primary_worktree_moves_runtime_out_of_git(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "project-visible-repo"
+            _init_git_repo(repo_path)
+            _write_config(repo_path, runtime_mode="project-visible")
+            _write_shared_state(repo_path, runtime_mode="project-visible")
+
+            data = _inspect_runtime_state(repo_path)
+            visible_root = (repo_path / ".specwright-local").resolve()
+
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str(visible_root / "repo"),
+            )
+            self.assertEqual(
+                data["roots"]["worktreeStateRoot"],
+                str(visible_root / "worktrees" / "main-worktree"),
+            )
+            self.assertEqual(
+                data["roots"]["workArtifactsRoot"],
+                str(visible_root / "work"),
+            )
+            self.assertEqual(
+                data["workflowPath"],
+                str(visible_root / "repo" / "work" / "runtime-proof" / "workflow.json"),
+            )
+
+    def test_project_visible_linked_worktree_keys_state_by_worktree_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main_repo_path = Path(tmp) / "main-repo"
+            linked_repo_path = Path(tmp) / "linked-repo"
+            _init_git_repo(main_repo_path)
+            _run(
+                ["git", "worktree", "add", "-b", "runtime-linked", str(linked_repo_path), "HEAD"],
+                cwd=main_repo_path,
+            )
+            _write_config(linked_repo_path, runtime_mode="project-visible")
+
+            data = _inspect_runtime_state(linked_repo_path)
+            visible_root = (main_repo_path / ".specwright-local").resolve()
+
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str(visible_root / "repo"),
+            )
+            self.assertEqual(
+                data["roots"]["worktreeStateRoot"],
+                str(visible_root / "worktrees" / "linked-repo"),
+            )
+            self.assertEqual(data["roots"]["worktreeId"], "linked-repo")
+
+    def test_tracked_work_artifacts_override_stays_independent_in_project_visible_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "tracked-artifacts-repo"
+            _init_git_repo(repo_path)
+            _write_config(
+                repo_path,
+                runtime_mode="project-visible",
+                work_artifacts_mode="tracked",
+                tracked_root=".specwright/audit-work",
+            )
+            _write_shared_state(repo_path, runtime_mode="project-visible")
+
+            data = _inspect_runtime_state(repo_path)
+            visible_root = (repo_path / ".specwright-local").resolve()
+
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str(visible_root / "repo"),
+            )
+            self.assertEqual(
+                data["roots"]["workArtifactsRoot"],
+                str((repo_path / ".specwright" / "audit-work").resolve()),
+            )
+            self.assertEqual(
+                data["artifactsRoot"],
+                str((repo_path / ".specwright" / "audit-work").resolve()),
+            )
+            self.assertEqual(
+                data["workDirPath"],
+                str((repo_path / ".specwright" / "audit-work" / "runtime-proof").resolve()),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This unit adds the runtime-root foundation for the workflow legibility and operator-devex workstream. It introduces an explicit `git.runtime.mode` / `git.runtime.projectVisibleRoot` policy surface, teaches the shared resolver to support both `git-admin` and `project-visible` layouts, and proves the new mode fails closed on unsafe roots without weakening verify strictness or tracked work-artifact separation.

Because this repository uses clone-local work artifacts, the reviewer-usable audit summary is inlined below instead of depending on local-only `.git/specwright/...` paths.

## Approval Lineage
- Design approval: **APPROVED** from `/sw-plan`. The current design artifact set still matches the recorded approval hash.
- Unit-spec approval for `02-project-visible-runtime-foundation`: **STALE** (`artifact-set-changed`) from `/sw-build`. `plan.md` changed after approval when build appended the as-built notes.
- Accepted-mutant lineage: none recorded in this verify run.

## What Changed
- `.specwright/config.json` now defines the runtime-root policy surface through `git.runtime.mode` and `git.runtime.projectVisibleRoot` while leaving `git.workArtifacts` as the separate publication-policy surface.
- `core/protocols/context.md` now documents both runtime modes, the five logical roots, and the project-visible guardrails that keep clone-local runtime state out of `.git` and tracked artifacts.
- `adapters/shared/specwright-state-paths.mjs` now resolves `git-admin` and `project-visible` runtime roots, keys linked worktrees by `worktreeId`, preserves tracked work-artifact overrides, and rejects unsafe project-visible roots.
- `.gitignore` now excludes `/.specwright-local/` so the project-visible runtime root stays untracked by default.
- `evals/tests/test_runtime_mode_paths.py` now locks the runtime contract with real Git temp repos, linked-worktree coverage, tracked-root override coverage, and invalid-root rejection coverage.

## Why The Agent Implemented It This Way
- Task 1 defined the runtime-mode contract in tracked config and protocol text first so later resolver work had one explicit vocabulary to implement.
- Task 2 centralized root derivation and tracked-root separation inside `adapters/shared/specwright-state-paths.mjs` so every existing hook and helper keeps consuming one shared resolver.
- Task 3 finished the unit by proving the failure-closed path behavior and the repo ignore boundary instead of widening the runtime surface again.

## Acceptance Criteria
- **AC-1 — PASS**  
  Implementation: `.specwright/config.json:40-46`; `core/protocols/context.md:12-14,21-54`  
  Evidence: `evals/tests/test_runtime_mode_paths.py:252-337` (`TestRuntimeModeConfigDefaults`, `TestRuntimeModeContextProtocol`)
- **AC-2 — PASS**  
  Implementation: `adapters/shared/specwright-state-paths.mjs:246-370,409-465,652-689`  
  Evidence: `evals/tests/test_runtime_mode_paths.py:343-419` (`TestRuntimeModeResolverPaths::test_git_admin_primary_worktree_keeps_runtime_under_git_admin`, `::test_project_visible_primary_worktree_moves_runtime_out_of_git`, `::test_project_visible_linked_worktree_keys_state_by_worktree_id`)
- **AC-3 — PASS**  
  Implementation: `adapters/shared/specwright-state-paths.mjs:373-406,458-464,749-780`  
  Evidence: `evals/tests/test_runtime_mode_paths.py:420-450` (`TestRuntimeModeResolverPaths::test_tracked_work_artifacts_override_stays_independent_in_project_visible_mode`)
- **AC-4 — PASS**  
  Implementation: `adapters/shared/specwright-state-paths.mjs:1-4,180-209,259-333`  
  Evidence: `evals/tests/test_runtime_mode_paths.py:459-503` (`TestRuntimeModeSafetyProof::test_project_visible_root_inside_git_is_rejected`, `::test_project_visible_root_inside_project_artifacts_is_rejected`, `::test_project_visible_root_symlinked_into_git_is_rejected`)
- **AC-5 — PASS**  
  Implementation: `.gitignore:1-15`; `adapters/shared/specwright-state-paths.mjs:338-370,652-689`  
  Evidence: `evals/tests/test_runtime_mode_paths.py:369-394,456-522` (`TestRuntimeModeResolverPaths::test_project_visible_primary_worktree_moves_runtime_out_of_git`, `TestRuntimeModeSafetyProof::test_gitignore_excludes_project_visible_runtime_root_by_default`, `::test_legacy_git_admin_install_still_loads_when_runtime_block_is_absent`)

## Spec Conformance
- `gate-spec`: **PASS**. AC-1 through AC-5 passed in the canonical compliance matrix for this unit.
- Behavioral IC mapping was inactive for this verify run because this is not the final work unit in the design.

## Gate Summary
| Gate | Status | Evidence-grounded summary |
|---|---|---|
| build | PASS | `bash build/build.sh` passed, and the configured `commands.test` tier passed with the full eval suite plus the Claude Code build regressions. |
| tests | PASS | The changed regression uses exact assertions, real Git temp repos, real Node execution, and a T3 mutation-resistance floor with all bypass classes passing. |
| security | PASS | No secrets, injection issues, or unsafe state-placement behavior were introduced; the resolver validates project-visible roots and keeps tracked artifacts separate. |
| wiring | PASS | The shared state-path resolver remains consumed by hooks, freshness helpers, and runtime-state regressions, so the unit does not leave a dead runtime path behind. |
| semantic | PASS | The changed helper logic stays fail-closed on invalid roots and unsafe tracked-root overlaps without introducing unchecked-error or fail-open regressions. |
| spec | PASS | The acceptance-criteria matrix maps each AC to implementation and test evidence with no WARN or BLOCK findings. |

## Remaining Attention
- The current `unit-spec` approval lineage is stale because `plan.md` changed after `/sw-build` recorded approval.

## Evidence Links
- Implementation surfaces: `.specwright/config.json`, `core/protocols/context.md`, `adapters/shared/specwright-state-paths.mjs`, `.gitignore`
- Regression proof: `evals/tests/test_runtime_mode_paths.py`
- Clone-local verify artifacts were generated under local Specwright state and are summarized inline above for reviewer use.
