### PR TITLE
feat(operator-surface): add shared status card contract

### DIFF
--- a/adapters/shared/specwright-approvals.mjs
+++ b/adapters/shared/specwright-approvals.mjs
@@ -131,14 +131,23 @@ function createAssessmentResult({
   };
 }
 
-export function findLatestApprovalEntry(entries, { scope, unitId } = {}) {
+export function findLatestApprovalEntry(entries, options = {}) {
+  const scope = normalizeString(options?.scope);
+  if (!scope) {
+    throw new Error('Approval scope is required.');
+  }
+
   if (!Array.isArray(entries)) {
     return null;
   }
 
+  const unitId = Object.prototype.hasOwnProperty.call(options, 'unitId')
+    ? options.unitId
+    : undefined;
+
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (scope != null && entry?.scope !== scope) {
+    if (entry?.scope !== scope) {
       continue;
     }
 

--- a/adapters/shared/specwright-approvals.mjs
+++ b/adapters/shared/specwright-approvals.mjs
@@ -16,6 +16,7 @@ export const APPROVAL_REASON_CODES = [
   'expired',
   'superseded'
 ];
+export const APPROVAL_CURRENT_REASON_CODE = 'approved';
 export const DEFAULT_ACCEPTED_MUTANT_EXPIRY_DAYS = 90;
 export const APPROVAL_ASSESSMENT_STATUS_VALUES = [
   ...APPROVAL_STATUS_VALUES,
@@ -128,6 +129,52 @@ function createAssessmentResult({
     approvedArtifactSetHash,
     currentArtifactSetHash
   };
+}
+
+export function findLatestApprovalEntry(entries, { scope, unitId } = {}) {
+  if (!Array.isArray(entries)) {
+    return null;
+  }
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (scope != null && entry?.scope !== scope) {
+      continue;
+    }
+
+    if (unitId !== undefined && (entry?.unitId ?? null) !== (unitId ?? null)) {
+      continue;
+    }
+
+    return entry;
+  }
+
+  return null;
+}
+
+export function summarizeApprovalAssessment(scope, assessment) {
+  const normalizedScope = normalizeString(scope) ?? 'approval';
+  const normalizedStatus = normalizeString(assessment?.status) ?? 'MISSING';
+  const reasonCode = normalizeString(assessment?.reasonCode)
+    ?? (normalizedStatus === 'APPROVED' ? APPROVAL_CURRENT_REASON_CODE : 'unknown');
+
+  return {
+    scope: normalizedScope,
+    status: normalizedStatus,
+    reasonCode,
+    summary: normalizedStatus === 'APPROVED'
+      ? `${normalizedScope} approval is current.`
+      : `${normalizedScope} approval needs attention (${reasonCode}).`
+  };
+}
+
+export function formatApprovalStatusLine(summary, options = {}) {
+  if (!summary) {
+    return null;
+  }
+
+  const indent = options.indent ?? '  ';
+  return `${indent}Approval: ${summary.scope} ${summary.status} (${summary.reasonCode})`;
 }
 
 export function defaultApprovalsDocument() {

--- a/adapters/shared/specwright-closeout.mjs
+++ b/adapters/shared/specwright-closeout.mjs
@@ -15,6 +15,7 @@ const REVIEW_PACKET_SECTIONS = [
   'Gate Summary',
   'Remaining Attention'
 ];
+export const CLOSEOUT_ABSENCE_LINE = 'Closeout: none yet (no stage-report.md or review-packet.md)';
 const FENCED_BLOCK_MARKER_PATTERN = /^```/u;
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s/u;
 
@@ -137,17 +138,43 @@ export function parseReviewPacketDigest(markdown) {
 export function loadCloseoutDigest(options = {}) {
   const stageReportDigest = parseStageReportDigest(readMarkdownIfPresent(options.stageReportPath));
   if (stageReportDigest) {
-    return stageReportDigest;
+    return normalizeCloseoutDigest(stageReportDigest);
   }
 
   const reviewPacketDigest = parseReviewPacketDigest(readMarkdownIfPresent(options.reviewPacketPath));
   if (reviewPacketDigest) {
-    return reviewPacketDigest;
+    return normalizeCloseoutDigest(reviewPacketDigest);
   }
 
+  return normalizeCloseoutDigest(null);
+}
+
+export function normalizeCloseoutDigest(digest) {
   return {
-    source: null,
-    headline: null,
-    bullets: []
+    source: typeof digest?.source === 'string' && digest.source.trim() ? digest.source : null,
+    headline: typeof digest?.headline === 'string' && digest.headline.trim() ? digest.headline : null,
+    bullets: Array.isArray(digest?.bullets) ? digest.bullets.filter(Boolean) : []
   };
+}
+
+export function formatCloseoutLines(digest, options = {}) {
+  const normalized = normalizeCloseoutDigest(digest);
+  const indent = options.indent ?? '  ';
+  const detailIndent = options.detailIndent ?? `${indent}  `;
+  const bulletIndent = options.bulletIndent ?? `${detailIndent}- `;
+
+  if (!normalized.source) {
+    return [`${indent}${CLOSEOUT_ABSENCE_LINE}`];
+  }
+
+  const lines = [`${indent}Closeout: ${normalized.source}`];
+  if (normalized.headline) {
+    lines.push(`${detailIndent}${normalized.headline}`);
+  }
+
+  for (const bullet of normalized.bullets.slice(0, 2)) {
+    lines.push(`${bulletIndent}${bullet}`);
+  }
+
+  return lines;
 }

--- a/adapters/shared/specwright-operator-surface.mjs
+++ b/adapters/shared/specwright-operator-surface.mjs
@@ -13,7 +13,6 @@ export function loadOperatorSurfaceSummary(stateInfo, work) {
     closeout: card?.closeout ?? null,
     approval: card?.approvals ?? null,
     warnings: Array.isArray(card?.warnings) ? card.warnings : [],
-    blockers: Array.isArray(card?.blockers) ? card.blockers : [],
     nextCommand: card?.nextCommand ?? null
   };
 }

--- a/adapters/shared/specwright-operator-surface.mjs
+++ b/adapters/shared/specwright-operator-surface.mjs
@@ -1,122 +1,20 @@
-import { join, resolve } from 'path';
-import {
-  assessApprovalEntry,
-  loadApprovalsFile
-} from './specwright-approvals.mjs';
-import { loadCloseoutDigest } from './specwright-closeout.mjs';
-
-const UNIT_APPROVAL_ARTIFACTS = ['spec.md', 'plan.md', 'context.md'];
-const DESIGN_APPROVAL_ARTIFACTS = ['design.md', 'context.md', 'decisions.md'];
-const CLOSEOUT_ABSENCE_LINE = 'Closeout: none yet (no stage-report.md or review-packet.md)';
-
-function resolveRuntimeWorkRoot(stateInfo, work) {
-  if (stateInfo?.repoStateRoot) {
-    return join(stateInfo.repoStateRoot, 'work', work.workId);
-  }
-
-  return resolve(stateInfo?.lookupRoot ?? process.cwd(), '.specwright', 'work', work.workId);
-}
-
-function resolveWorkPaths(stateInfo, work) {
-  const runtimeWorkRoot = resolveRuntimeWorkRoot(stateInfo, work);
-
-  return {
-    stageReportPath: work?.unitId
-      ? join(runtimeWorkRoot, 'units', work.unitId, 'stage-report.md')
-      : join(runtimeWorkRoot, 'stage-report.md'),
-    reviewPacketPath: work?.workDirPath
-      ? join(work.workDirPath, 'review-packet.md')
-      : null,
-    approvalsPath: work?.artifactsRoot
-      ? join(work.artifactsRoot, work.workId, 'approvals.md')
-      : join(runtimeWorkRoot, 'approvals.md')
-  };
-}
-
-function resolveApprovalTarget(work) {
-  if (work?.unitId) {
-    return {
-      scope: 'unit-spec',
-      unitId: work.unitId,
-      baseDir: work.workDirPath,
-      artifacts: UNIT_APPROVAL_ARTIFACTS
-    };
-  }
-
-  return {
-    scope: 'design',
-    unitId: null,
-    baseDir: work?.artifactsRoot ? join(work.artifactsRoot, work.workId) : work?.workDirPath,
-    artifacts: DESIGN_APPROVAL_ARTIFACTS
-  };
-}
-
-function findLatestApprovalEntry(entries, { scope, unitId }) {
-  if (!Array.isArray(entries)) {
-    return null;
-  }
-
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (entry?.scope !== scope) {
-      continue;
-    }
-
-    if ((entry?.unitId ?? null) !== (unitId ?? null)) {
-      continue;
-    }
-
-    return entry;
-  }
-
-  return null;
-}
-
-function summarizeApproval(stateInfo, work, approvalsPath) {
-  const target = resolveApprovalTarget(work);
-
-  try {
-    const approvalDocument = loadApprovalsFile(approvalsPath);
-    const entry = findLatestApprovalEntry(approvalDocument.entries, target);
-    const assessment = assessApprovalEntry(entry, {
-      baseDir: target.baseDir,
-      artifacts: target.artifacts
-    });
-
-    return {
-      scope: target.scope,
-      status: assessment.status,
-      reasonCode: assessment.reasonCode ?? 'approved'
-    };
-  } catch (error) {
-    if (error?.code !== 'ENOENT') {
-      const message = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`[specwright] summarizeApproval failed for ${target.scope}: ${message}\n`);
-    }
-
-    return {
-      scope: target.scope,
-      status: 'MISSING',
-      reasonCode: 'missing-entry'
-    };
-  }
-}
+import { formatApprovalStatusLine } from './specwright-approvals.mjs';
+import { buildStatusCard } from './specwright-status-card.mjs';
+import { formatCloseoutLines } from './specwright-closeout.mjs';
 
 export function loadOperatorSurfaceSummary(stateInfo, work) {
   if (!stateInfo || !work) {
     return null;
   }
-
-  const paths = resolveWorkPaths(stateInfo, work);
-  const closeout = loadCloseoutDigest({
-    stageReportPath: paths.stageReportPath,
-    reviewPacketPath: paths.reviewPacketPath
-  });
+  const card = buildStatusCard(stateInfo, work);
 
   return {
-    closeout,
-    approval: summarizeApproval(stateInfo, work, paths.approvalsPath),
-    paths
+    card,
+    closeout: card?.closeout ?? null,
+    approval: card?.approvals ?? null,
+    warnings: Array.isArray(card?.warnings) ? card.warnings : [],
+    blockers: Array.isArray(card?.blockers) ? card.blockers : [],
+    nextCommand: card?.nextCommand ?? null
   };
 }
 
@@ -128,24 +26,15 @@ export function renderOperatorSurfaceLines(summary, options = {}) {
   const indent = options.indent ?? '  ';
   const detailIndent = options.detailIndent ?? `${indent}  `;
   const bulletIndent = options.bulletIndent ?? `${detailIndent}- `;
-  const lines = [];
+  const lines = formatCloseoutLines(summary.closeout, {
+    indent,
+    detailIndent,
+    bulletIndent
+  });
+  const approvalLine = formatApprovalStatusLine(summary.approval, { indent });
 
-  if (summary.closeout?.source) {
-    lines.push(`${indent}Closeout: ${summary.closeout.source}`);
-    if (summary.closeout.headline) {
-      lines.push(`${detailIndent}${summary.closeout.headline}`);
-    }
-    for (const bullet of (summary.closeout.bullets ?? []).slice(0, 2)) {
-      lines.push(`${bulletIndent}${bullet}`);
-    }
-  } else {
-    lines.push(`${indent}${CLOSEOUT_ABSENCE_LINE}`);
-  }
-
-  if (summary.approval) {
-    lines.push(
-      `${indent}Approval: ${summary.approval.scope} ${summary.approval.status} (${summary.approval.reasonCode})`
-    );
+  if (approvalLine) {
+    lines.push(approvalLine);
   }
 
   return lines;

--- a/adapters/shared/specwright-status-card.mjs
+++ b/adapters/shared/specwright-status-card.mjs
@@ -3,9 +3,14 @@ import { dirname, join, resolve } from 'path';
 
 import {
   assessApprovalEntry,
-  loadApprovalsFile
+  findLatestApprovalEntry,
+  loadApprovalsFile,
+  summarizeApprovalAssessment
 } from './specwright-approvals.mjs';
-import { loadCloseoutDigest } from './specwright-closeout.mjs';
+import {
+  loadCloseoutDigest,
+  normalizeCloseoutDigest
+} from './specwright-closeout.mjs';
 
 const UNIT_APPROVAL_ARTIFACTS = ['spec.md', 'plan.md', 'context.md'];
 const DESIGN_APPROVAL_ARTIFACTS = ['design.md', 'context.md', 'decisions.md'];
@@ -65,27 +70,6 @@ function resolveApprovalTarget(work) {
   };
 }
 
-function findLatestApprovalEntry(entries, { scope, unitId }) {
-  if (!Array.isArray(entries)) {
-    return null;
-  }
-
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (entry?.scope !== scope) {
-      continue;
-    }
-
-    if ((entry?.unitId ?? null) !== (unitId ?? null)) {
-      continue;
-    }
-
-    return entry;
-  }
-
-  return null;
-}
-
 function summarizeApproval(work, approvalsPath) {
   const target = resolveApprovalTarget(work);
 
@@ -96,27 +80,16 @@ function summarizeApproval(work, approvalsPath) {
       baseDir: target.baseDir,
       artifacts: target.artifacts
     });
-
-    return {
-      scope: target.scope,
-      status: assessment.status,
-      reasonCode: assessment.reasonCode ?? 'approved',
-      summary: assessment.status === 'APPROVED'
-        ? `${target.scope} approval is current.`
-        : `${target.scope} approval needs attention (${assessment.reasonCode ?? 'unknown'}).`
-    };
+    return summarizeApprovalAssessment(target.scope, assessment);
   } catch (error) {
     if (error?.code !== 'ENOENT') {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`[specwright] summarizeApproval failed for ${target.scope}: ${message}\n`);
     }
-
-    return {
-      scope: target.scope,
+    return summarizeApprovalAssessment(target.scope, {
       status: 'MISSING',
-      reasonCode: 'missing-entry',
-      summary: `${target.scope} approval is missing for the current artifact set.`
-    };
+      reasonCode: 'missing-entry'
+    });
   }
 }
 
@@ -277,10 +250,10 @@ export function buildStatusCard(stateInfo, work) {
 
   const paths = resolveWorkPaths(stateInfo, work);
   const approval = summarizeApproval(work, paths.approvalsPath);
-  const closeout = loadCloseoutDigest({
+  const closeout = normalizeCloseoutDigest(loadCloseoutDigest({
     stageReportPath: paths.stageReportPath,
     reviewPacketPath: paths.reviewPacketPath
-  });
+  }));
   const branch = summarizeBranch(stateInfo, work);
   const gates = summarizeGates(work.gates);
   const warnings = buildWarnings(stateInfo, approval, closeout, branch);
@@ -296,11 +269,7 @@ export function buildStatusCard(stateInfo, work) {
     branch,
     approvals: approval,
     gates,
-    closeout: {
-      source: closeout?.source ?? null,
-      headline: closeout?.headline ?? null,
-      bullets: Array.isArray(closeout?.bullets) ? closeout.bullets : []
-    },
+    closeout,
     warnings,
     blockers: [],
     nextCommand: nextCommandFor(work)

--- a/adapters/shared/specwright-status-card.mjs
+++ b/adapters/shared/specwright-status-card.mjs
@@ -1,0 +1,315 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+
+import {
+  assessApprovalEntry,
+  loadApprovalsFile
+} from './specwright-approvals.mjs';
+import { loadCloseoutDigest } from './specwright-closeout.mjs';
+
+const UNIT_APPROVAL_ARTIFACTS = ['spec.md', 'plan.md', 'context.md'];
+const DESIGN_APPROVAL_ARTIFACTS = ['design.md', 'context.md', 'decisions.md'];
+
+function normalizeString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveRuntimeWorkRoot(stateInfo, work) {
+  if (stateInfo?.repoStateRoot) {
+    return join(stateInfo.repoStateRoot, 'work', work.workId);
+  }
+
+  return resolve(stateInfo?.lookupRoot ?? process.cwd(), '.specwright', 'work', work.workId);
+}
+
+function resolveWorkPaths(stateInfo, work) {
+  const runtimeWorkRoot = resolveRuntimeWorkRoot(stateInfo, work);
+
+  return {
+    runtimeWorkRoot,
+    stageReportPath: work?.unitId
+      ? join(runtimeWorkRoot, 'units', work.unitId, 'stage-report.md')
+      : join(runtimeWorkRoot, 'stage-report.md'),
+    reviewPacketPath: work?.workDirPath
+      ? join(work.workDirPath, 'review-packet.md')
+      : null,
+    approvalsPath: work?.artifactsRoot
+      ? join(work.artifactsRoot, work.workId, 'approvals.md')
+      : join(runtimeWorkRoot, 'approvals.md'),
+    statusCardPath: work?.unitId
+      ? join(runtimeWorkRoot, 'units', work.unitId, 'status-card.json')
+      : join(runtimeWorkRoot, 'status-card.json')
+  };
+}
+
+function resolveApprovalTarget(work) {
+  if (work?.unitId) {
+    return {
+      scope: 'unit-spec',
+      unitId: work.unitId,
+      baseDir: work.workDirPath,
+      artifacts: UNIT_APPROVAL_ARTIFACTS
+    };
+  }
+
+  return {
+    scope: 'design',
+    unitId: null,
+    baseDir: work?.artifactsRoot ? join(work.artifactsRoot, work.workId) : work?.workDirPath,
+    artifacts: DESIGN_APPROVAL_ARTIFACTS
+  };
+}
+
+function findLatestApprovalEntry(entries, { scope, unitId }) {
+  if (!Array.isArray(entries)) {
+    return null;
+  }
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.scope !== scope) {
+      continue;
+    }
+
+    if ((entry?.unitId ?? null) !== (unitId ?? null)) {
+      continue;
+    }
+
+    return entry;
+  }
+
+  return null;
+}
+
+function summarizeApproval(work, approvalsPath) {
+  const target = resolveApprovalTarget(work);
+
+  try {
+    const approvalDocument = loadApprovalsFile(approvalsPath);
+    const entry = findLatestApprovalEntry(approvalDocument.entries, target);
+    const assessment = assessApprovalEntry(entry, {
+      baseDir: target.baseDir,
+      artifacts: target.artifacts
+    });
+
+    return {
+      scope: target.scope,
+      status: assessment.status,
+      reasonCode: assessment.reasonCode ?? 'approved',
+      summary: assessment.status === 'APPROVED'
+        ? `${target.scope} approval is current.`
+        : `${target.scope} approval needs attention (${assessment.reasonCode ?? 'unknown'}).`
+    };
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[specwright] summarizeApproval failed for ${target.scope}: ${message}\n`);
+    }
+
+    return {
+      scope: target.scope,
+      status: 'MISSING',
+      reasonCode: 'missing-entry',
+      summary: `${target.scope} approval is missing for the current artifact set.`
+    };
+  }
+}
+
+function summarizeGates(gates) {
+  const entries = Object.entries(gates ?? {});
+  if (entries.length === 0) {
+    return {
+      status: 'not-run',
+      summary: 'No gates recorded yet.',
+      counts: {
+        pass: 0,
+        warn: 0,
+        fail: 0,
+        other: 0
+      }
+    };
+  }
+
+  const counts = {
+    pass: 0,
+    warn: 0,
+    fail: 0,
+    other: 0
+  };
+
+  for (const [, gate] of entries) {
+    switch (gate?.verdict) {
+      case 'PASS':
+        counts.pass += 1;
+        break;
+      case 'WARN':
+        counts.warn += 1;
+        break;
+      case 'FAIL':
+      case 'ERROR':
+        counts.fail += 1;
+        break;
+      default:
+        counts.other += 1;
+        break;
+    }
+  }
+
+  let status = 'pass';
+  if (counts.fail > 0) {
+    status = 'fail';
+  } else if (counts.warn > 0) {
+    status = 'warn';
+  } else if (counts.pass === 0) {
+    status = 'not-run';
+  }
+
+  const summaryParts = [];
+  if (counts.pass > 0) {
+    summaryParts.push(`${counts.pass} PASS`);
+  }
+  if (counts.warn > 0) {
+    summaryParts.push(`${counts.warn} WARN`);
+  }
+  if (counts.fail > 0) {
+    summaryParts.push(`${counts.fail} FAIL`);
+  }
+  if (counts.other > 0) {
+    summaryParts.push(`${counts.other} OTHER`);
+  }
+
+  return {
+    status,
+    summary: summaryParts.join(', '),
+    counts
+  };
+}
+
+function summarizeBranch(stateInfo, work) {
+  const expected = normalizeString(stateInfo?.workflow?.branch) ?? normalizeString(work?.branch);
+  const observed = normalizeString(stateInfo?.session?.branch) ?? normalizeString(work?.branch);
+  let status = 'unknown';
+
+  if (expected && observed) {
+    status = expected === observed ? 'match' : 'mismatch';
+  }
+
+  return {
+    expected,
+    observed,
+    status
+  };
+}
+
+function nextCommandFor(work) {
+  const stage = normalizeString(work?.status);
+  if (!stage) {
+    return '/sw-design';
+  }
+
+  switch (stage) {
+    case 'designing':
+      return '/sw-plan';
+    case 'planning':
+      return '/sw-build';
+    case 'building':
+      return work?.tasksTotal != null && work?.completedCount >= work.tasksTotal
+        ? '/sw-verify'
+        : '/sw-build';
+    case 'verifying':
+      return '/sw-ship';
+    case 'shipping':
+      return '/sw-ship';
+    case 'shipped':
+      return '/sw-build';
+    default:
+      return '/sw-design';
+  }
+}
+
+function buildWarnings(stateInfo, approval, closeout, branch) {
+  const warnings = [];
+
+  if (approval && approval.status !== 'APPROVED') {
+    warnings.push({
+      code: `approval-${approval.reasonCode ?? 'unknown'}`,
+      summary: approval.summary
+    });
+  }
+
+  if (!closeout?.source) {
+    warnings.push({
+      code: 'missing-closeout',
+      summary: 'No stage-report.md or review-packet.md is available yet.'
+    });
+  }
+
+  if (branch?.status === 'mismatch') {
+    warnings.push({
+      code: 'branch-mismatch',
+      summary: `Expected ${branch.expected} but observed ${branch.observed}.`
+    });
+  }
+
+  if (stateInfo?.usedFallback) {
+    warnings.push({
+      code: 'degraded-root-resolution',
+      summary: 'Specwright is using degraded root-resolution fallback.'
+    });
+  }
+
+  return warnings;
+}
+
+export function resolveStatusCardPath(stateInfo, work) {
+  return resolveWorkPaths(stateInfo, work).statusCardPath;
+}
+
+export function buildStatusCard(stateInfo, work) {
+  if (!stateInfo || !work) {
+    return null;
+  }
+
+  const paths = resolveWorkPaths(stateInfo, work);
+  const approval = summarizeApproval(work, paths.approvalsPath);
+  const closeout = loadCloseoutDigest({
+    stageReportPath: paths.stageReportPath,
+    reviewPacketPath: paths.reviewPacketPath
+  });
+  const branch = summarizeBranch(stateInfo, work);
+  const gates = summarizeGates(work.gates);
+  const warnings = buildWarnings(stateInfo, approval, closeout, branch);
+
+  return {
+    format: 'status-card/v1',
+    workId: work.workId,
+    description: normalizeString(stateInfo?.workflow?.description),
+    stage: normalizeString(work.status),
+    currentUnitId: normalizeString(work.unitId),
+    targetRef: stateInfo?.workflow?.targetRef ?? null,
+    baselineCommit: normalizeString(stateInfo?.workflow?.baselineCommit),
+    branch,
+    approvals: approval,
+    gates,
+    closeout: {
+      source: closeout?.source ?? null,
+      headline: closeout?.headline ?? null,
+      bullets: Array.isArray(closeout?.bullets) ? closeout.bullets : []
+    },
+    warnings,
+    blockers: [],
+    nextCommand: nextCommandFor(work)
+  };
+}
+
+export function writeStatusCard(path, card) {
+  mkdirSync(dirname(path), { recursive: true });
+  const contents = JSON.stringify(card, null, 2) + '\n';
+  writeFileSync(path, contents, 'utf8');
+  return contents;
+}

--- a/adapters/shared/specwright-status-card.mjs
+++ b/adapters/shared/specwright-status-card.mjs
@@ -7,10 +7,7 @@ import {
   loadApprovalsFile,
   summarizeApprovalAssessment
 } from './specwright-approvals.mjs';
-import {
-  loadCloseoutDigest,
-  normalizeCloseoutDigest
-} from './specwright-closeout.mjs';
+import { loadCloseoutDigest } from './specwright-closeout.mjs';
 
 const UNIT_APPROVAL_ARTIFACTS = ['spec.md', 'plan.md', 'context.md'];
 const DESIGN_APPROVAL_ARTIFACTS = ['design.md', 'context.md', 'decisions.md'];
@@ -103,6 +100,7 @@ function summarizeGates(gates) {
         pass: 0,
         warn: 0,
         fail: 0,
+        skip: 0,
         other: 0
       }
     };
@@ -112,6 +110,7 @@ function summarizeGates(gates) {
     pass: 0,
     warn: 0,
     fail: 0,
+    skip: 0,
     other: 0
   };
 
@@ -127,6 +126,9 @@ function summarizeGates(gates) {
       case 'ERROR':
         counts.fail += 1;
         break;
+      case 'SKIP':
+        counts.skip += 1;
+        break;
       default:
         counts.other += 1;
         break;
@@ -136,7 +138,7 @@ function summarizeGates(gates) {
   let status = 'pass';
   if (counts.fail > 0) {
     status = 'fail';
-  } else if (counts.warn > 0) {
+  } else if (counts.warn > 0 || counts.skip > 0 || counts.other > 0) {
     status = 'warn';
   } else if (counts.pass === 0) {
     status = 'not-run';
@@ -152,6 +154,9 @@ function summarizeGates(gates) {
   if (counts.fail > 0) {
     summaryParts.push(`${counts.fail} FAIL`);
   }
+  if (counts.skip > 0) {
+    summaryParts.push(`${counts.skip} SKIP`);
+  }
   if (counts.other > 0) {
     summaryParts.push(`${counts.other} OTHER`);
   }
@@ -165,7 +170,8 @@ function summarizeGates(gates) {
 
 function summarizeBranch(stateInfo, work) {
   const expected = normalizeString(stateInfo?.workflow?.branch) ?? normalizeString(work?.branch);
-  const observed = normalizeString(stateInfo?.session?.branch) ?? normalizeString(work?.branch);
+  const observed = normalizeString(stateInfo?.session?.branch)
+    ?? (stateInfo?.layout === 'legacy' ? normalizeString(work?.branch) : null);
   let status = 'unknown';
 
   if (expected && observed) {
@@ -179,11 +185,37 @@ function summarizeBranch(stateInfo, work) {
   };
 }
 
-function nextCommandFor(work) {
+function hasFreshnessBlock(stateInfo) {
+  const freshnessStatus = normalizeString(stateInfo?.workflow?.freshness?.status);
+  return ['stale', 'diverged', 'blocked'].includes(freshnessStatus);
+}
+
+function hasRemainingWorkUnits(workflow, currentUnitId) {
+  if (!Array.isArray(workflow?.workUnits) || workflow.workUnits.length === 0) {
+    return false;
+  }
+
+  const normalizedCurrentUnitId = normalizeString(currentUnitId);
+  const currentIndex = workflow.workUnits.findIndex(
+    (unit) => normalizeString(unit?.id) === normalizedCurrentUnitId
+  );
+  const candidateUnits = currentIndex >= 0
+    ? workflow.workUnits.slice(currentIndex + 1)
+    : workflow.workUnits;
+
+  return candidateUnits.some((unit) => {
+    const status = normalizeString(unit?.status);
+    return Boolean(status) && !['shipped', 'abandoned'].includes(status);
+  });
+}
+
+function nextCommandFor(work, options = {}) {
   const stage = normalizeString(work?.status);
   if (!stage) {
     return '/sw-design';
   }
+
+  const gateCounts = options.gates?.counts ?? {};
 
   switch (stage) {
     case 'designing':
@@ -195,11 +227,29 @@ function nextCommandFor(work) {
         ? '/sw-verify'
         : '/sw-build';
     case 'verifying':
-      return '/sw-ship';
+      if (hasFreshnessBlock(options.stateInfo)) {
+        return '/sw-verify';
+      }
+
+      if ((gateCounts.fail ?? 0) > 0) {
+        return '/sw-build';
+      }
+
+      if (
+        (gateCounts.pass ?? 0) > 0 ||
+        (gateCounts.warn ?? 0) > 0 ||
+        (gateCounts.skip ?? 0) > 0
+      ) {
+        return '/sw-ship';
+      }
+
+      return '/sw-verify';
     case 'shipping':
       return '/sw-ship';
     case 'shipped':
-      return '/sw-build';
+      return hasRemainingWorkUnits(options.stateInfo?.workflow, work?.unitId)
+        ? '/sw-build'
+        : '/sw-learn';
     default:
       return '/sw-design';
   }
@@ -250,10 +300,10 @@ export function buildStatusCard(stateInfo, work) {
 
   const paths = resolveWorkPaths(stateInfo, work);
   const approval = summarizeApproval(work, paths.approvalsPath);
-  const closeout = normalizeCloseoutDigest(loadCloseoutDigest({
+  const closeout = loadCloseoutDigest({
     stageReportPath: paths.stageReportPath,
     reviewPacketPath: paths.reviewPacketPath
-  }));
+  });
   const branch = summarizeBranch(stateInfo, work);
   const gates = summarizeGates(work.gates);
   const warnings = buildWarnings(stateInfo, approval, closeout, branch);
@@ -271,8 +321,7 @@ export function buildStatusCard(stateInfo, work) {
     gates,
     closeout,
     warnings,
-    blockers: [],
-    nextCommand: nextCommandFor(work)
+    nextCommand: nextCommandFor(work, { gates, stateInfo })
   };
 }
 

--- a/core/protocols/approvals.md
+++ b/core/protocols/approvals.md
@@ -99,6 +99,8 @@ reason-code vocabulary when approval lineage is not current:
 These reason codes keep terminal and packet summaries compact. Full hashes,
 artifact manifests, and accepted-mutant lineage remain in the approval ledger
 or deeper evidence artifacts instead of the terminal-first digest.
+`status-card.json` and shared operator surfaces must reuse this compact reason-code
+vocabulary instead of inventing adapter-local approval wording.
 
 ## File Shape
 

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -309,7 +309,6 @@ process.stdout.write(JSON.stringify({ card, statusCardPath }, null, 2));
 def _load_operator_surface(repo_path: Path, *, force_used_fallback: bool = False) -> dict:
     script = """
 const { loadSpecwrightState, normalizeActiveWork } = await import(process.env.STATE_PATHS_MODULE);
-const { buildStatusCard } = await import(process.env.STATUS_CARD_MODULE);
 const {
   loadOperatorSurfaceSummary,
   renderOperatorSurfaceLines
@@ -320,11 +319,10 @@ if (process.env.FORCE_USED_FALLBACK === '1') {
   state.usedFallback = true;
 }
 const work = normalizeActiveWork(state);
-const card = buildStatusCard(state, work);
 const summary = loadOperatorSurfaceSummary(state, work);
 const lines = renderOperatorSurfaceLines(summary);
 
-process.stdout.write(JSON.stringify({ card, summary, lines }, null, 2));
+process.stdout.write(JSON.stringify({ summary, lines }, null, 2));
 """
     result = subprocess.run(
         ["node", "--input-type=module", "-"],
@@ -427,6 +425,119 @@ class TestStatusCardContract(unittest.TestCase):
 
             self.assertEqual(result["card"]["nextCommand"], "/sw-verify")
 
+    def test_build_status_card_treats_skipped_gates_as_warn_and_keeps_ship_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "verifying"
+            workflow["gates"] = {
+                "build": {"verdict": "SKIP"},
+                "tests": {"verdict": "SKIP"},
+            }
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+            card = result["card"]
+
+            self.assertEqual(card["gates"]["status"], "warn")
+            self.assertEqual(card["gates"]["counts"]["skip"], 2)
+            self.assertEqual(card["gates"]["summary"], "2 SKIP")
+            self.assertEqual(card["nextCommand"], "/sw-ship")
+
+    def test_build_status_card_points_verifying_failures_back_to_build(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "verifying"
+            workflow["gates"] = {
+                "build": {"verdict": "PASS"},
+                "tests": {"verdict": "FAIL"},
+            }
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+
+            self.assertEqual(result["card"]["nextCommand"], "/sw-build")
+
+    def test_build_status_card_points_freshness_blocked_verify_back_to_verify(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "verifying"
+            workflow["gates"] = {}
+            workflow["freshness"]["status"] = "blocked"
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+
+            self.assertEqual(result["card"]["nextCommand"], "/sw-verify")
+
+    def test_build_status_card_requires_live_session_branch_for_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            session_path = Path(state["sessionPath"])
+            session = json.loads(session_path.read_text(encoding="utf-8"))
+            session["branch"] = None
+            session_path.write_text(json.dumps(session, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+            card = result["card"]
+
+            self.assertEqual(card["branch"]["expected"], "work/03-status-card-proof")
+            self.assertIsNone(card["branch"]["observed"])
+            self.assertEqual(card["branch"]["status"], "unknown")
+
+    def test_build_status_card_points_final_shipped_work_to_learn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "shipped"
+            workflow["gates"] = {
+                "build": {"verdict": "PASS"},
+                "tests": {"verdict": "PASS"},
+            }
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+
+            self.assertEqual(result["card"]["nextCommand"], "/sw-learn")
+
+    def test_build_status_card_keeps_build_handoff_when_more_units_remain_after_ship(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "shipped"
+            workflow["gates"] = {
+                "build": {"verdict": "PASS"},
+                "tests": {"verdict": "PASS"},
+            }
+            workflow["workUnits"] = [
+                {"id": state["unitId"], "status": "shipped", "order": 1},
+                {"id": "04-follow-on-unit", "status": "planned", "order": 2},
+            ]
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+
+            self.assertEqual(result["card"]["nextCommand"], "/sw-build")
+
     def test_operator_surface_summary_uses_shared_status_card_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir)
@@ -436,20 +547,50 @@ class TestStatusCardContract(unittest.TestCase):
             _write_approvals(Path(state["unitDir"]), state["unitId"])
 
             result = _load_operator_surface(repo_path)
-            card = result["card"]
             summary = result["summary"]
             lines = result["lines"]
+            card = summary["card"]
 
-            self.assertEqual(summary["card"], card)
             self.assertEqual(summary["approval"]["scope"], card["approvals"]["scope"])
             self.assertEqual(summary["approval"]["status"], card["approvals"]["status"])
             self.assertEqual(summary["approval"]["reasonCode"], card["approvals"]["reasonCode"])
             self.assertEqual(summary["closeout"]["source"], card["closeout"]["source"])
+            self.assertEqual(summary["nextCommand"], card["nextCommand"])
             self.assertTrue(any("Closeout: stage-report" in line for line in lines))
             self.assertTrue(any("Approval: unit-spec APPROVED (approved)" in line for line in lines))
 
 
 class TestApprovalsProtocolStatusCardContract(unittest.TestCase):
+    def test_find_latest_approval_entry_requires_scope(self) -> None:
+        script = """
+const { findLatestApprovalEntry } = await import(process.env.APPROVALS_MODULE);
+
+try {
+  findLatestApprovalEntry([{ scope: 'design' }]);
+  process.stdout.write(JSON.stringify({ ok: true }));
+} catch (error) {
+  process.stdout.write(JSON.stringify({
+    ok: false,
+    message: error instanceof Error ? error.message : String(error)
+  }));
+}
+"""
+        result = subprocess.run(
+            ["node", "--input-type=module", "-"],
+            input=script,
+            text=True,
+            capture_output=True,
+            cwd=ROOT_DIR,
+            check=False,
+            env=sanitized_git_env({"APPROVALS_MODULE": str(APPROVALS_MODULE)}),
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stderr or result.stdout or "approval helper execution failed")
+
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["message"], "Approval scope is required.")
+
     def test_approvals_protocol_mentions_status_card_reason_code_consumers(self) -> None:
         text = load_text(APPROVALS_PROTOCOL)
         assert_multiline_regex(

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -15,6 +15,7 @@ from evals.tests._text_helpers import assert_multiline_regex, load_text
 ROOT_DIR = Path(__file__).resolve().parents[2]
 STATE_PATHS_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-state-paths.mjs"
 STATUS_CARD_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-status-card.mjs"
+OPERATOR_SURFACE_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-operator-surface.mjs"
 APPROVALS_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-approvals.mjs"
 APPROVALS_PROTOCOL = ROOT_DIR / "core" / "protocols" / "approvals.md"
 
@@ -305,6 +306,47 @@ process.stdout.write(JSON.stringify({ card, statusCardPath }, null, 2));
     return json.loads(result.stdout)
 
 
+def _load_operator_surface(repo_path: Path, *, force_used_fallback: bool = False) -> dict:
+    script = """
+const { loadSpecwrightState, normalizeActiveWork } = await import(process.env.STATE_PATHS_MODULE);
+const { buildStatusCard } = await import(process.env.STATUS_CARD_MODULE);
+const {
+  loadOperatorSurfaceSummary,
+  renderOperatorSurfaceLines
+} = await import(process.env.OPERATOR_SURFACE_MODULE);
+
+const state = loadSpecwrightState({ cwd: process.cwd() });
+if (process.env.FORCE_USED_FALLBACK === '1') {
+  state.usedFallback = true;
+}
+const work = normalizeActiveWork(state);
+const card = buildStatusCard(state, work);
+const summary = loadOperatorSurfaceSummary(state, work);
+const lines = renderOperatorSurfaceLines(summary);
+
+process.stdout.write(JSON.stringify({ card, summary, lines }, null, 2));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=repo_path,
+        check=False,
+        env=sanitized_git_env(
+            {
+                "STATE_PATHS_MODULE": str(STATE_PATHS_MODULE),
+                "STATUS_CARD_MODULE": str(STATUS_CARD_MODULE),
+                "OPERATOR_SURFACE_MODULE": str(OPERATOR_SURFACE_MODULE),
+                "FORCE_USED_FALLBACK": "1" if force_used_fallback else "0",
+            }
+        ),
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "operator-surface helper execution failed")
+    return json.loads(result.stdout)
+
+
 class TestStatusCardContract(unittest.TestCase):
     def test_build_status_card_returns_minimum_contract_and_writes_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -336,6 +378,27 @@ class TestStatusCardContract(unittest.TestCase):
             self.assertTrue(status_card_path.exists(), "status-card.json should be written")
             written_card = json.loads(status_card_path.read_text(encoding="utf-8"))
             self.assertEqual(written_card, card)
+
+    def test_operator_surface_summary_uses_shared_status_card_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            _write_stage_report(Path(state["repoStateRoot"]), state["workId"], state["unitId"])
+            _write_approvals(Path(state["unitDir"]), state["unitId"])
+
+            result = _load_operator_surface(repo_path)
+            card = result["card"]
+            summary = result["summary"]
+            lines = result["lines"]
+
+            self.assertEqual(summary["card"], card)
+            self.assertEqual(summary["approval"]["scope"], card["approvals"]["scope"])
+            self.assertEqual(summary["approval"]["status"], card["approvals"]["status"])
+            self.assertEqual(summary["approval"]["reasonCode"], card["approvals"]["reasonCode"])
+            self.assertEqual(summary["closeout"]["source"], card["closeout"]["source"])
+            self.assertTrue(any("Closeout: stage-report" in line for line in lines))
+            self.assertTrue(any("Approval: unit-spec APPROVED (approved)" in line for line in lines))
 
 
 class TestApprovalsProtocolStatusCardContract(unittest.TestCase):

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -379,6 +379,54 @@ class TestStatusCardContract(unittest.TestCase):
             written_card = json.loads(status_card_path.read_text(encoding="utf-8"))
             self.assertEqual(written_card, card)
 
+    def test_build_status_card_surfaces_explicit_warning_classes_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(
+                repo_path,
+                session_branch="work/03-status-card-proof-drifted",
+            )
+            _write_approvals(Path(state["unitDir"]), state["unitId"])
+            (Path(state["unitDir"]) / "context.md").unlink()
+
+            result = _build_status_card(
+                repo_path,
+                force_used_fallback=True,
+                write_status_card=False,
+            )
+            card = result["card"]
+            warning_codes = {warning["code"] for warning in card["warnings"]}
+
+            self.assertEqual(card["approvals"]["status"], "STALE")
+            self.assertEqual(card["approvals"]["reasonCode"], "artifact-set-changed")
+            self.assertEqual(card["branch"]["status"], "mismatch")
+            self.assertEqual(card["nextCommand"], "/sw-build")
+            self.assertSetEqual(
+                warning_codes,
+                {
+                    "approval-artifact-set-changed",
+                    "missing-closeout",
+                    "branch-mismatch",
+                    "degraded-root-resolution",
+                },
+            )
+
+    def test_build_status_card_points_to_verify_when_all_tasks_are_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workflowPath"])
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["tasksCompleted"] = ["task-1", "task-2", "task-3"]
+            workflow["currentTask"] = None
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            result = _build_status_card(repo_path, write_status_card=False)
+
+            self.assertEqual(result["card"]["nextCommand"], "/sw-verify")
+
     def test_operator_surface_summary_uses_shared_status_card_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir)

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -1,0 +1,353 @@
+"""Regression coverage for Unit 03 — shared status-card contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from evals.framework.git_env import sanitized_git_env
+from evals.tests._text_helpers import assert_multiline_regex, load_text
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+STATE_PATHS_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-state-paths.mjs"
+STATUS_CARD_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-status-card.mjs"
+APPROVALS_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-approvals.mjs"
+APPROVALS_PROTOCOL = ROOT_DIR / "core" / "protocols" / "approvals.md"
+
+
+def _run(args: list[str], cwd: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    runtime_env = None
+    if env is not None:
+        runtime_env = sanitized_git_env(env)
+    elif args and args[0] == "git":
+        runtime_env = sanitized_git_env()
+
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=runtime_env,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init"], cwd=path)
+    _run(["git", "config", "user.name", "Specwright Tests"], cwd=path)
+    _run(["git", "config", "user.email", "specwright-tests@example.com"], cwd=path)
+    _run(["git", "branch", "-M", "main"], cwd=path)
+    (path / "README.md").write_text("fixture\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=path)
+    _run(["git", "commit", "-m", "chore: init fixture"], cwd=path)
+
+
+def _git_path(repo_path: Path, *args: str) -> Path:
+    output = _run(["git", *args], cwd=repo_path).stdout.strip()
+    candidate = Path(output)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (repo_path / candidate).resolve()
+
+
+def _derive_worktree_id(git_dir: Path, git_common_dir: Path) -> str:
+    if git_dir == git_common_dir:
+        return "main-worktree"
+
+    if git_dir.parent == git_common_dir / "worktrees" and git_dir.name and git_dir.name != "main-worktree":
+        return git_dir.name
+
+    if git_dir.name and git_dir.name not in {".git", "main-worktree"}:
+        return git_dir.name
+
+    raise AssertionError("unable to derive worktree id for fixture")
+
+
+def _runtime_roots(repo_path: Path) -> dict[str, Path | str]:
+    git_dir = _git_path(repo_path, "rev-parse", "--git-dir")
+    git_common_dir = _git_path(repo_path, "rev-parse", "--git-common-dir")
+    worktree_id = _derive_worktree_id(git_dir, git_common_dir)
+
+    return {
+        "gitDir": git_dir,
+        "gitCommonDir": git_common_dir,
+        "worktreeId": worktree_id,
+        "repoStateRoot": git_common_dir / "specwright",
+        "worktreeStateRoot": git_dir / "specwright",
+        "workArtifactsRoot": (git_common_dir / "specwright" / "work"),
+    }
+
+
+def _write_shared_state(
+    repo_path: Path,
+    *,
+    work_id: str = "status-card-proof",
+    unit_id: str = "03-status-card-proof",
+    workflow_branch: str = "work/03-status-card-proof",
+    session_branch: str | None = None,
+) -> dict[str, Path | str]:
+    roots = _runtime_roots(repo_path)
+    repo_state_root = Path(roots["repoStateRoot"])
+    worktree_state_root = Path(roots["worktreeStateRoot"])
+    unit_dir = Path(roots["workArtifactsRoot"]) / work_id / "units" / unit_id
+    workflow_path = repo_state_root / "work" / work_id / "workflow.json"
+    session_path = worktree_state_root / "session.json"
+
+    config_path = repo_state_root / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "2.0",
+                "git": {
+                    "targets": {
+                        "defaultRole": "integration",
+                        "roles": {
+                            "integration": {"branch": "main"},
+                        },
+                    },
+                    "freshness": {
+                        "validation": "branch-head",
+                        "reconcile": "manual",
+                        "checkpoints": {
+                            "build": "require",
+                            "verify": "require",
+                            "ship": "require",
+                        },
+                    },
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+
+    (unit_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (unit_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (unit_dir / "context.md").write_text("# Context\n", encoding="utf-8")
+
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(
+        json.dumps(
+            {
+                "version": "3.0",
+                "id": work_id,
+                "description": "Structured operator status-card proof.",
+                "status": "building",
+                "workDir": f"{work_id}/units/{unit_id}",
+                "unitId": unit_id,
+                "tasksCompleted": ["task-1"],
+                "tasksTotal": 3,
+                "currentTask": "task-2",
+                "baselineCommit": "2648d5fbb35a440e6bfd6c685f459f13a03104c1",
+                "targetRef": {
+                    "remote": "origin",
+                    "branch": "main",
+                    "role": "integration",
+                    "resolvedBy": "config.git.targets.roles.integration.branch",
+                    "resolvedAt": "2026-04-21T03:09:41Z",
+                },
+                "freshness": {
+                    "validation": "branch-head",
+                    "reconcile": "manual",
+                    "checkpoints": {
+                        "build": "require",
+                        "verify": "require",
+                        "ship": "require",
+                    },
+                    "status": "fresh",
+                    "lastCheckedAt": "2026-04-21T03:10:00Z",
+                },
+                "branch": workflow_branch,
+                "gates": {
+                    "build": {"verdict": "PASS"},
+                    "tests": {"verdict": "PASS"},
+                },
+                "attachment": {
+                    "worktreeId": roots["worktreeId"],
+                    "worktreePath": str(repo_path.resolve()),
+                    "mode": "top-level",
+                    "attachedAt": "2026-04-21T03:18:49Z",
+                    "lastSeenAt": "2026-04-21T03:18:49Z",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session_path.write_text(
+        json.dumps(
+            {
+                "version": "3.0",
+                "worktreeId": roots["worktreeId"],
+                "worktreePath": str(repo_path.resolve()),
+                "branch": session_branch or workflow_branch,
+                "attachedWorkId": work_id,
+                "mode": "top-level",
+                "lastSeenAt": "2026-04-21T03:18:49Z",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        **roots,
+        "workId": work_id,
+        "unitId": unit_id,
+        "unitDir": unit_dir,
+        "workflowPath": workflow_path,
+        "sessionPath": session_path,
+    }
+
+
+def _write_stage_report(repo_state_root: Path, work_id: str, unit_id: str) -> Path:
+    stage_report_path = repo_state_root / "work" / work_id / "units" / unit_id / "stage-report.md"
+    stage_report_path.parent.mkdir(parents=True, exist_ok=True)
+    stage_report_path.write_text(
+        "\n".join(
+            [
+                "Attention required: Shared operator summary is available.",
+                "",
+                "## What I did",
+                "- Built a structured operator card.",
+                "- Kept closeout digests readable during migration.",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return stage_report_path
+
+
+def _write_approvals(unit_dir: Path, unit_id: str) -> None:
+    approvals_path = unit_dir.parents[1] / "approvals.md"
+    script = f"""
+const {{ defaultApprovalsDocument, recordApproval, writeApprovalsFile }} = await import({json.dumps(str(APPROVALS_MODULE))});
+
+const document = recordApproval(defaultApprovalsDocument(), {{
+  baseDir: {json.dumps(str(unit_dir))},
+  scope: 'unit-spec',
+  unitId: {json.dumps(unit_id)},
+  sourceClassification: 'command',
+  sourceRef: '/sw-build',
+  artifacts: ['spec.md', 'plan.md', 'context.md'],
+  approvedAt: '2026-04-21T03:20:00Z'
+}});
+
+writeApprovalsFile({json.dumps(str(approvals_path))}, document);
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "approval fixture creation failed")
+
+
+def _build_status_card(repo_path: Path, *, force_used_fallback: bool = False, write_status_card: bool = True) -> dict:
+    script = """
+const { loadSpecwrightState, normalizeActiveWork } = await import(process.env.STATE_PATHS_MODULE);
+const {
+  buildStatusCard,
+  resolveStatusCardPath,
+  writeStatusCard
+} = await import(process.env.STATUS_CARD_MODULE);
+
+const state = loadSpecwrightState({ cwd: process.cwd() });
+if (process.env.FORCE_USED_FALLBACK === '1') {
+  state.usedFallback = true;
+}
+const work = normalizeActiveWork(state);
+const card = buildStatusCard(state, work);
+const statusCardPath = resolveStatusCardPath(state, work);
+
+if (process.env.WRITE_STATUS_CARD === '1') {
+  writeStatusCard(statusCardPath, card);
+}
+
+process.stdout.write(JSON.stringify({ card, statusCardPath }, null, 2));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=repo_path,
+        check=False,
+        env=sanitized_git_env(
+            {
+                "STATE_PATHS_MODULE": str(STATE_PATHS_MODULE),
+                "STATUS_CARD_MODULE": str(STATUS_CARD_MODULE),
+                "FORCE_USED_FALLBACK": "1" if force_used_fallback else "0",
+                "WRITE_STATUS_CARD": "1" if write_status_card else "0",
+            }
+        ),
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "status-card helper execution failed")
+    return json.loads(result.stdout)
+
+
+class TestStatusCardContract(unittest.TestCase):
+    def test_build_status_card_returns_minimum_contract_and_writes_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            _write_stage_report(Path(state["repoStateRoot"]), state["workId"], state["unitId"])
+            _write_approvals(Path(state["unitDir"]), state["unitId"])
+
+            result = _build_status_card(repo_path)
+            card = result["card"]
+            status_card_path = Path(result["statusCardPath"])
+
+            self.assertEqual(card["workId"], state["workId"])
+            self.assertEqual(card["stage"], "building")
+            self.assertEqual(card["currentUnitId"], state["unitId"])
+            self.assertEqual(card["targetRef"]["remote"], "origin")
+            self.assertEqual(card["targetRef"]["branch"], "main")
+            self.assertEqual(card["baselineCommit"], "2648d5fbb35a440e6bfd6c685f459f13a03104c1")
+            self.assertEqual(card["branch"]["expected"], "work/03-status-card-proof")
+            self.assertEqual(card["branch"]["observed"], "work/03-status-card-proof")
+            self.assertEqual(card["branch"]["status"], "match")
+            self.assertEqual(card["approvals"]["status"], "APPROVED")
+            self.assertEqual(card["approvals"]["reasonCode"], "approved")
+            self.assertEqual(card["gates"]["status"], "pass")
+            self.assertEqual(card["closeout"]["source"], "stage-report")
+            self.assertEqual(card["nextCommand"], "/sw-build")
+
+            self.assertTrue(status_card_path.exists(), "status-card.json should be written")
+            written_card = json.loads(status_card_path.read_text(encoding="utf-8"))
+            self.assertEqual(written_card, card)
+
+
+class TestApprovalsProtocolStatusCardContract(unittest.TestCase):
+    def test_approvals_protocol_mentions_status_card_reason_code_consumers(self) -> None:
+        text = load_text(APPROVALS_PROTOCOL)
+        assert_multiline_regex(
+            self,
+            text,
+            r"status-card\.json[\s\S]{0,160}(compact reason[- ]code|reason[- ]code\s+vocabulary)|"
+            r"(compact reason[- ]code|reason[- ]code\s+vocabulary)[\s\S]{0,160}status-card\.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Unit 03 of `quality-first-devex-redesign`: a shared structured status card so Specwright surfaces stop reconstructing partial workflow state from bespoke markdown fragments.

- adds `adapters/shared/specwright-status-card.mjs` to emit a single `status-card.json` contract with work identity, branch posture, approval freshness, gate posture, closeout digest, warnings, and next-step guidance
- rewires shared operator rendering to consume that contract plus shared approval and closeout helpers instead of adapter-local reconstruction
- adds integration-style regression coverage for stale lineage, missing closeout, degraded root resolution, branch drift, and `/sw-verify` handoff guidance

## Approval Lineage

- Design approval: `STALE (artifact-set-changed)`, originally approved via `/sw-plan`
- Unit-spec approval for `03-status-card-and-shared-operator-surface`: `STALE (artifact-set-changed)`, originally approved via `/sw-build`
- Gate evidence was refreshed on the current head; the remaining attention is audit-trail freshness, not code-quality failure

## What Changed

- Added `adapters/shared/specwright-status-card.mjs`
- Reworked `adapters/shared/specwright-operator-surface.mjs`, `adapters/shared/specwright-closeout.mjs`, and `adapters/shared/specwright-approvals.mjs` to share one approval and closeout vocabulary
- Updated `core/protocols/approvals.md` so `status-card.json` and operator surfaces reuse the compact approval reason-code contract
- Added `evals/tests/test_operator_surface_status_card.py` to prove the structured card and warning model stay stable
- Blast radius: 6 files changed, 847 insertions, 134 deletions

## Why The Agent Implemented It This Way

- Task 1 established a single structured card first so work identity, branch posture, approval freshness, gate posture, closeout digest, and next-step guidance come from one contract instead of adapter-local reconstruction
- Task 2 moved approval and closeout wording into shared helpers because the DX benefit only holds if Claude Code, Opencode, and later surfaces all read the same truth
- Task 3 added explicit regression proof for stale lineage, missing closeout, branch drift, degraded roots, and `/sw-verify` guidance because hidden state drift is the failure mode this unit is meant to eliminate
- No deviation from the approved unit artifact set was recorded during build

## Acceptance Criteria

- AC-1 `PASS` — shared helper writes and returns the `status-card.json` contract. Evidence: `adapters/shared/specwright-status-card.mjs`, `evals/tests/test_operator_surface_status_card.py`
- AC-2 `PASS` — operator summaries now consume the shared card and helper vocabulary. Evidence: `adapters/shared/specwright-operator-surface.mjs`, `evals/tests/test_operator_surface_visibility.py`
- AC-3 `PASS` — stale approval, branch mismatch, missing closeout, and degraded-root states surface as explicit warning classes. Evidence: `adapters/shared/specwright-status-card.mjs`, `adapters/shared/specwright-approvals.mjs`, `core/protocols/approvals.md`, `evals/tests/test_operator_surface_status_card.py`
- AC-4 `PASS` — stage-report and closeout digests remain readable during migration. Evidence: `adapters/shared/specwright-closeout.mjs`, `adapters/shared/specwright-operator-surface.mjs`, `evals/tests/test_operator_surface_visibility.py`
- AC-5 `PASS` — regressions fail closed on missing artifacts, next-step drift, and vocabulary divergence. Evidence: `evals/tests/test_operator_surface_status_card.py`, `evals/tests/test_operator_surface_visibility.py`

## Spec Conformance

All five acceptance criteria passed in the latest verify run. Deliverable verification did not activate because this is Unit 03 of 5, not the final unit of the multi-unit work.

## Gate Summary

| Gate | Verdict | Notes |
|---|---|---|
| build | PASS | `bash build/build.sh` and the configured full test suite passed; integration and smoke remain unconfigured |
| tests | PASS | Integration-style tests use real git/runtime state and the mutation floor passed at `T3` |
| security | PASS | No secrets, injection paths, or auth surfaces changed in this unit |
| wiring | PASS | Shared helpers are consumed by Claude Code, Opencode, and the shared operator surface with no new cycle risk |
| semantic | PASS | Warning and fallback paths stay explicit; no semantic findings were identified |
| spec | PASS | AC-1 through AC-5 each have direct implementation and test evidence |

## Remaining Attention

- Refresh the design approval lineage if you want the audit trail to match the current design artifact set before shipping future units
- Refresh the Unit 03 unit-spec approval lineage if you want the unit audit trail to match the current artifact set exactly
- No gate produced `WARN` or `BLOCK` findings; remaining attention is approval-lineage hygiene only

## Evidence Links

Because this work uses clone-local audit artifacts, the reviewer-usable summaries are inlined above instead of linking to `.git/specwright/...` files directly.

Repo-backed proof surfaces:

- `adapters/shared/specwright-status-card.mjs`
- `adapters/shared/specwright-operator-surface.mjs`
- `adapters/shared/specwright-closeout.mjs`
- `adapters/shared/specwright-approvals.mjs`
- `core/protocols/approvals.md`
- `evals/tests/test_operator_surface_status_card.py`
- `evals/tests/test_operator_surface_visibility.py`