### PR TITLE
test(evals): isolate nested git env in pre-push fixtures

### DIFF
--- a/evals/framework/git_env.py
+++ b/evals/framework/git_env.py
@@ -5,7 +5,9 @@ temporary repos must not inherit that outer context.
 """
 
 import os
-from typing import Dict, Optional
+from pathlib import Path
+import subprocess
+from typing import Dict, Mapping, Optional
 
 # Keep only the repo-local variables Git itself marks as local context.
 _REPO_LOCAL_GIT_ENV_VARS = frozenset(
@@ -19,6 +21,7 @@ _REPO_LOCAL_GIT_ENV_VARS = frozenset(
         "GIT_GRAFT_FILE",
         "GIT_IMPLICIT_WORK_TREE",
         "GIT_INDEX_FILE",
+        "GIT_NAMESPACE",
         "GIT_NO_REPLACE_OBJECTS",
         "GIT_OBJECT_DIRECTORY",
         "GIT_PREFIX",
@@ -29,7 +32,11 @@ _REPO_LOCAL_GIT_ENV_VARS = frozenset(
 )
 
 
-def sanitized_git_env(extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+def sanitized_git_env(
+    extra: Optional[Mapping[str, str]] = None,
+    *,
+    strip_from_extra: bool = True,
+) -> Dict[str, str]:
     """Return an environment without inherited repo-local git context."""
     env = {
         key: value
@@ -37,5 +44,41 @@ def sanitized_git_env(extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         if key not in _REPO_LOCAL_GIT_ENV_VARS
     }
     if extra is not None:
-        env.update(extra)
+        cleaned = (
+            {
+                key: value
+                for key, value in extra.items()
+                if key not in _REPO_LOCAL_GIT_ENV_VARS
+            }
+            if strip_from_extra
+            else dict(extra)
+        )
+        env.update(cleaned)
     return env
+
+
+def outer_git_env(repo_path: Path) -> Dict[str, str]:
+    """Return the repo-local git context for a specific repository path."""
+    git_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-dir")
+    git_common_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    return {
+        "GIT_DIR": str(git_dir),
+        "GIT_WORK_TREE": str(repo_path.resolve()),
+        "GIT_COMMON_DIR": str(git_common_dir),
+        "GIT_PREFIX": "",
+    }
+
+
+def _git_path(repo_path: Path, *args: str) -> Path:
+    output = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=sanitized_git_env(),
+    ).stdout.strip()
+    candidate = Path(output)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (repo_path / candidate).resolve()

--- a/evals/tests/test_operator_surface_visibility.py
+++ b/evals/tests/test_operator_surface_visibility.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import unittest
 
+from evals.framework.git_env import _REPO_LOCAL_GIT_ENV_VARS, sanitized_git_env
 from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
@@ -23,33 +24,57 @@ DOCTOR_SKILL = ROOT_DIR / "core" / "skills" / "sw-doctor" / "SKILL.md"
 
 
 def _run(args: list[str], cwd: Path, *, env: dict | None = None) -> subprocess.CompletedProcess[str]:
+    runtime_env = None
+    if args and args[0] == "git":
+        extra_env = None
+        if env is not None:
+            extra_env = {
+                key: value
+                for key, value in env.items()
+                if key not in _REPO_LOCAL_GIT_ENV_VARS
+            }
+        runtime_env = sanitized_git_env(extra_env)
+    elif env is not None:
+        runtime_env = {**os.environ, **env}
+
     return subprocess.run(
         args,
         cwd=cwd,
         check=True,
         capture_output=True,
         text=True,
-        env={**os.environ, **(env or {})},
+        env=runtime_env,
     )
 
 
-def _init_git_repo(path: Path) -> None:
+def _init_git_repo(path: Path, *, env: dict | None = None) -> None:
     path.mkdir(parents=True, exist_ok=True)
-    _run(["git", "init"], cwd=path)
-    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path)
-    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path)
-    _run(["git", "branch", "-M", "main"], cwd=path)
+    _run(["git", "init"], cwd=path, env=env)
+    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path, env=env)
+    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path, env=env)
+    _run(["git", "branch", "-M", "main"], cwd=path, env=env)
     (path / "README.md").write_text("fixture\n", encoding="utf-8")
-    _run(["git", "add", "README.md"], cwd=path)
-    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path)
+    _run(["git", "add", "README.md"], cwd=path, env=env)
+    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path, env=env)
 
 
-def _git_path(repo_path: Path, *args: str) -> Path:
-    output = _run(["git", *args], cwd=repo_path).stdout.strip()
+def _git_path(repo_path: Path, *args: str, env: dict | None = None) -> Path:
+    output = _run(["git", *args], cwd=repo_path, env=env).stdout.strip()
     candidate = Path(output)
     if candidate.is_absolute():
         return candidate.resolve()
     return (repo_path / candidate).resolve()
+
+
+def _outer_git_env(repo_path: Path) -> dict[str, str]:
+    git_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-dir")
+    git_common_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    return {
+        "GIT_DIR": str(git_dir),
+        "GIT_WORK_TREE": str(repo_path.resolve()),
+        "GIT_COMMON_DIR": str(git_common_dir),
+        "GIT_PREFIX": "",
+    }
 
 
 def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
@@ -65,9 +90,9 @@ def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
     raise AssertionError("unable to derive worktree id for test fixture")
 
 
-def _runtime_roots(repo_path: Path) -> dict[str, Path | str]:
-    git_dir = _git_path(repo_path, "rev-parse", "--git-dir")
-    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir")
+def _runtime_roots(repo_path: Path, *, env: dict | None = None) -> dict[str, Path | str]:
+    git_dir = _git_path(repo_path, "rev-parse", "--git-dir", env=env)
+    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir", env=env)
     worktree_id = _derive_worktree_id(git_dir, git_common_dir)
     repo_state_root = git_common_dir / "specwright"
     worktree_state_root = git_dir / "specwright"
@@ -87,12 +112,13 @@ def _write_shared_state(
     *,
     work_id: str = "operator-surface-proof",
     unit_id: str = "03-operator-surface-cutover",
+    env: dict | None = None,
 ) -> dict[str, Path | str]:
-    roots = _runtime_roots(repo_path)
+    roots = _runtime_roots(repo_path, env=env)
     repo_state_root = roots["repoStateRoot"]
     worktree_state_root = roots["worktreeStateRoot"]
     work_artifacts_root = roots["workArtifactsRoot"]
-    branch = _run(["git", "branch", "--show-current"], cwd=repo_path).stdout.strip()
+    branch = _run(["git", "branch", "--show-current"], cwd=repo_path, env=env).stdout.strip()
 
     (repo_state_root / "config.json").parent.mkdir(parents=True, exist_ok=True)
     (repo_state_root / "config.json").write_text(
@@ -265,6 +291,33 @@ def _fresh_timestamp() -> str:
 
 
 class TestSessionStartSurface(unittest.TestCase):
+    def test_shared_state_writes_ignore_outer_hook_context(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outer_repo_path = Path(tmpdir) / "outer-repo"
+            inner_repo_path = Path(tmpdir) / "inner-repo"
+            _init_git_repo(outer_repo_path)
+            _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
+
+            outer_env = _outer_git_env(outer_repo_path)
+            _init_git_repo(inner_repo_path, env=outer_env)
+            state = _write_shared_state(inner_repo_path, env=outer_env)
+
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=outer_repo_path).stdout.strip(),
+                "outer-scope",
+            )
+            self.assertEqual(
+                Path(state["repoStateRoot"]),
+                (inner_repo_path / ".git" / "specwright").resolve(),
+            )
+            self.assertEqual(
+                Path(state["worktreeStateRoot"]),
+                (inner_repo_path / ".git" / "specwright").resolve(),
+            )
+            self.assertTrue((Path(state["repoStateRoot"]) / "config.json").exists())
+            self.assertTrue((Path(state["worktreeStateRoot"]) / "session.json").exists())
+            self.assertFalse((outer_repo_path / ".git" / "specwright" / "session.json").exists())
+
     def test_session_start_names_missing_closeout_and_approval(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir)

--- a/evals/tests/test_operator_surface_visibility.py
+++ b/evals/tests/test_operator_surface_visibility.py
@@ -2,14 +2,13 @@
 
 from datetime import datetime, timezone
 import json
-import os
 from pathlib import Path
 import shutil
 import subprocess
 import tempfile
 import unittest
 
-from evals.framework.git_env import _REPO_LOCAL_GIT_ENV_VARS, sanitized_git_env
+from evals.framework.git_env import outer_git_env, sanitized_git_env
 from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
@@ -25,17 +24,10 @@ DOCTOR_SKILL = ROOT_DIR / "core" / "skills" / "sw-doctor" / "SKILL.md"
 
 def _run(args: list[str], cwd: Path, *, env: dict | None = None) -> subprocess.CompletedProcess[str]:
     runtime_env = None
-    if args and args[0] == "git":
-        extra_env = None
-        if env is not None:
-            extra_env = {
-                key: value
-                for key, value in env.items()
-                if key not in _REPO_LOCAL_GIT_ENV_VARS
-            }
-        runtime_env = sanitized_git_env(extra_env)
-    elif env is not None:
-        runtime_env = {**os.environ, **env}
+    if env is not None:
+        runtime_env = sanitized_git_env(env)
+    elif args and args[0] == "git":
+        runtime_env = sanitized_git_env()
 
     return subprocess.run(
         args,
@@ -64,17 +56,6 @@ def _git_path(repo_path: Path, *args: str, env: dict | None = None) -> Path:
     if candidate.is_absolute():
         return candidate.resolve()
     return (repo_path / candidate).resolve()
-
-
-def _outer_git_env(repo_path: Path) -> dict[str, str]:
-    git_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-dir")
-    git_common_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    return {
-        "GIT_DIR": str(git_dir),
-        "GIT_WORK_TREE": str(repo_path.resolve()),
-        "GIT_COMMON_DIR": str(git_common_dir),
-        "GIT_PREFIX": "",
-    }
 
 
 def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
@@ -298,7 +279,7 @@ class TestSessionStartSurface(unittest.TestCase):
             _init_git_repo(outer_repo_path)
             _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
 
-            outer_env = _outer_git_env(outer_repo_path)
+            outer_env = outer_git_env(outer_repo_path)
             _init_git_repo(inner_repo_path, env=outer_env)
             state = _write_shared_state(inner_repo_path, env=outer_env)
 

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 import unittest
 
-from evals.framework.git_env import _REPO_LOCAL_GIT_ENV_VARS, sanitized_git_env
+from evals.framework.git_env import outer_git_env, sanitized_git_env
 from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
@@ -32,17 +32,10 @@ def _load_json(path):
 
 def _run(args, cwd, *, env=None):
     runtime_env = None
-    if args and args[0] == "git":
-        extra_env = None
-        if env is not None:
-            extra_env = {
-                key: value
-                for key, value in env.items()
-                if key not in _REPO_LOCAL_GIT_ENV_VARS
-            }
-        runtime_env = sanitized_git_env(extra_env)
-    elif env is not None:
-        runtime_env = {**os.environ, **env}
+    if env is not None:
+        runtime_env = sanitized_git_env(env)
+    elif args and args[0] == "git":
+        runtime_env = sanitized_git_env()
 
     return subprocess.run(
         args,
@@ -71,17 +64,6 @@ def _git_path(repo_path: Path, *args: str, env=None) -> Path:
     if candidate.is_absolute():
         return candidate.resolve()
     return (repo_path / candidate).resolve()
-
-
-def _outer_git_env(repo_path: Path) -> dict[str, str]:
-    git_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-dir")
-    git_common_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    return {
-        "GIT_DIR": str(git_dir),
-        "GIT_WORK_TREE": str(repo_path.resolve()),
-        "GIT_COMMON_DIR": str(git_common_dir),
-        "GIT_PREFIX": "",
-    }
 
 
 def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
@@ -220,7 +202,7 @@ def _write_shared_state(
     )
 
 
-def _inspect_runtime_state(repo_path: Path) -> dict:
+def _inspect_runtime_state(repo_path: Path, *, env=None) -> dict:
     script = """
 const { resolveSpecwrightRoots, loadSpecwrightState, normalizeActiveWork } =
   await import(process.env.STATE_PATHS_MODULE);
@@ -246,35 +228,29 @@ process.stdout.write(JSON.stringify({
   workDirPath: work?.workDirPath ?? null
 }));
 """
-    completed = subprocess.run(
+    extra_env = {"STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH}
+    if env is not None:
+        extra_env = {**env, **extra_env}
+    completed = _run(
         ["node", "--input-type=module", "-e", script],
         cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            "STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH,
-        },
+        env=extra_env,
     )
     return json.loads(completed.stdout)
 
 
-def _resolve_roots(repo_path: Path) -> dict:
+def _resolve_roots(repo_path: Path, *, env=None) -> dict:
     script = """
 const { resolveSpecwrightRoots } = await import(process.env.STATE_PATHS_MODULE);
 process.stdout.write(JSON.stringify(resolveSpecwrightRoots({ cwd: process.cwd() })));
 """
-    completed = subprocess.run(
+    extra_env = {"STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH}
+    if env is not None:
+        extra_env = {**env, **extra_env}
+    completed = _run(
         ["node", "--input-type=module", "-e", script],
         cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            "STATE_PATHS_MODULE": _STATE_PATHS_MODULE_PATH,
-        },
+        env=extra_env,
     )
     return json.loads(completed.stdout)
 
@@ -460,24 +436,6 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
                 str(visible_root / "repo" / "work"),
             )
 
-    def test_nested_git_fixture_init_ignores_outer_hook_context(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            outer_repo_path = Path(tmp) / "outer-repo"
-            inner_repo_path = Path(tmp) / "inner-repo"
-            _init_git_repo(outer_repo_path)
-            _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
-
-            _init_git_repo(inner_repo_path, env=_outer_git_env(outer_repo_path))
-
-            self.assertEqual(
-                _run(["git", "branch", "--show-current"], cwd=outer_repo_path).stdout.strip(),
-                "outer-scope",
-            )
-            self.assertEqual(
-                _run(["git", "branch", "--show-current"], cwd=inner_repo_path).stdout.strip(),
-                "main",
-            )
-
     def test_project_visible_linked_worktree_named_main_worktree_uses_non_primary_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             main_repo_path = Path(tmp) / "main-repo"
@@ -533,6 +491,60 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
             self.assertEqual(
                 data["workDirPath"],
                 str((repo_path / ".specwright" / "audit-work" / "runtime-proof").resolve()),
+            )
+
+
+class TestFixtureGitEnvIsolation(unittest.TestCase):
+    """Fixture helpers ignore outer hook git context across subprocess types."""
+
+    def test_nested_git_fixture_init_ignores_outer_hook_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outer_repo_path = Path(tmp) / "outer-repo"
+            inner_repo_path = Path(tmp) / "inner-repo"
+            _init_git_repo(outer_repo_path)
+            _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
+
+            _init_git_repo(inner_repo_path, env=outer_git_env(outer_repo_path))
+
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=outer_repo_path).stdout.strip(),
+                "outer-scope",
+            )
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=inner_repo_path).stdout.strip(),
+                "main",
+            )
+
+    def test_runtime_state_node_helpers_ignore_outer_hook_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outer_repo_path = Path(tmp) / "outer-repo"
+            inner_repo_path = Path(tmp) / "inner-repo"
+            _init_git_repo(outer_repo_path)
+            _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
+
+            outer_env = outer_git_env(outer_repo_path)
+            _init_git_repo(inner_repo_path, env=outer_env)
+            _write_config(inner_repo_path, runtime_mode="git-admin")
+            _write_shared_state(inner_repo_path, runtime_mode="git-admin", env=outer_env)
+
+            roots = _resolve_roots(inner_repo_path, env=outer_env)
+            data = _inspect_runtime_state(inner_repo_path, env=outer_env)
+
+            self.assertTrue(roots["ok"])
+            self.assertEqual(roots["gitDir"], str((inner_repo_path / ".git").resolve()))
+            self.assertEqual(roots["repoStateRoot"], str((inner_repo_path / ".git" / "specwright").resolve()))
+            self.assertEqual(data["roots"]["gitDir"], str((inner_repo_path / ".git").resolve()))
+            self.assertEqual(
+                data["roots"]["repoStateRoot"],
+                str((inner_repo_path / ".git" / "specwright").resolve()),
+            )
+            self.assertEqual(
+                data["workflowPath"],
+                str((inner_repo_path / ".git" / "specwright" / "work" / "runtime-proof" / "workflow.json").resolve()),
+            )
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=outer_repo_path).stdout.strip(),
+                "outer-scope",
             )
 
 

--- a/evals/tests/test_runtime_mode_paths.py
+++ b/evals/tests/test_runtime_mode_paths.py
@@ -12,6 +12,7 @@ import subprocess
 import tempfile
 import unittest
 
+from evals.framework.git_env import _REPO_LOCAL_GIT_ENV_VARS, sanitized_git_env
 from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 
@@ -29,33 +30,58 @@ def _load_json(path):
         return json.load(f)
 
 
-def _run(args, cwd):
+def _run(args, cwd, *, env=None):
+    runtime_env = None
+    if args and args[0] == "git":
+        extra_env = None
+        if env is not None:
+            extra_env = {
+                key: value
+                for key, value in env.items()
+                if key not in _REPO_LOCAL_GIT_ENV_VARS
+            }
+        runtime_env = sanitized_git_env(extra_env)
+    elif env is not None:
+        runtime_env = {**os.environ, **env}
+
     return subprocess.run(
         args,
         cwd=cwd,
         check=True,
         capture_output=True,
         text=True,
+        env=runtime_env,
     )
 
 
-def _init_git_repo(path: Path) -> None:
+def _init_git_repo(path: Path, *, env=None) -> None:
     path.mkdir(parents=True, exist_ok=True)
-    _run(["git", "init"], cwd=path)
-    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path)
-    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path)
-    _run(["git", "branch", "-M", "main"], cwd=path)
+    _run(["git", "init"], cwd=path, env=env)
+    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path, env=env)
+    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path, env=env)
+    _run(["git", "branch", "-M", "main"], cwd=path, env=env)
     (path / "README.md").write_text("fixture\n", encoding="utf-8")
-    _run(["git", "add", "README.md"], cwd=path)
-    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path)
+    _run(["git", "add", "README.md"], cwd=path, env=env)
+    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path, env=env)
 
 
-def _git_path(repo_path: Path, *args: str) -> Path:
-    output = _run(["git", *args], cwd=repo_path).stdout.strip()
+def _git_path(repo_path: Path, *args: str, env=None) -> Path:
+    output = _run(["git", *args], cwd=repo_path, env=env).stdout.strip()
     candidate = Path(output)
     if candidate.is_absolute():
         return candidate.resolve()
     return (repo_path / candidate).resolve()
+
+
+def _outer_git_env(repo_path: Path) -> dict[str, str]:
+    git_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-dir")
+    git_common_dir = _git_path(repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    return {
+        "GIT_DIR": str(git_dir),
+        "GIT_WORK_TREE": str(repo_path.resolve()),
+        "GIT_COMMON_DIR": str(git_common_dir),
+        "GIT_PREFIX": "",
+    }
 
 
 def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
@@ -112,9 +138,10 @@ def _runtime_roots(
     *,
     runtime_mode: str,
     project_visible_root: str = ".specwright-local",
+    env=None,
 ) -> dict[str, Path | str]:
-    git_dir = _git_path(repo_path, "rev-parse", "--git-dir")
-    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir")
+    git_dir = _git_path(repo_path, "rev-parse", "--git-dir", env=env)
+    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir", env=env)
     worktree_id = _derive_worktree_id(git_dir, git_common_dir)
 
     if runtime_mode == "project-visible":
@@ -145,11 +172,12 @@ def _write_shared_state(
     runtime_mode: str,
     work_id: str = "runtime-proof",
     work_dir: str = "runtime-proof",
+    env=None,
 ) -> None:
-    roots = _runtime_roots(repo_path, runtime_mode=runtime_mode)
+    roots = _runtime_roots(repo_path, runtime_mode=runtime_mode, env=env)
     repo_state_root = roots["repoStateRoot"]
     worktree_state_root = roots["worktreeStateRoot"]
-    branch = _run(["git", "branch", "--show-current"], cwd=repo_path).stdout.strip()
+    branch = _run(["git", "branch", "--show-current"], cwd=repo_path, env=env).stdout.strip()
 
     workflow_path = repo_state_root / "work" / work_id / "workflow.json"
     session_path = worktree_state_root / "session.json"
@@ -430,6 +458,24 @@ class TestRuntimeModeResolverPaths(unittest.TestCase):
             self.assertEqual(
                 data["roots"]["workArtifactsRoot"],
                 str(visible_root / "repo" / "work"),
+            )
+
+    def test_nested_git_fixture_init_ignores_outer_hook_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outer_repo_path = Path(tmp) / "outer-repo"
+            inner_repo_path = Path(tmp) / "inner-repo"
+            _init_git_repo(outer_repo_path)
+            _run(["git", "checkout", "-b", "outer-scope"], cwd=outer_repo_path)
+
+            _init_git_repo(inner_repo_path, env=_outer_git_env(outer_repo_path))
+
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=outer_repo_path).stdout.strip(),
+                "outer-scope",
+            )
+            self.assertEqual(
+                _run(["git", "branch", "--show-current"], cwd=inner_repo_path).stdout.strip(),
+                "main",
             )
 
     def test_project_visible_linked_worktree_named_main_worktree_uses_non_primary_id(self):


### PR DESCRIPTION
## Summary
- sanitize repo-local `GIT_*` variables before nested Git subprocesses run in the pre-push eval fixture helpers
- thread explicit outer-hook-style env through both helper stacks without letting the inner fixture repo inherit the caller checkout's Git admin paths
- add regressions proving outer hook context cannot rename the caller branch or redirect shared-state writes into the live checkout

## Approval Lineage
- Design approval: `MISSING (missing-entry)`
- Unit-spec approval: `MISSING (missing-entry)`
- This fix was developed and verified as a direct branch-local debug work item on `work/debug-pre-push-git-env-leakage`; there is no selected-work session or per-work workflow ledger for this branch, so reviewer-usable proof is inlined here instead of relying on clone-local Specwright artifacts.

## What Changed
- [`evals/tests/test_runtime_mode_paths.py#L33-L84`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_runtime_mode_paths.py#L33-L84) now sanitizes Git subprocess env at the shared `_run(...)` boundary, threads optional env through the helper stack, and keeps nested fixture setup from inheriting repo-local Git admin state.
- [`evals/tests/test_runtime_mode_paths.py#L463-L479`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_runtime_mode_paths.py#L463-L479) adds a regression proving an outer hook-style Git context cannot rename the caller branch while an inner fixture repo initializes.
- [`evals/tests/test_operator_surface_visibility.py#L26-L121`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_operator_surface_visibility.py#L26-L121) applies the same sanitization pattern to runtime-root and shared-state helpers.
- [`evals/tests/test_operator_surface_visibility.py#L294-L319`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_operator_surface_visibility.py#L294-L319) adds a regression proving session/workflow writes stay inside the inner fixture repo under inherited outer hook context.

## Why The Agent Implemented It This Way
- The failure came from inherited repo-local `GIT_*` variables leaking into nested Git subprocesses, so the durable fix is at the shared `_run(...)` boundary rather than patching individual Git calls one by one.
- Both changed modules had the same nested-Git shape, so the isolation strategy is intentionally mirrored across them to avoid divergent fixture behavior.
- The regressions use real temporary Git repositories plus real outer hook-style env because that is the exact failure mode that previously renamed the live branch and redirected shared state.

## Acceptance Criteria
| Criterion | Status | Evidence |
|---|---|---|
| AC-1: `evals/tests/test_runtime_mode_paths.py` no longer runs nested Git subprocesses under inherited outer repo-local `GIT_*` variables | PASS | [`test_runtime_mode_paths.py#L15-L84`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_runtime_mode_paths.py#L15-L84) hardens the helper boundary; targeted `python -m pytest evals/tests/test_runtime_mode_paths.py -v` passed (`24 passed`) |
| AC-2: `evals/tests/test_operator_surface_visibility.py` resolves runtime roots and shared-state writes from the inner fixture repo under outer hook context | PASS | [`test_operator_surface_visibility.py#L12-L121`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_operator_surface_visibility.py#L12-L121) hardens the helper boundary; targeted `python -m pytest evals/tests/test_operator_surface_visibility.py -v` passed (`9 passed`) |
| AC-3: regression coverage proves hook-style outer Git context no longer corrupts the live checkout | PASS | [`test_runtime_mode_paths.py#L463-L479`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_runtime_mode_paths.py#L463-L479) covers branch safety and [`test_operator_surface_visibility.py#L294-L319`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_operator_surface_visibility.py#L294-L319) covers shared-state isolation; fresh full-suite verify and pre-push reruns passed |

## Spec Conformance
- All three acceptance criteria have implementation evidence in the changed test modules and fresh execution evidence from verify.
- Fresh verify evidence: `bash build/build.sh` passed; `python -m pytest evals/tests/ -v && bash tests/test-claude-code-build.sh` passed with `1037 passed, 1 skipped, 3 deselected` in the eval suite and `265 passed, 0 failed` in the Claude Code build surface.
- Push-time pre-push validation reran the eval and shell suite and passed with `103 passed, 0 failed` on the hook surface.

## Gate Summary
| Gate | Verdict | Evidence |
|---|---|---|
| build | PASS | fresh verify rerun of `bash build/build.sh` |
| tests | PASS | targeted module reruns passed; full verify rerun passed; push-time pre-push hook rerun passed |
| security | PASS | test-only scope, no new secrets/auth/injection path, stricter env sanitization |
| wiring | PASS | both modules reuse the shared `evals.framework.git_env` isolation utility; no layer drift |
| semantic | PASS | failure path removed at nested Git subprocess creation; regressions cover both corruption modes |
| spec | PASS | all three acceptance criteria mapped to implementation and fresh test evidence |

## Remaining Attention
- Approval lineage is missing for this direct debug branch. That is a review warning, not a gate failure, but it should be noted as the reason no normal selected-work workflow state was advanced.
- Clone-local Specwright artifacts for this fix are retained under the debug work root and were used to assemble the verify/ship handoff locally.
- The attached `pivot-scope-expansion` workflow in the original worktree was intentionally left untouched while shipping this isolated debug fix.

## Evidence Links
- [`evals/tests/test_runtime_mode_paths.py`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_runtime_mode_paths.py)
- [`evals/tests/test_operator_surface_visibility.py`](https://github.com/Obsidian-Owl/specwright/blob/work/debug-pre-push-git-env-leakage/evals/tests/test_operator_surface_visibility.py)
