### PR TITLE
docs(pivot): cut over docs and prompt guidance

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -65,11 +65,19 @@ Validated, referenced findings about external systems: API documentation, SDK co
 | `sw-learn` | Post-ship capture. What worked, what to remember | Promotes patterns to constitution. Clears workflow state (shipped → none) |
 | `sw-research` | Deep outward-facing research | External docs, APIs, patterns, validation. Produces referenced briefs for design |
 | `sw-debug` | Investigation-first debugging | Scope → investigate → diagnose → fix/log/defer |
-| `sw-pivot` | Mid-build course correction | Captures progress, revises remaining tasks via architect |
+| `sw-pivot` | Research-backed rebaselining | Revises design, plan, and in-progress work in `planning`, `building`, or `verifying` while preserving completed scope and shipped scope |
 | `sw-doctor` | Installation health check | Read-only validation of config, gates, hooks |
 | `sw-audit` | Periodic codebase health check | Finds systemic debt gates miss. Feeds findings into design + learn |
 | `sw-sync` | Git housekeeping — fetch, prune, sync | Config-driven stale branch cleanup with safety guards and preview |
 | `sw-review` | PR comment review and response | Fetches all 3 comment types (REST + GraphQL), groups by status, responds inline |
+
+Pivot escalation stays explicit at the architecture level. If a requested
+change would rewrite shipped scope, discard history, or needs a brand-new
+direction, route back through `/sw-design <changes>` instead of forcing
+`/sw-pivot`. If manual reconcile blocks `/sw-build`, `/sw-verify`, or
+`/sw-ship`, reconcile the current branch against the recorded target in the
+owning worktree, then rerun `/sw-build`, rerun `/sw-verify`, or rerun
+`/sw-verify` followed by `/sw-ship`.
 
 ### Internal Gate Skills (6)
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ When a work unit has 4+ independent tasks, Specwright can execute them in parall
 |-------|---------|
 | `/sw-research` | Deep external research briefs |
 | `/sw-debug` | Investigation-first debugging |
-| `/sw-pivot` | Research-backed rebaselining for active work |
+| `/sw-pivot` | Research-backed rebaselining for active work. Preserves completed and shipped scope. |
 | `/sw-doctor` | Installation health check |
 | `/sw-guard` | Configure guardrails (hooks, CI) |
 | `/sw-status` | Progress and state |

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ When a work unit has 4+ independent tasks, Specwright can execute them in parall
 |-------|---------|
 | `/sw-research` | Deep external research briefs |
 | `/sw-debug` | Investigation-first debugging |
-| `/sw-pivot` | Mid-build course correction |
+| `/sw-pivot` | Research-backed rebaselining for active work |
 | `/sw-doctor` | Installation health check |
 | `/sw-guard` | Configure guardrails (hooks, CI) |
 | `/sw-status` | Progress and state |
@@ -339,6 +339,20 @@ When a work unit has 4+ independent tasks, Specwright can execute them in parall
 
 </td></tr>
 </table>
+
+### Pivoting Active Work
+
+`/sw-pivot` is research-backed rebaselining for work in `planning`, `building`,
+or `verifying`. It can revise design, plan, and in-progress work while
+preserving completed scope and shipped scope as the baseline instead of
+rewriting what is already done.
+
+If a requested change would rewrite shipped scope, discard history, or needs a
+brand-new direction, use `/sw-design <changes>` instead of forcing `/sw-pivot`.
+If manual reconcile blocks `/sw-build`, `/sw-verify`, or `/sw-ship`, reconcile
+the current branch against the recorded target in the owning worktree, then
+rerun `/sw-build`, rerun `/sw-verify`, or rerun `/sw-verify` followed by
+`/sw-ship`.
 
 <details>
 <summary><b>Configuration</b></summary>

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -18,7 +18,7 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 | `sw-verify` | Interactive quality gates. Shows findings, validates against spec. |
 | `sw-ship` | Strategy-aware merge via PR. |
 | `sw-debug` | Investigation-first debugging. Scope → investigate → diagnose → fix/log/defer. |
-| `sw-pivot` | Mid-build course correction. Revises remaining tasks via architect; append-only. |
+| `sw-pivot` | Research-backed rebaselining. Revises design, plan, and in-progress work while preserving shipped scope. |
 | `sw-doctor` | Read-only installation health check. 13 checks, repair hints. |
 | `sw-guard` | Detect stack, gap-analyze against 10 quality dimensions, configure guardrails across 4 layers. |
 | `sw-status` | Current state and progress. Supports `--cleanup` to remove orphaned work directories. |
@@ -26,6 +26,13 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 | `sw-audit` | Periodic codebase health check. Finds systemic tech debt. |
 | `sw-sync` | Git housekeeping. Fetch, prune stale branches, sync with remote. |
 | `sw-review` | PR comment review. Fetch all comment types, group by status, respond inline. |
+
+## Pivot Guidance
+
+- `/sw-pivot` is research-backed rebaselining for work in `planning`, `building`, or `verifying`.
+- It can revise design, plan, and in-progress work while preserving completed scope and shipped scope as the baseline.
+- If a requested change would rewrite shipped scope, discard history, or needs a brand-new direction, use `/sw-design <changes>` instead of forcing `/sw-pivot`.
+- If manual reconcile blocks `/sw-build`, `/sw-verify`, or `/sw-ship`, reconcile the current branch against the recorded target in the owning worktree, then rerun `/sw-build`, rerun `/sw-verify`, or rerun `/sw-verify` followed by `/sw-ship`.
 
 ## Anchor Documents
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -18,7 +18,7 @@ Spec-driven app development with quality gates. Ensures the user gets what they 
 | `sw-verify` | Interactive quality gates. Shows findings, validates against spec. |
 | `sw-ship` | Strategy-aware merge via PR. |
 | `sw-debug` | Investigation-first debugging. Scope → investigate → diagnose → fix/log/defer. |
-| `sw-pivot` | Research-backed rebaselining. Revises design, plan, and in-progress work while preserving shipped scope. |
+| `sw-pivot` | Research-backed rebaselining. Revises design, plan, and in-progress work while preserving completed and shipped scope. |
 | `sw-doctor` | Read-only installation health check. 13 checks, repair hints. |
 | `sw-guard` | Detect stack, gap-analyze against 10 quality dimensions, configure guardrails across 4 layers. |
 | `sw-status` | Current state and progress. Supports `--cleanup` to remove orphaned work directories. |

--- a/adapters/codex/commands/sw-build.md
+++ b/adapters/codex/commands/sw-build.md
@@ -1,5 +1,5 @@
 ---
-description: TDD implementation of one work unit.
+description: TDD implementation of one work unit. If freshness blocks, manual reconcile the current branch and rerun /sw-build.
 ---
 
 Use the installed `specwright:sw-build` skill for this request.

--- a/adapters/codex/commands/sw-pivot.md
+++ b/adapters/codex/commands/sw-pivot.md
@@ -1,5 +1,5 @@
 ---
-description: Mid-build course correction that revises remaining tasks.
+description: Research-backed rebaselining for planning, building, or verifying work. Preserves completed and shipped scope while revising remaining design, plan, and in-progress work.
 ---
 
 Use the installed `specwright:sw-pivot` skill for this request.

--- a/adapters/codex/commands/sw-ship.md
+++ b/adapters/codex/commands/sw-ship.md
@@ -1,5 +1,5 @@
 ---
-description: Strategy-aware merge via pull request.
+description: Strategy-aware merge via pull request. If freshness blocks, manual reconcile the current branch, rerun /sw-verify, then rerun /sw-ship.
 ---
 
 Use the installed `specwright:sw-ship` skill for this request.

--- a/adapters/codex/commands/sw-verify.md
+++ b/adapters/codex/commands/sw-verify.md
@@ -1,5 +1,5 @@
 ---
-description: Interactive quality gates. If manual reconcile blocks freshness, rerun /sw-verify instead of bouncing back to /sw-build.
+description: Interactive quality gates. Shows findings and validates against the spec. If manual reconcile blocks freshness, rerun /sw-verify instead of bouncing back to /sw-build.
 ---
 
 Use the installed `specwright:sw-verify` skill for this request.

--- a/adapters/codex/commands/sw-verify.md
+++ b/adapters/codex/commands/sw-verify.md
@@ -1,5 +1,5 @@
 ---
-description: Interactive quality gates. Shows findings and validates against the spec.
+description: Interactive quality gates. If manual reconcile blocks freshness, rerun /sw-verify instead of bouncing back to /sw-build.
 ---
 
 Use the installed `specwright:sw-verify` skill for this request.

--- a/adapters/opencode/commands/sw-build.md
+++ b/adapters/opencode/commands/sw-build.md
@@ -1,5 +1,5 @@
 ---
-description: TDD implementation of one work unit
+description: TDD implementation of one work unit. If freshness blocks, manual reconcile the current branch and rerun /sw-build.
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-build/SKILL.md`.

--- a/adapters/opencode/commands/sw-pivot.md
+++ b/adapters/opencode/commands/sw-pivot.md
@@ -1,5 +1,5 @@
 ---
-description: Mid-build course correction for remaining tasks
+description: Research-backed rebaselining for planning, building, or verifying work. Preserves completed and shipped scope while revising remaining design, plan, and in-progress work.
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-pivot/SKILL.md`.

--- a/adapters/opencode/commands/sw-ship.md
+++ b/adapters/opencode/commands/sw-ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship current work unit via pull request
+description: Ship current work unit via pull request. If freshness blocks, manual reconcile the current branch, rerun /sw-verify, then rerun /sw-ship.
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-ship/SKILL.md`.

--- a/adapters/opencode/commands/sw-verify.md
+++ b/adapters/opencode/commands/sw-verify.md
@@ -1,5 +1,5 @@
 ---
-description: Run quality gates and show findings interactively
+description: Run quality gates and show findings interactively. If manual reconcile blocks freshness, rerun /sw-verify instead of bouncing back to /sw-build.
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-verify/SKILL.md`.

--- a/evals/framework/prompts.py
+++ b/evals/framework/prompts.py
@@ -128,9 +128,10 @@ This is a constrained non-interactive ship eval. Execute only the ship flow.
 Do not reopen `core/skills/sw-ship/SKILL.md` unless execution is blocked.
 Read only the selected workflow state, `.specwright/config.json`,
 `{workDir}/spec.md`, `{workDir}/plan.md`, and `{workDir}/evidence/`.
-If shipping freshness blocks under manual reconcile, reconcile the current
-branch against the recorded target in the owning worktree, rerun /sw-verify,
-then rerun /sw-ship.
+If shipping freshness blocks under manual reconcile, STOP and report that the
+operator must reconcile the current branch against the recorded target in the
+owning worktree, then rerun /sw-verify followed by /sw-ship in a separate
+invocation.
 If pre-flight passes, set status to `shipping`, run exactly one
 `gh pr create`, then on success write `prNumber`, keep `prMergedAt` null,
 set status to `shipped`, and write `{workDir}/stage-report.md`.

--- a/evals/framework/prompts.py
+++ b/evals/framework/prompts.py
@@ -230,7 +230,8 @@ Review the current work in planning, building, or verifying and apply
 research-backed rebaselining. Preserve completed scope and shipped scope while
 revising design, plan, and in-progress work.
 If the requested change would rewrite shipped scope, discard history, or needs
-a brand-new direction, use /sw-design instead."""
+a brand-new direction, use /sw-design instead.
+Do not invent a new command or extra confirmation."""
 
 
 def status(repair_unit_id: str = "", headless: bool = False) -> str:

--- a/evals/framework/prompts.py
+++ b/evals/framework/prompts.py
@@ -69,6 +69,9 @@ def build(instructions: str = "") -> str:
 
 Implement per the spec and plan in the selected work directory.
 Follow TDD strictly. Commit after each completed task.
+If branch-head freshness blocks entry under manual reconcile, reconcile the
+current branch against the recorded target in the owning worktree, then rerun
+/sw-build. Do not rewrite target metadata to bypass the block.
 Do not ask for confirmation — proceed through all tasks.
 Write the stage report before the terminal handoff.
 The stage report must begin with `Attention required:` and stay concise.""" + _format_instructions(instructions) + """
@@ -90,6 +93,9 @@ def verify(gate: str = "", instructions: str = "") -> str:
         return f"""Run /sw-verify --gate={gate}
 
 Run only the {gate} quality gate. Report results.
+If branch-head freshness blocks entry under manual reconcile, reconcile the
+current branch against the recorded target in the owning worktree, then rerun
+/sw-verify. Do not go back to /sw-build solely to clear freshness.
 Accept all defaults.
 Write the stage report before the terminal handoff.
 The stage report must begin with `Attention required:` and stay concise.{_format_instructions(instructions)}
@@ -101,6 +107,9 @@ Next: /sw-build or /sw-ship"""
     return """Run /sw-verify.
 
 Run all enabled quality gates. Report results.
+If branch-head freshness blocks entry under manual reconcile, reconcile the
+current branch against the recorded target in the owning worktree, then rerun
+/sw-verify. Do not go back to /sw-build solely to clear freshness.
 Do not skip any gates. Accept all defaults.
 Write the stage report before the terminal handoff.
 The stage report must begin with `Attention required:` and stay concise.""" + _format_instructions(instructions) + """
@@ -119,6 +128,9 @@ This is a constrained non-interactive ship eval. Execute only the ship flow.
 Do not reopen `core/skills/sw-ship/SKILL.md` unless execution is blocked.
 Read only the selected workflow state, `.specwright/config.json`,
 `{workDir}/spec.md`, `{workDir}/plan.md`, and `{workDir}/evidence/`.
+If shipping freshness blocks under manual reconcile, reconcile the current
+branch against the recorded target in the owning worktree, rerun /sw-verify,
+then rerun /sw-ship.
 If pre-flight passes, set status to `shipping`, run exactly one
 `gh pr create`, then on success write `prNumber`, keep `prMergedAt` null,
 set status to `shipped`, and write `{workDir}/stage-report.md`.
@@ -204,14 +216,21 @@ def pivot(change_description: str = "") -> str:
     if change_description:
         return f"""Run /sw-pivot.
 
-Apply this mid-build course correction. Revise remaining tasks.
-Do not ask for confirmation.
+Apply research-backed rebaselining for work in planning, building, or verifying.
+Preserve completed scope and shipped scope while revising design, plan, and
+in-progress work.
+If the requested change would rewrite shipped scope, discard history, or needs
+a brand-new direction, use /sw-design instead.
+Do not invent a new command or extra confirmation.
 
 Change: {change_description}"""
     return """Run /sw-pivot.
 
-Review the current build state and apply course corrections
-based on the most recent feedback or change request."""
+Review the current work in planning, building, or verifying and apply
+research-backed rebaselining. Preserve completed scope and shipped scope while
+revising design, plan, and in-progress work.
+If the requested change would rewrite shipped scope, discard history, or needs
+a brand-new direction, use /sw-design instead."""
 
 
 def status(repair_unit_id: str = "", headless: bool = False) -> str:

--- a/evals/tests/test_prompts.py
+++ b/evals/tests/test_prompts.py
@@ -290,12 +290,14 @@ class TestPromptTemplatePivotAndFreshnessGuidance(unittest.TestCase):
                 self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-verify", re.IGNORECASE))
                 self.assertRegex(result, re.compile(r"do not[\s\S]{0,120}/sw-build", re.IGNORECASE))
 
-    def test_ship_prompt_describes_manual_reconcile_rerun_via_verify_then_ship(self):
+    def test_ship_prompt_hands_off_manual_reconcile_rerun_via_verify_then_ship(self):
         result = ship()
         self.assertRegex(
             result,
             re.compile(r"manual reconcile[\s\S]{0,220}/sw-verify[\s\S]{0,80}/sw-ship", re.IGNORECASE),
         )
+        self.assertIn("STOP and report", result)
+        self.assertIn("in a separate", result)
 
 
 class TestPromptAndDocRegressionCoverage(unittest.TestCase):

--- a/evals/tests/test_prompts.py
+++ b/evals/tests/test_prompts.py
@@ -4,12 +4,22 @@ AC-11: Each template returns string with /sw-{skill} and pre-scripted decisions
 AC-12: design() accepts problem_statement, plan() and build() accept no args
 """
 
+from pathlib import Path
+import re
 import unittest
 
 from evals.framework.prompts import (
     init, design, plan, build, verify, ship,
     doctor, debug, research, learn, pivot, status, sync, guard, audit,
 )
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+PRIMARY_DOC_SURFACES = {
+    "CLAUDE.md": ROOT_DIR / "CLAUDE.md",
+    "adapters/claude-code/CLAUDE.md": ROOT_DIR / "adapters" / "claude-code" / "CLAUDE.md",
+    "README.md": ROOT_DIR / "README.md",
+    "DESIGN.md": ROOT_DIR / "DESIGN.md",
+}
 
 
 class TestPromptTemplatesReturnStrings(unittest.TestCase):
@@ -126,6 +136,66 @@ class TestPromptTemplatesContainPreScriptedDecisions(unittest.TestCase):
         self.assertIn("Done. <one-line outcome>.", result)
         self.assertIn("Artifacts: <path to stage-report.md>", result)
         self.assertIn("Next: /sw-build or /sw-ship", result)
+
+
+class TestPrimaryDocPivotSurfaces(unittest.TestCase):
+    """Unit 03 Task 1 RED: primary docs must document the broadened pivot contract."""
+
+    def test_primary_docs_frame_pivot_as_research_backed_rebaselining(self):
+        for label, path in PRIMARY_DOC_SURFACES.items():
+            with self.subTest(label=label):
+                content = path.read_text(encoding="utf-8")
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"sw-pivot[\s\S]{0,160}(research-backed|rebaselin)|"
+                        r"(research-backed|rebaselin)[\s\S]{0,160}sw-pivot",
+                        re.IGNORECASE,
+                    ),
+                )
+
+    def test_primary_docs_explain_entry_states_and_preserved_scope(self):
+        for label, path in PRIMARY_DOC_SURFACES.items():
+            with self.subTest(label=label):
+                content = path.read_text(encoding="utf-8")
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"planning[\s\S]{0,80}building[\s\S]{0,80}verifying|"
+                        r"verifying[\s\S]{0,80}building[\s\S]{0,80}planning",
+                        re.IGNORECASE,
+                    ),
+                )
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"(preserv|keep)[\s\S]{0,120}(completed|shipped) scope|"
+                        r"(completed|shipped) scope[\s\S]{0,120}(preserv|keep)",
+                        re.IGNORECASE,
+                    ),
+                )
+
+    def test_primary_docs_route_history_rewrites_to_design_and_freshness_to_stage_reruns(self):
+        for label, path in PRIMARY_DOC_SURFACES.items():
+            with self.subTest(label=label):
+                content = path.read_text(encoding="utf-8")
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"/sw-design[\s\S]{0,160}(rewrite|history|shipped)|"
+                        r"(rewrite|history|shipped)[\s\S]{0,160}/sw-design",
+                        re.IGNORECASE,
+                    ),
+                )
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"manual reconcile[\s\S]{0,180}/sw-build|"
+                        r"manual reconcile[\s\S]{0,180}/sw-verify|"
+                        r"manual reconcile[\s\S]{0,220}/sw-ship",
+                        re.IGNORECASE,
+                    ),
+                )
 
 
 class TestNewPromptTemplates(unittest.TestCase):

--- a/evals/tests/test_prompts.py
+++ b/evals/tests/test_prompts.py
@@ -294,6 +294,78 @@ class TestPromptTemplatePivotAndFreshnessGuidance(unittest.TestCase):
         )
 
 
+class TestPromptAndDocRegressionCoverage(unittest.TestCase):
+    """Unit 03 Task 3 RED: touched surfaces must not drift back to the old loop-prone contract."""
+
+    def test_pivot_surfaces_do_not_reintroduce_mid_build_remaining_task_wording(self):
+        surfaces = {
+            **{
+                label: path.read_text(encoding="utf-8")
+                for label, path in PRIMARY_DOC_SURFACES.items()
+            },
+            **{
+                label: path.read_text(encoding="utf-8")
+                for label, path in ADAPTER_COMMAND_SURFACES.items()
+                if label.endswith("pivot")
+            },
+            "prompt-pivot-default": pivot(),
+            "prompt-pivot-change": pivot("Expand the active work without discarding shipped scope."),
+        }
+        forbidden_patterns = [
+            r"mid-build course correction",
+            r"remaining-task-only",
+            r"remaining tasks only",
+            r"mid-build[\s\S]{0,40}remaining tasks",
+        ]
+        for label, content in surfaces.items():
+            with self.subTest(label=label):
+                for pattern in forbidden_patterns:
+                    self.assertNotRegex(content, re.compile(pattern, re.IGNORECASE))
+
+    def test_pivot_summary_rows_keep_completed_and_shipped_scope_visible(self):
+        summary_surfaces = {
+            "CLAUDE.md": PRIMARY_DOC_SURFACES["CLAUDE.md"],
+            "adapters/claude-code/CLAUDE.md": PRIMARY_DOC_SURFACES["adapters/claude-code/CLAUDE.md"],
+            "README.md": PRIMARY_DOC_SURFACES["README.md"],
+            "DESIGN.md": PRIMARY_DOC_SURFACES["DESIGN.md"],
+        }
+        patterns = {
+            "CLAUDE.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
+            "adapters/claude-code/CLAUDE.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
+            "README.md": r"\|\s*`/sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
+            "DESIGN.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
+        }
+        for label, path in summary_surfaces.items():
+            content = path.read_text(encoding="utf-8")
+            with self.subTest(label=label):
+                self.assertRegex(content, re.compile(patterns[label], re.IGNORECASE))
+
+    def test_verify_surfaces_do_not_redirect_back_to_build_without_reconcile_context(self):
+        surfaces = {
+            "codex-verify": ADAPTER_COMMAND_SURFACES["codex-verify"].read_text(encoding="utf-8"),
+            "opencode-verify": ADAPTER_COMMAND_SURFACES["opencode-verify"].read_text(encoding="utf-8"),
+            "prompt-verify-default": verify(),
+            "prompt-verify-gated": verify("security"),
+        }
+        negative_build_redirect = re.compile(
+            r"(do not|instead of)[\s\S]{0,80}/sw-build|/sw-build[\s\S]{0,80}(do not|instead of)",
+            re.IGNORECASE,
+        )
+        for label, content in surfaces.items():
+            with self.subTest(label=label):
+                self.assertRegex(content, re.compile(r"manual reconcile", re.IGNORECASE))
+                self.assertRegex(content, re.compile(r"/sw-verify", re.IGNORECASE))
+                if "/sw-build" in content:
+                    self.assertRegex(content, negative_build_redirect)
+
+    def test_default_pivot_prompt_rejects_invented_commands(self):
+        result = pivot()
+        self.assertRegex(
+            result,
+            re.compile(r"do not invent a new command[\s\S]{0,40}extra confirmation", re.IGNORECASE),
+        )
+
+
 class TestNewPromptTemplates(unittest.TestCase):
     """New templates return non-empty strings with default args."""
 

--- a/evals/tests/test_prompts.py
+++ b/evals/tests/test_prompts.py
@@ -20,6 +20,16 @@ PRIMARY_DOC_SURFACES = {
     "README.md": ROOT_DIR / "README.md",
     "DESIGN.md": ROOT_DIR / "DESIGN.md",
 }
+ADAPTER_COMMAND_SURFACES = {
+    "codex-build": ROOT_DIR / "adapters" / "codex" / "commands" / "sw-build.md",
+    "codex-verify": ROOT_DIR / "adapters" / "codex" / "commands" / "sw-verify.md",
+    "codex-ship": ROOT_DIR / "adapters" / "codex" / "commands" / "sw-ship.md",
+    "codex-pivot": ROOT_DIR / "adapters" / "codex" / "commands" / "sw-pivot.md",
+    "opencode-build": ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-build.md",
+    "opencode-verify": ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-verify.md",
+    "opencode-ship": ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-ship.md",
+    "opencode-pivot": ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-pivot.md",
+}
 
 
 class TestPromptTemplatesReturnStrings(unittest.TestCase):
@@ -196,6 +206,92 @@ class TestPrimaryDocPivotSurfaces(unittest.TestCase):
                         re.IGNORECASE,
                     ),
                 )
+
+
+class TestAdapterCommandSurfaces(unittest.TestCase):
+    """Unit 03 Task 2 RED: adapter command docs must align with pivot and reconcile semantics."""
+
+    def test_adapter_pivot_commands_describe_research_backed_rebaselining(self):
+        for label in ("codex-pivot", "opencode-pivot"):
+            content = ADAPTER_COMMAND_SURFACES[label].read_text(encoding="utf-8")
+            with self.subTest(label=label):
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"(research-backed|rebaselin)[\s\S]{0,120}(planning|building|verifying)|"
+                        r"(planning|building|verifying)[\s\S]{0,120}(research-backed|rebaselin)",
+                        re.IGNORECASE,
+                    ),
+                )
+                self.assertRegex(
+                    content,
+                    re.compile(
+                        r"(preserv|keep)[\s\S]{0,120}(completed|shipped) scope|"
+                        r"(completed|shipped) scope[\s\S]{0,120}(preserv|keep)",
+                        re.IGNORECASE,
+                    ),
+                )
+
+    def test_adapter_build_verify_ship_commands_describe_manual_reconcile_reruns(self):
+        expectations = {
+            "codex-build": r"manual reconcile[\s\S]{0,160}/sw-build",
+            "opencode-build": r"manual reconcile[\s\S]{0,160}/sw-build",
+            "codex-verify": r"manual reconcile[\s\S]{0,160}/sw-verify",
+            "opencode-verify": r"manual reconcile[\s\S]{0,160}/sw-verify",
+            "codex-ship": r"manual reconcile[\s\S]{0,220}/sw-verify[\s\S]{0,80}/sw-ship",
+            "opencode-ship": r"manual reconcile[\s\S]{0,220}/sw-verify[\s\S]{0,80}/sw-ship",
+        }
+        for label, pattern in expectations.items():
+            content = ADAPTER_COMMAND_SURFACES[label].read_text(encoding="utf-8")
+            with self.subTest(label=label):
+                self.assertRegex(content, re.compile(pattern, re.IGNORECASE))
+
+
+class TestPromptTemplatePivotAndFreshnessGuidance(unittest.TestCase):
+    """Unit 03 Task 2 RED: prompt templates must encode the broadened pivot contract."""
+
+    def test_pivot_prompt_uses_research_backed_rebaselining(self):
+        result = pivot()
+        self.assertRegex(
+            result,
+            re.compile(
+                r"(research-backed|rebaselin)[\s\S]{0,160}(planning|building|verifying)|"
+                r"(planning|building|verifying)[\s\S]{0,160}(research-backed|rebaselin)",
+                re.IGNORECASE,
+            ),
+        )
+        self.assertRegex(
+            result,
+            re.compile(
+                r"(preserv|keep)[\s\S]{0,120}(completed|shipped) scope|"
+                r"(completed|shipped) scope[\s\S]{0,120}(preserv|keep)",
+                re.IGNORECASE,
+            ),
+        )
+        self.assertRegex(
+            result,
+            re.compile(
+                r"/sw-design[\s\S]{0,160}(rewrite|history|shipped)|"
+                r"(rewrite|history|shipped)[\s\S]{0,160}/sw-design",
+                re.IGNORECASE,
+            ),
+        )
+
+    def test_build_prompt_describes_manual_reconcile_rerun(self):
+        result = build()
+        self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-build", re.IGNORECASE))
+
+    def test_verify_prompt_describes_manual_reconcile_rerun_without_build_loop(self):
+        result = verify()
+        self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-verify", re.IGNORECASE))
+        self.assertRegex(result, re.compile(r"do not[\s\S]{0,120}/sw-build", re.IGNORECASE))
+
+    def test_ship_prompt_describes_manual_reconcile_rerun_via_verify_then_ship(self):
+        result = ship()
+        self.assertRegex(
+            result,
+            re.compile(r"manual reconcile[\s\S]{0,220}/sw-verify[\s\S]{0,80}/sw-ship", re.IGNORECASE),
+        )
 
 
 class TestNewPromptTemplates(unittest.TestCase):

--- a/evals/tests/test_prompts.py
+++ b/evals/tests/test_prompts.py
@@ -282,9 +282,13 @@ class TestPromptTemplatePivotAndFreshnessGuidance(unittest.TestCase):
         self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-build", re.IGNORECASE))
 
     def test_verify_prompt_describes_manual_reconcile_rerun_without_build_loop(self):
-        result = verify()
-        self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-verify", re.IGNORECASE))
-        self.assertRegex(result, re.compile(r"do not[\s\S]{0,120}/sw-build", re.IGNORECASE))
+        for label, result in (
+            ("default", verify()),
+            ("gated", verify("security")),
+        ):
+            with self.subTest(label=label):
+                self.assertRegex(result, re.compile(r"manual reconcile[\s\S]{0,180}/sw-verify", re.IGNORECASE))
+                self.assertRegex(result, re.compile(r"do not[\s\S]{0,120}/sw-build", re.IGNORECASE))
 
     def test_ship_prompt_describes_manual_reconcile_rerun_via_verify_then_ship(self):
         result = ship()
@@ -323,19 +327,13 @@ class TestPromptAndDocRegressionCoverage(unittest.TestCase):
                     self.assertNotRegex(content, re.compile(pattern, re.IGNORECASE))
 
     def test_pivot_summary_rows_keep_completed_and_shipped_scope_visible(self):
-        summary_surfaces = {
-            "CLAUDE.md": PRIMARY_DOC_SURFACES["CLAUDE.md"],
-            "adapters/claude-code/CLAUDE.md": PRIMARY_DOC_SURFACES["adapters/claude-code/CLAUDE.md"],
-            "README.md": PRIMARY_DOC_SURFACES["README.md"],
-            "DESIGN.md": PRIMARY_DOC_SURFACES["DESIGN.md"],
-        }
         patterns = {
             "CLAUDE.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
             "adapters/claude-code/CLAUDE.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
             "README.md": r"\|\s*`/sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
             "DESIGN.md": r"\|\s*`sw-pivot`\s*\|[^\n]*(completed[^\n]*shipped|shipped[^\n]*completed)",
         }
-        for label, path in summary_surfaces.items():
+        for label, path in PRIMARY_DOC_SURFACES.items():
             content = path.read_text(encoding="utf-8")
             with self.subTest(label=label):
                 self.assertRegex(content, re.compile(patterns[label], re.IGNORECASE))
@@ -359,11 +357,15 @@ class TestPromptAndDocRegressionCoverage(unittest.TestCase):
                     self.assertRegex(content, negative_build_redirect)
 
     def test_default_pivot_prompt_rejects_invented_commands(self):
-        result = pivot()
-        self.assertRegex(
-            result,
-            re.compile(r"do not invent a new command[\s\S]{0,40}extra confirmation", re.IGNORECASE),
-        )
+        for label, result in (
+            ("default", pivot()),
+            ("with-change", pivot("Expand the active work without discarding shipped scope.")),
+        ):
+            with self.subTest(label=label):
+                self.assertRegex(
+                    result,
+                    re.compile(r"do not invent a new command[\s\S]{0,40}extra confirmation", re.IGNORECASE),
+                )
 
 
 class TestNewPromptTemplates(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR ships Unit 03 of `pivot-scope-expansion`.

It cuts the user-facing docs, adapter command descriptions, and prompt templates over to the broadened `/sw-pivot` contract so operators and agents see research-backed rebaselining, preserved completed and shipped scope, and explicit manual-reconcile rerun guidance instead of the older remaining-task-only or loop-inducing wording.

## Approval Lineage
- `design`: STALE (`artifact-set-changed`). Approved via `/sw-plan` on `2026-04-20T07:10:13Z` for the prior design artifact set; the current design artifact set no longer matches that approved hash.
- `unit-spec (03-docs-and-prompt-cutover)`: STALE (`artifact-set-changed`). Approved via `/sw-build` on `2026-04-21T04:52:26.635Z` for `spec.md`, `plan.md`, and `context.md`; the current unit artifact set no longer matches that approved hash.
- `accepted-mutant lineage`: none recorded and none required for this verify run.

## What Changed
- Primary operator docs now frame `/sw-pivot` as research-backed rebaselining that preserves completed and shipped scope while revising unfinished design, plan, and in-progress work.
- Codex and Opencode command descriptions now direct freshness-blocked users to manual reconcile and the correct rerun stage instead of bouncing them between `/sw-build` and `/sw-verify`.
- `evals/framework/prompts.py` now carries the same preserved-scope, manual-reconcile, and anti-invention guidance as the command surfaces.
- `evals/tests/test_prompts.py` now locks both the positive contract and the negative regressions that previously allowed quick-scan summaries and the default `pivot()` variant to drift.

## Why The Agent Implemented It This Way
- Task 1 updated the highest-traffic doc surfaces first so the broadened pivot contract appears where operators look earliest.
- Task 2 changed adapter command descriptions and prompt helpers together so manual-reconcile behavior and pivot wording stay on one contract.
- Task 3 expanded the regression surface and then fixed the two omissions RED exposed: quick-scan summary rows understated preserved scope, and the default `pivot()` prompt variant had dropped the anti-invention guard.

## Acceptance Criteria
- `AC-1` PASS: `CLAUDE.md`, `adapters/claude-code/CLAUDE.md`, `README.md`, and `DESIGN.md` now describe `/sw-pivot` as research-backed rebaselining that preserves completed/shipped scope and avoids the old remaining-task-only framing. Verified by `TestPrimaryDocPivotSurfaces.*` in `evals/tests/test_prompts.py:154-208`.
- `AC-2` PASS: `adapters/codex/commands/sw-{build,verify,ship,pivot}.md`, `adapters/opencode/commands/sw-{build,verify,ship,pivot}.md`, and `evals/framework/prompts.py` encode preserved scope, manual-reconcile guidance, and no invented command path. Verified by `TestAdapterCommandSurfaces.*`, `TestPromptTemplatePivotAndFreshnessGuidance.*`, and `TestPromptAndDocRegressionCoverage.test_default_pivot_prompt_rejects_invented_commands` in `evals/tests/test_prompts.py:214-294,361-365`.
- `AC-3` PASS: the touched doc and prompt surfaces now state valid pivot entry states, route shipped/history-rewriting requests to `/sw-design`, and keep build/verify/ship guidance aligned with manual freshness reconciliation. Verified by `TestPrimaryDocPivotSurfaces.*` and `TestPromptTemplatePivotAndFreshnessGuidance.*` in `evals/tests/test_prompts.py:167-188,253-294`.
- `AC-4` PASS: regression coverage now fails if touched surfaces reintroduce old mid-build wording, lose preserved-scope or research-first expectations, or redirect verify back into build without reconcile context. Verified by `TestPromptAndDocRegressionCoverage.*` in `evals/tests/test_prompts.py:300-365`.

## Spec Conformance
- All four acceptance criteria passed in `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/spec-compliance.md`.
- Canonical proof surface: `evidence/spec-compliance.md`.
- This was a non-final unit verify run, so final deliverable activation was not required yet.

## Gate Summary
| Gate | Verdict | Evidence | Recorded proof |
|------|---------|----------|----------------|
| build | PASS | `evidence/build-report.md` | `bash build/build.sh` passed and the authoritative test command completed successfully. |
| tests | PASS | `evidence/test-quality.md` | Regression assertions in `evals/tests/test_prompts.py` cover prompt/doc boundaries, negative paths, and the anti-loop behavior. |
| security | PASS | `evidence/security-report.md` | No secrets, injection paths, or auth-sensitive behavior were introduced in the changed docs/prompt/test surfaces. |
| wiring | PASS | `evidence/wiring-report.md` | The changed prompt module kept its existing shape and the regression file is wired into the active pytest suite. |
| semantic | PASS | `evidence/semantic-report.md` | The changed code is limited to static prompt strings and unittest assertions, with no error-path or resource-lifecycle regressions. |
| spec | PASS | `evidence/spec-compliance.md` | Each acceptance criterion has implementation evidence and passing test evidence. |

## Remaining Attention
- Approval lineage remains stale for both the design artifact set and the Unit 03 unit-spec artifact set; this PR carries that warning forward instead of fabricating refreshed approvals during shipping.
- No gate WARN or BLOCK findings remain.

## Evidence Links
Work artifacts for this repo are in clone-local mode, so the reviewer-usable summaries are inlined above. The recorded evidence paths are:

- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/review-packet.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/build-report.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/test-quality.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/security-report.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/wiring-report.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/semantic-report.md`
- `pivot-scope-expansion/units/03-docs-and-prompt-cutover/evidence/spec-compliance.md`