### PR TITLE
feat(pivot): broaden rebaselining contract

### DIFF
--- a/core/protocols/approvals.md
+++ b/core/protocols/approvals.md
@@ -158,6 +158,10 @@ Durable human approval checkpoints for this work.
 - `sw-plan` records design approval on entry when a human triggered `/sw-plan`.
   In headless mode it must validate an existing human approval instead of
   fabricating one.
+- `sw-pivot` reassesses design freshness when work-level artifacts change and
+  reassesses `unit-spec` freshness when current or remaining unit artifacts
+  change. It preserves the stale lineage with compact freshness reasons instead
+  of fabricating a replacement approval entry.
 - `sw-build` records or validates `unit-spec` approval on entry using the
   current unit artifact set.
 - `sw-verify` validates approval freshness before gate execution and reports
@@ -177,6 +181,8 @@ Shared approval helpers must provide deterministic support for:
 - recording or refreshing `accepted-mutant` entries without collapsing them
   into a silent config-only waiver
 - validating approval freshness against current artifacts
+- assessing both `design` and `unit-spec` entries against pivoted artifact sets
+  without special-case logic that would hide stale lineage
 - returning structured freshness assessment with status, compact reason code,
   and approved/current artifact hashes when applicable
 - rejecting any attempt to create `APPROVED` approval state from

--- a/core/protocols/state.md
+++ b/core/protocols/state.md
@@ -278,6 +278,19 @@ Valid lifecycle transitions are enforced per selected work:
 `sw-learn` is an optional capture step after `shipped`. It is never a
 prerequisite for starting the next work or queued unit.
 
+### Pivoted Re-entry
+
+`sw-pivot` is not a new persisted workflow status. It operates inside
+`planning`, `building`, and `verifying`.
+
+- `task-pivot` keeps the work in `building` when the active unit stays the same
+- `unit-pivot` or `work-pivot` may return the touched work to `building` when
+  active or affected unit artifacts change
+- `sw-pivot` must preserve shipped units as shipped baseline scope rather than
+  rewriting them
+- no `pivoting` status is added to `workflow.json`; the existing lifecycle
+  state remains the only persisted status vocabulary
+
 **Enforcement:** skills check the selected work's `status` before mutating. If
 the intended transition is invalid, STOP with:
 

--- a/core/protocols/state.md
+++ b/core/protocols/state.md
@@ -264,7 +264,7 @@ Valid lifecycle transitions are enforced per selected work:
 |---|---|---|
 | (none) | `designing` | sw-design creates a new work and attaches the current session |
 | `designing` | `planning` | sw-plan |
-| `planning` | `building` | sw-plan or sw-build |
+| `planning` | `building` | sw-plan or sw-build or sw-pivot (work-pivot) |
 | `building` | `verifying` | sw-verify |
 | `verifying` | `building` | fix after failed verify |
 | `verifying` | `shipping` | sw-ship |
@@ -283,7 +283,8 @@ prerequisite for starting the next work or queued unit.
 `sw-pivot` is not a new persisted workflow status. It operates inside
 `planning`, `building`, and `verifying`.
 
-- `task-pivot` keeps the work in `building` when the active unit stays the same
+- `task-pivot` keeps the active status unchanged when the active unit still
+  holds (`building` or `verifying` as appropriate)
 - `unit-pivot` or `work-pivot` may return the touched work to `building` when
   active or affected unit artifacts change
 - `sw-pivot` must preserve shipped units as shipped baseline scope rather than

--- a/core/skills/sw-pivot/SKILL.md
+++ b/core/skills/sw-pivot/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: sw-pivot
 description: >-
-  Mid-build course correction. Captures committed progress, takes pivot input,
-  has the architect revise remaining tasks, and resumes sw-build with a revised plan.
+  Research-backed rebaselining. Revises design, plan, or in-progress work
+  while preserving completed scope and approval lineage.
 argument-hint: "[reason for pivot]"
 allowed-tools:
   - Read
@@ -18,63 +18,101 @@ allowed-tools:
 
 ## Goal
 
-Graceful course correction during an active sw-build. Capture what's committed,
-understand what changed, revise remaining tasks via architect, and hand back to
-sw-build. Applies `protocols/decision.md` for all decisions. Revisions auto-applied
-and recorded in decisions.md — the revised plan is the artifact.
+Research-backed rebaselining for the selected work. Capture preserved scope,
+understand what changed, classify the pivot, revise the affected open work via
+architect, and hand back to `sw-build`. Applies `protocols/decision.md` for
+all decisions. Revisions auto-applied and recorded in `decisions.md`; the
+revised artifact set is the contract.
 
 ## Inputs
 
 - `{worktreeStateRoot}/session.json` — selected work for this worktree
-- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` — `tasksCompleted`, `tasksTotal`, `workDir`
-- `{workDir}/spec.md` — full spec (completed + remaining)
-- `{workDir}/plan.md` — task breakdown
-- `{workDir}/context.md` — unit context that downstream build and verify consume
+- `{repoStateRoot}/work/{selectedWork.id}/workflow.json` — selected work state,
+  active unit, `tasksCompleted`, `tasksTotal`, and work/unit paths
+- work-level artifacts: `design.md`, `context.md`, `assumptions.md`,
+  `decisions.md`, `integration-criteria.md` when present
+- active or affected unit artifacts: `spec.md`, `plan.md`, `context.md`
 - `{workArtifactsRoot}/{selectedWork.id}/approvals.md` — durable approval ledger for design and unit lineage
 - Pivot reason (argument or conversation)
+- Optional recent retro or research inputs when available and relevant
 
 ## Outputs
 
-- `spec.md` — appended with `## Revision` section
-- `plan.md` — appended with `## Pivot Note` section
-- selected work's `workflow.json` — remaining tasks updated
+- revised work-level artifacts when design or scope changes require them
+- regenerated affected remaining-unit artifacts when unit boundaries or
+  observable behavior change
+- updated `integration-criteria.md` when structural pivots stale the current
+  criteria
+- selected work's `workflow.json` — pivot classification, active state, and
+  affected remaining work updated
 - `decisions.md` — pivot decisions recorded
 
 ## Constraints
 
 **Pre-condition (LOW freedom):**
-Resolve the selected work from the current worktree session. Status must be
-`building`. If all tasks are done: STOP — "Run /sw-verify." If another live
-top-level worktree owns the selected work, STOP with explicit
-adopt/takeover guidance.
+Resolve the selected work from the current worktree session. Valid entry states
+are `planning`, `building`, and `verifying`. Reject `designing`,
+`shipping`, and `shipped` with explicit guidance: use `/sw-design` change
+request flow for `designing`, and start a fresh work or normal ship/fix flow
+for `shipping` or `shipped`. If another live top-level worktree owns the
+selected work, STOP with explicit adopt/takeover guidance.
 
 **Snapshot (LOW freedom):**
-Read the selected work's `tasksCompleted`, present done vs. remaining.
+Read the selected work's completed and open scope. Present preserved baseline
+scope versus delta scope before proposing any mutation.
+
+**Classification (MEDIUM freedom):**
+Classify the request before mutation:
+- `task-pivot` — execution detail changed but design and unit boundaries remain valid
+- `unit-pivot` — current or future unit scope changed, but work-level design intent still holds
+- `work-pivot` — design path changed, scope expanded, or the architecture must be rebaselined
 
 **Pivot input (MEDIUM freedom):**
 If argument provided, use it as the pivot reason. If no argument, infer from
 conversation context per `protocols/decision.md` DISAMBIGUATION.
 
+**Research-first analysis (MEDIUM freedom):**
+For `unit-pivot` and `work-pivot`, run a bounded research pass before revision.
+Prefer existing tracked artifacts first, recent retro evidence second, and
+fresh external research only when the pivot changes an external contract.
+Capture the synthesized findings in work context rather than requiring the user
+to restate them.
+
 **Revise (HIGH freedom for architect, LOW freedom for mutation):**
-Delegate to `specwright-architect` per `protocols/delegation.md`. Completed tasks
-are immutable. Architect revises remaining tasks only. If architect proposes modifying
-completed criteria: reject and re-delegate (max 2 attempts).
+Delegate to `specwright-architect` per `protocols/delegation.md`. Completed
+tasks and shipped units are immutable baseline scope. Architect may revise
+remaining tasks, affected remaining-unit artifacts, or work-level design
+artifacts depending on pivot class. If architect proposes rewriting completed
+criteria or shipped scope: reject and re-delegate (max 2 attempts). If the
+pivot would invalidate shipped scope anyway, STOP and escalate to a fresh
+`/sw-design` work instead of rewriting history.
 
 **Apply (MEDIUM freedom):**
-Auto-apply revision. Append revision to spec.md and pivot note to plan.md. Update
-the selected work's `workflow.json`. Record scope (% tasks changed) and
-rationale in decisions.md. The revised plan is the artifact — sw-build resumes
-from it, verify validates the result. Mutate only the selected work's
-workflow state; never rewrite unrelated active works. NEVER overwrite existing
-content — append only.
+Auto-apply the classified revision. `task-pivot` may revise the active unit
+task list; `unit-pivot` may regenerate affected remaining-unit artifacts and
+`integration-criteria.md`; `work-pivot` may revise work-level design artifacts
+plus affected remaining units. Update the selected work's `workflow.json`,
+record preserved baseline scope versus delta scope in `decisions.md`, and
+mutate only the selected work's workflow state. Never rewrite unrelated active
+works. Use revision-chain updates for work-level artifacts instead of creating
+parallel design trees.
+
+**State handling (LOW freedom):**
+Do not create a new persisted `pivoting` workflow status. `sw-pivot` runs
+inside `planning`, `building`, or `verifying`; if active or affected unit
+artifacts change, the touched work returns to `building`. If only future units
+change and the active unit remains valid, preserve the active unit's current
+state.
 
 **Approval lineage (LOW freedom):**
-If the pivot changes `spec.md`, `plan.md`, or `context.md`, the current
-`unit-spec` approval lineage becomes stale against the revised artifact set.
-Use `protocols/approvals.md` and the shared approval helper implemented in
-`adapters/shared/specwright-approvals.mjs` to assess and preserve that stale
-lineage rather than erasing it. Never fabricate a replacement `APPROVED`
-entry during `/sw-pivot`; the next human-triggered `/sw-build` records the
+If the pivot changes work-level or unit-level artifacts, the corresponding
+design or `unit-spec` approval lineage becomes stale against the revised
+artifact set. Use `protocols/approvals.md` and the shared approval helper
+implemented in `adapters/shared/specwright-approvals.mjs` to assess and
+preserve that stale lineage rather than erasing it. Surface compact stale
+reasons such as `missing-entry`, `artifact-set-changed`, `missing-lineage`,
+`expired`, and `superseded`. Never fabricate a replacement `APPROVED` entry
+during `/sw-pivot`; the next human-triggered `/sw-build` records the
 replacement approval that supersedes the stale lineage.
 
 **Stage boundary (LOW freedom):**
@@ -93,8 +131,9 @@ Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
 
 | Condition | Action |
 |-----------|--------|
-| Status not `building` | STOP: "sw-pivot only valid during active sw-build" |
+| Status not `planning`, `building`, or `verifying` | STOP with the stage-appropriate guidance for `/sw-design` or a fresh follow-up work |
 | Selected work owned by another live top-level worktree | STOP with explicit adopt/takeover guidance |
-| All tasks completed | STOP: "Run /sw-verify" |
-| Architect modifies completed criteria | Reject, re-delegate (max 2) |
+| No open scope remains | STOP: "Run /sw-verify" |
+| Architect modifies completed criteria or shipped scope | Reject, re-delegate (max 2) |
+| Requested pivot would rewrite shipped scope | STOP and escalate to a fresh `/sw-design` work |
 | Compaction during pivot | Read the selected work's workflow.json, check if revision was applied |

--- a/core/skills/sw-pivot/SKILL.md
+++ b/core/skills/sw-pivot/SKILL.md
@@ -115,6 +115,14 @@ reasons such as `missing-entry`, `artifact-set-changed`, `missing-lineage`,
 during `/sw-pivot`; the next human-triggered `/sw-build` records the
 replacement approval that supersedes the stale lineage.
 
+**Closeout summary (LOW freedom):**
+Before the stage handoff, summarize the preserved completed scope, delta scope
+introduced by the pivot, affected units or tasks, whether the active unit was
+reset to `building`, and any stale approval reasons (`missing-entry`,
+`artifact-set-changed`, `missing-lineage`, `expired`, `superseded`). The
+closeout must make scope preservation explicit instead of implying a
+remaining-tasks-only rewrite.
+
 **Stage boundary (LOW freedom):**
 Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
 

--- a/core/skills/sw-pivot/SKILL.md
+++ b/core/skills/sw-pivot/SKILL.md
@@ -20,9 +20,9 @@ allowed-tools:
 
 Research-backed rebaselining for the selected work. Capture preserved scope,
 understand what changed, classify the pivot, revise the affected open work via
-architect, and hand back to `sw-build`. Applies `protocols/decision.md` for
-all decisions. Revisions auto-applied and recorded in `decisions.md`; the
-revised artifact set is the contract.
+architect, and hand back to `/sw-plan` or `/sw-build` as appropriate. Applies
+`protocols/decision.md` for all decisions. Revisions auto-applied and recorded
+in `decisions.md`; the revised artifact set is the contract.
 
 ## Inputs
 
@@ -124,7 +124,9 @@ closeout must make scope preservation explicit instead of implying a
 remaining-tasks-only rewrite.
 
 **Stage boundary (LOW freedom):**
-Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
+Follow `protocols/stage-boundary.md`. After apply: STOP with the appropriate
+handoff — "Run `/sw-plan`." for planning-state `work-pivot`s that revise the
+work-level design before unit decomposition, and "Run `/sw-build`." otherwise.
 
 ## Protocol References
 
@@ -141,7 +143,7 @@ Follow `protocols/stage-boundary.md`. After apply: STOP → "Run `/sw-build`."
 |-----------|--------|
 | Status not `planning`, `building`, or `verifying` | STOP with the stage-appropriate guidance for `/sw-design` or a fresh follow-up work |
 | Selected work owned by another live top-level worktree | STOP with explicit adopt/takeover guidance |
-| No open scope remains | STOP: "Run /sw-verify" |
+| No open scope remains (only applicable in `building` or `verifying`) | STOP: "Run /sw-verify" |
 | Architect modifies completed criteria or shipped scope | Reject, re-delegate (max 2) |
 | Requested pivot would rewrite shipped scope | STOP and escalate to a fresh `/sw-design` work |
 | Compaction during pivot | Read the selected work's workflow.json, check if revision was applied |

--- a/evals/tests/test_pivot_rebaselining_foundation.py
+++ b/evals/tests/test_pivot_rebaselining_foundation.py
@@ -50,13 +50,16 @@ class TestPivotRebaseliningContract(unittest.TestCase):
                 self.assertIn(pivot_class, self.pivot_text)
 
     def test_precondition_accepts_planning_building_and_verifying(self):
-        self.assertRegex(
+        precondition_block = re.search(
+            r"\*\*Pre-condition.*?\*\*\n(.*?)(?=\n\*\*|\Z)",
             self.pivot_text,
-            re.compile(
-                r"planning[\s\S]*building[\s\S]*verifying|verifying[\s\S]*planning[\s\S]*building",
-                re.IGNORECASE,
-            ),
+            re.DOTALL,
         )
+        self.assertIsNotNone(precondition_block, "Pre-condition block not found")
+        block = precondition_block.group(0)
+        for state in ("planning", "building", "verifying"):
+            with self.subTest(state=state):
+                self.assertIn(state, block)
 
     def test_failure_modes_no_longer_claim_building_only(self):
         self.assertNotRegex(
@@ -146,11 +149,20 @@ class TestPivotApprovalLineage(unittest.TestCase):
                 writeFileSync(join(workRoot, 'design.md'), 'design v2\\n');
                 writeFileSync(join(unitRoot, 'spec.md'), 'spec v2\\n');
 
-                const designAssessment = assessApprovalEntry(doc.entries[0], {{
+                const designEntry = doc.entries.find((entry) => entry.scope === 'design');
+                const unitEntry = doc.entries.find(
+                  (entry) => entry.scope === 'unit-spec' && entry.unitId === '01-pivot'
+                );
+
+                if (!designEntry || !unitEntry) {{
+                  throw new Error('expected design and unit-spec approval entries');
+                }}
+
+                const designAssessment = assessApprovalEntry(designEntry, {{
                   baseDir: workRoot,
                   artifacts: ['assumptions.md', 'context.md', 'decisions.md', 'design.md']
                 }});
-                const unitAssessment = assessApprovalEntry(doc.entries[1], {{
+                const unitAssessment = assessApprovalEntry(unitEntry, {{
                   baseDir: unitRoot,
                   artifacts: ['context.md', 'plan.md', 'spec.md']
                 }});

--- a/evals/tests/test_pivot_rebaselining_foundation.py
+++ b/evals/tests/test_pivot_rebaselining_foundation.py
@@ -1,13 +1,31 @@
 """Regression tests for Unit 01 — pivot rebaselining foundation."""
 
+import json
 from pathlib import Path
 import re
+import subprocess
+import tempfile
 import unittest
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 PIVOT_SKILL = ROOT_DIR / "core" / "skills" / "sw-pivot" / "SKILL.md"
 STATE_PROTOCOL = ROOT_DIR / "core" / "protocols" / "state.md"
+APPROVALS_PROTOCOL = ROOT_DIR / "core" / "protocols" / "approvals.md"
+
+
+def _run_node_json(script: str) -> dict:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "node execution failed")
+    return json.loads(result.stdout)
 
 
 class TestPivotRebaseliningContract(unittest.TestCase):
@@ -54,6 +72,92 @@ class TestPivotRebaseliningContract(unittest.TestCase):
                 re.IGNORECASE,
             ),
         )
+
+
+class TestPivotApprovalLineage(unittest.TestCase):
+    """Task 2 RED: approvals must describe and prove pivot stale-lineage handling."""
+
+    def setUp(self):
+        self.approvals_text = APPROVALS_PROTOCOL.read_text(encoding="utf-8")
+
+    def test_approvals_protocol_assigns_sw_pivot_lineage_reassessment(self):
+        self.assertRegex(
+            self.approvals_text,
+            re.compile(
+                r"sw-pivot[\s\S]*(design|unit-spec)[\s\S]*(stale|freshness)|"
+                r"(design|unit-spec)[\s\S]*sw-pivot[\s\S]*(stale|freshness)",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_helper_marks_design_and_unit_entries_stale_after_pivot_artifact_change(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = _run_node_json(
+                f"""
+                import {{
+                  defaultApprovalsDocument,
+                  recordApproval,
+                  assessApprovalEntry
+                }} from './adapters/shared/specwright-approvals.mjs';
+                import {{ mkdirSync, writeFileSync }} from 'fs';
+                import {{ join }} from 'path';
+
+                const workRoot = {json.dumps(tmpdir)};
+                const unitRoot = join(workRoot, 'units', '01-pivot');
+                mkdirSync(unitRoot, {{ recursive: true }});
+
+                writeFileSync(join(workRoot, 'design.md'), 'design v1\\n');
+                writeFileSync(join(workRoot, 'context.md'), 'context v1\\n');
+                writeFileSync(join(workRoot, 'decisions.md'), 'decisions v1\\n');
+                writeFileSync(join(workRoot, 'assumptions.md'), 'assumptions v1\\n');
+                writeFileSync(join(unitRoot, 'spec.md'), 'spec v1\\n');
+                writeFileSync(join(unitRoot, 'plan.md'), 'plan v1\\n');
+                writeFileSync(join(unitRoot, 'context.md'), 'unit context v1\\n');
+
+                let doc = defaultApprovalsDocument();
+                doc = recordApproval(doc, {{
+                  baseDir: workRoot,
+                  scope: 'design',
+                  sourceClassification: 'command',
+                  sourceRef: '/sw-plan',
+                  artifacts: ['assumptions.md', 'context.md', 'decisions.md', 'design.md'],
+                  approvedAt: '2026-04-20T00:00:00Z'
+                }});
+                doc = recordApproval(doc, {{
+                  baseDir: unitRoot,
+                  scope: 'unit-spec',
+                  unitId: '01-pivot',
+                  sourceClassification: 'command',
+                  sourceRef: '/sw-build',
+                  artifacts: ['context.md', 'plan.md', 'spec.md'],
+                  approvedAt: '2026-04-20T00:05:00Z'
+                }});
+
+                writeFileSync(join(workRoot, 'design.md'), 'design v2\\n');
+                writeFileSync(join(unitRoot, 'spec.md'), 'spec v2\\n');
+
+                const designAssessment = assessApprovalEntry(doc.entries[0], {{
+                  baseDir: workRoot,
+                  artifacts: ['assumptions.md', 'context.md', 'decisions.md', 'design.md']
+                }});
+                const unitAssessment = assessApprovalEntry(doc.entries[1], {{
+                  baseDir: unitRoot,
+                  artifacts: ['context.md', 'plan.md', 'spec.md']
+                }});
+
+                console.log(JSON.stringify({{
+                  designStatus: designAssessment.status,
+                  designReason: designAssessment.reasonCode,
+                  unitStatus: unitAssessment.status,
+                  unitReason: unitAssessment.reasonCode
+                }}));
+                """
+            )
+
+            self.assertEqual(output["designStatus"], "STALE")
+            self.assertEqual(output["designReason"], "artifact-set-changed")
+            self.assertEqual(output["unitStatus"], "STALE")
+            self.assertEqual(output["unitReason"], "artifact-set-changed")
 
 
 if __name__ == "__main__":

--- a/evals/tests/test_pivot_rebaselining_foundation.py
+++ b/evals/tests/test_pivot_rebaselining_foundation.py
@@ -1,0 +1,60 @@
+"""Regression tests for Unit 01 — pivot rebaselining foundation."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+PIVOT_SKILL = ROOT_DIR / "core" / "skills" / "sw-pivot" / "SKILL.md"
+STATE_PROTOCOL = ROOT_DIR / "core" / "protocols" / "state.md"
+
+
+class TestPivotRebaseliningContract(unittest.TestCase):
+    """Task 1 RED: sw-pivot must stop describing the narrow build-only contract."""
+
+    def setUp(self):
+        self.pivot_text = PIVOT_SKILL.read_text(encoding="utf-8")
+        self.state_text = STATE_PROTOCOL.read_text(encoding="utf-8")
+
+    def test_goal_reframes_pivot_as_research_backed_rebaselining(self):
+        self.assertRegex(
+            self.pivot_text,
+            re.compile(
+                r"research[- ]backed[\s\S]*rebaselin|rebaselin[\s\S]*research[- ]backed",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_skill_declares_task_unit_and_work_pivot_classes(self):
+        for pivot_class in ("task-pivot", "unit-pivot", "work-pivot"):
+            with self.subTest(pivot_class=pivot_class):
+                self.assertIn(pivot_class, self.pivot_text)
+
+    def test_precondition_accepts_planning_building_and_verifying(self):
+        self.assertRegex(
+            self.pivot_text,
+            re.compile(
+                r"planning[\s\S]*building[\s\S]*verifying|verifying[\s\S]*planning[\s\S]*building",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_failure_modes_no_longer_claim_building_only(self):
+        self.assertNotRegex(
+            self.pivot_text,
+            re.compile(r"Status not `?building`?|only valid during active sw-build", re.IGNORECASE),
+        )
+
+    def test_state_protocol_mentions_pivot_return_to_building_without_new_status(self):
+        self.assertRegex(
+            self.state_text,
+            re.compile(
+                r"sw-pivot[\s\S]*returns?.*building|building[\s\S]*sw-pivot[\s\S]*without.*new.*status",
+                re.IGNORECASE,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/tests/test_pivot_rebaselining_foundation.py
+++ b/evals/tests/test_pivot_rebaselining_foundation.py
@@ -73,6 +73,16 @@ class TestPivotRebaseliningContract(unittest.TestCase):
             ),
         )
 
+    def test_skill_requires_closeout_summary_for_preserved_scope_and_stale_reasons(self):
+        self.assertRegex(
+            self.pivot_text,
+            re.compile(
+                r"preserved(?: completed)? scope[\s\S]*delta scope[\s\S]*affected units[\s\S]*"
+                r"(missing-entry|artifact-set-changed|missing-lineage|expired|superseded)",
+                re.IGNORECASE,
+            ),
+        )
+
 
 class TestPivotApprovalLineage(unittest.TestCase):
     """Task 2 RED: approvals must describe and prove pivot stale-lineage handling."""

--- a/tests/test-optional-stage-enforcement.sh
+++ b/tests/test-optional-stage-enforcement.sh
@@ -12,7 +12,8 @@
 #   AC-2        — state.md documents sw-learn as optional
 #   AC-3        — sw-design State mutations handles prior shipped + clobber notice
 #   AC-5, AC-5a — No core pipeline skill hard-requires an optional skill (negative assertions)
-#                 sw-pivot remains self-gated when explicitly invoked
+#                 sw-pivot remains explicitly state-gated without reverting to
+#                 the old build-only contract
 #   AC-6        — Optional skills may have recommendations in free-text (not enforced)
 #   AC-9 proxy  — stage-boundary handoff table does not force sw-learn between ship and next build
 #
@@ -125,8 +126,8 @@ echo ""
 echo "AC-5a: sw-pivot self-gating is captured as justified"
 assert_file_contains \
   "core/skills/sw-pivot/SKILL.md" \
-  'Status must be `?building`?|sw-pivot only valid during active sw-build' \
-  "sw-pivot remains self-gated only when explicitly invoked during sw-build"
+  'Status not `?planning`?, `?building`?, or `?verifying`?' \
+  "sw-pivot still has explicit state-gating for the broadened entry states"
 
 # AC-6: recommendations in free text are allowed
 echo ""


### PR DESCRIPTION
## Summary
This unit establishes the rebaselining foundation for the pivot-scope-expansion workstream. It broadens `sw-pivot` from a narrow remaining-work adjustment into a research-backed rebaselining contract, keeps already-completed scope as preserved baseline, and makes stale approval lineage explicit instead of silently rewriting it.

Because this repository uses clone-local work artifacts, the reviewer-usable audit summary is inlined below instead of depending on local-only `.git/specwright/...` paths.

## Approval Lineage
- Design approval: **STALE** (`artifact-set-changed`) from `/sw-plan`. The current work-level artifact set no longer matches the recorded approved hash for `assumptions.md`, `context.md`, `decisions.md`, and `design.md` after the work-level pivot. This is expected carryover until a later human-triggered `/sw-build` refreshes design approval for the revised remaining units.
- Unit-spec approval for `01-pivot-rebaselining-foundation`: **APPROVED** from `/sw-build`. The refreshed artifact set for `spec.md`, `plan.md`, and `context.md` matches the recorded approval hash after branch reconciliation.
- Accepted-mutant lineage: none recorded in this verify run. `.specwright/config.json` keeps `acceptedMutants` empty.

## What Changed
- `core/skills/sw-pivot/SKILL.md` now frames Pivot as research-backed rebaselining, defines `task-pivot` / `unit-pivot` / `work-pivot`, broadens valid entry states, records preserved baseline scope versus delta scope, and requires closeout summaries that surface stale approval reasons.
- `core/protocols/state.md` now documents pivoted re-entry without inventing a new persisted `pivoting` workflow status and preserves shipped units as immutable baseline scope.
- `core/protocols/approvals.md` now assigns `sw-pivot` responsibility for reassessing design and unit-spec freshness for pivoted artifact sets.
- `evals/tests/test_pivot_rebaselining_foundation.py` adds regression coverage across the broadened pivot skill contract, the state-protocol alignment, and the existing approval-helper stale-lineage behavior.

## Why The Agent Implemented It This Way
- The dominant failure mode here is contract drift between user-visible workflow language and the real lifecycle semantics, so the unit locks the broader pivot behavior in regression tests while changing the markdown contracts.
- The approval helper already produced the right stale-lineage outcomes for changed artifact sets; the missing piece was protocol visibility and proof, not a new pivot-only helper path.
- Preserved baseline scope and stale-lineage closeout requirements were kept in the same regression surface so future edits cannot weaken one while leaving the other behind.

## Acceptance Criteria
- **AC-1 — PASS**  
  Implementation: `core/skills/sw-pivot/SKILL.md:21-25`, `core/skills/sw-pivot/SKILL.md:64-79`, `core/skills/sw-pivot/SKILL.md:90-99`  
  Evidence: `evals/tests/test_pivot_rebaselining_foundation.py:38-50`, `evals/tests/test_pivot_rebaselining_foundation.py:76-84` (`TestPivotRebaseliningContract::test_goal_reframes_pivot_as_research_backed_rebaselining`, `::test_skill_declares_task_unit_and_work_pivot_classes`, `::test_skill_requires_closeout_summary_for_preserved_scope_and_stale_reasons`)
- **AC-2 — PASS**  
  Implementation: `core/skills/sw-pivot/SKILL.md:52-58`, `core/skills/sw-pivot/SKILL.md:85-88`, `core/skills/sw-pivot/SKILL.md:142-146`  
  Evidence: `evals/tests/test_pivot_rebaselining_foundation.py:52-65` (`TestPivotRebaseliningContract::test_precondition_accepts_planning_building_and_verifying`, `::test_failure_modes_no_longer_claim_building_only`)
- **AC-3 — PASS**  
  Implementation: `core/protocols/state.md:281-292`, `core/skills/sw-pivot/SKILL.md:95-105`  
  Evidence: `evals/tests/test_pivot_rebaselining_foundation.py:67-74` (`TestPivotRebaseliningContract::test_state_protocol_mentions_pivot_return_to_building_without_new_status`)
- **AC-4 — PASS**  
  Implementation: `core/protocols/approvals.md:161-189`, `adapters/shared/specwright-approvals.mjs:270-303`, `adapters/shared/specwright-approvals.mjs:316-355`  
  Evidence: `evals/tests/test_pivot_rebaselining_foundation.py:93-170` (`TestPivotApprovalLineage::test_approvals_protocol_assigns_sw_pivot_lineage_reassessment`, `::test_helper_marks_design_and_unit_entries_stale_after_pivot_artifact_change`)
- **AC-5 — PASS**  
  Implementation: `core/skills/sw-pivot/SKILL.md:52-58`, `core/skills/sw-pivot/SKILL.md:61-79`, `core/skills/sw-pivot/SKILL.md:107-124`, `core/skills/sw-pivot/SKILL.md:142-146`; `core/protocols/state.md:281-292`; `core/protocols/approvals.md:161-189`  
  Evidence: the full regression suite in `evals/tests/test_pivot_rebaselining_foundation.py:38-170`, re-run inside the passing configured test command captured in `evidence/build-report.md`.

## Spec Conformance
- `gate-spec`: **PASS**. AC-1 through AC-5 passed in the canonical compliance matrix for this unit.
- Behavioral IC mapping was inactive for this verify run because this is not the final work unit in the queued design.

## Gate Summary
| Gate | Status | Evidence-grounded summary |
|---|---|---|
| build | PASS | `bash build/build.sh` passed, and the configured test tier passed with `1028 passed, 1 skipped, 3 deselected` plus `263 passed, 0 failed` in the Claude Code build regression suite. |
| tests | PASS | The changed regression uses concrete contract assertions, real markdown artifacts, real helper execution against a temporary filesystem layout, and a qualitative mutation-resistance floor tied to the pivot/reapproval failure modes. |
| security | PASS | No secrets, injection paths, or exposure surfaces were introduced; the changes stay within markdown contracts plus a local regression harness. |
| wiring | PASS | The broadened pivot contract is exercised by the new regression file through the repo's normal pytest path, and no new runtime export surface or import cycle was introduced. |
| semantic | PASS | The only changed code path is the regression harness, which fails closed on subprocess errors and does not introduce unchecked-error or fail-open behavior. |
| spec | PASS | The acceptance-criteria matrix maps each AC to implementation and test evidence with no WARN or BLOCK findings. |

## Remaining Attention
- Design approval lineage remains **STALE** (`artifact-set-changed`). Verify surfaced it explicitly and did not fabricate a replacement design approval entry; the replacement approval belongs to the next human-triggered `/sw-build` on the affected future units.

## Evidence Links
- Implementation surfaces: `core/skills/sw-pivot/SKILL.md`, `core/protocols/state.md`, `core/protocols/approvals.md`
- Regression proof: `evals/tests/test_pivot_rebaselining_foundation.py`
- Clone-local audit artifacts from `/sw-verify` were generated under local Specwright state and are summarized inline above for reviewer use.
