### PR TITLE
docs(workflow): align verify scheduling and workflow policy

### DIFF
--- a/core/protocols/parallel-build.md
+++ b/core/protocols/parallel-build.md
@@ -46,8 +46,8 @@ When verification borrows concurrency, the same boundary applies:
   aggregate result fail-closed
 
 This protocol does not grant subordinate helpers or read-only lanes permission
-to write `workflow.json`, mutate `session.json`, or self-report a passing
-aggregate verdict.
+to directly write `workflow.json`, directly write `session.json`, or
+self-report a passing aggregate verdict.
 
 ## Independence Analysis
 

--- a/core/protocols/parallel-build.md
+++ b/core/protocols/parallel-build.md
@@ -1,8 +1,9 @@
 # Parallel Build Protocol
 
-Experimental parallel task execution using helper worktrees. Only used by
-`sw-build` when all prerequisites are met. Falls back to sequential execution
-otherwise.
+Experimental helper concurrency using subordinate worktrees or lanes. `sw-build`
+uses it for mutable task execution only when all prerequisites are met, and
+`sw-verify` may reference the same parent/subordinate contract for read-only
+evidence lanes. Falls back to sequential execution otherwise.
 
 ## Prerequisites
 
@@ -34,6 +35,19 @@ Subordinate sessions may read the parent work's shared artifacts and use local
 continuation state, but they must not directly ship, verify, rewrite another
 worktree's `session.json`, or mutate shared workflow state. Shared workflow
 state remains parent-only.
+
+When verification borrows concurrency, the same boundary applies:
+
+- freshness, build, and tests stay parent-ordered prerequisites
+- only read-only evidence lanes may run concurrently after those prerequisites
+- the parent top-level session remains the only authority that aggregates lane
+  results into `workflow.json` or shared gate state
+- missing evidence, lane failure, or skipped prerequisite state keeps the
+  aggregate result fail-closed
+
+This protocol does not grant subordinate helpers or read-only lanes permission
+to write `workflow.json`, mutate `session.json`, or self-report a passing
+aggregate verdict.
 
 ## Independence Analysis
 

--- a/core/skills/sw-audit/SKILL.md
+++ b/core/skills/sw-audit/SKILL.md
@@ -40,6 +40,7 @@ and persist findings for future design cycles.
 **Scope (LOW freedom):**
 - This skill reads and analyzes. It NEVER modifies source code, creates branches, runs builds, or starts work units.
 - Does NOT create `currentWork` in workflow.json. Does NOT require a lock. Can run while a work unit is in progress.
+- It is not a core workflow stage and never claims top-level work ownership.
 - On compaction: re-run from scratch (no state to recover).
 
 **Triage (MEDIUM freedom):**

--- a/core/skills/sw-build/SKILL.md
+++ b/core/skills/sw-build/SKILL.md
@@ -83,7 +83,7 @@ Per-task integration and regression runs do not happen inside this loop.
 
 **State updates (LOW freedom):** Follow `protocols/state.md`: acquire the per-work lock on the selected work before mutations, update the selected work's `tasksCompleted` after each committed task, refresh `currentTask`, and append as-built notes before handoff. Mutate only the selected work's `workflow.json` and the current worktree's session state.
 
-**Parallel execution (MEDIUM freedom):** Only use `protocols/parallel-build.md` when the experimental config flag enables it; otherwise ignore it and stay sequential.
+**Parallel execution (MEDIUM freedom):** Only use `protocols/parallel-build.md` when the experimental config flag enables it; otherwise ignore it and stay sequential. When mutable concurrency needs more than subordinate helpers or read-only lanes, split the effort into separate works with integration criteria rather than sharing one mutable workflow across top-level worktrees.
 
 ## Protocol References
 

--- a/core/skills/sw-doctor/SKILL.md
+++ b/core/skills/sw-doctor/SKILL.md
@@ -120,7 +120,7 @@ STATE_DRIFT findings must print the inline remediation command
 - The only allowed mutation is STATE_DRIFT backfill.
 - When mutating a work's `workflow.json`, follow `protocols/state.md`.
 - Doctor never modifies `status`; only `prNumber` and `prMergedAt` may change.
-- Doctor is not a core workflow stage and never claims top-level work ownership.
+- It is not a core workflow stage and never claims top-level work ownership.
 - Any repair guidance beyond PR backfill must remain bounded to the documented
   migration surface: tracked docs/config under `{projectArtifactsRoot}`, split
   per-work workflows under `{repoStateRoot}`, and this worktree's

--- a/core/skills/sw-doctor/SKILL.md
+++ b/core/skills/sw-doctor/SKILL.md
@@ -120,6 +120,7 @@ STATE_DRIFT findings must print the inline remediation command
 - The only allowed mutation is STATE_DRIFT backfill.
 - When mutating a work's `workflow.json`, follow `protocols/state.md`.
 - Doctor never modifies `status`; only `prNumber` and `prMergedAt` may change.
+- Doctor is not a core workflow stage and never claims top-level work ownership.
 - Any repair guidance beyond PR backfill must remain bounded to the documented
   migration surface: tracked docs/config under `{projectArtifactsRoot}`, split
   per-work workflows under `{repoStateRoot}`, and this worktree's

--- a/core/skills/sw-learn/SKILL.md
+++ b/core/skills/sw-learn/SKILL.md
@@ -50,6 +50,7 @@ work benefits.
 **Stage boundary (LOW freedom):**
 - Follow `protocols/stage-boundary.md`.
 - You capture learnings and promote patterns. You NEVER start new work units, run builds, or create PRs.
+- It is not a core workflow stage and never claims top-level work ownership.
 - After learnings are captured, STOP and present the handoff:
   - If more work units pending: "Run `/sw-build` to start the next unit."
   - If no more units: "All work units complete. Learnings captured."

--- a/core/skills/sw-plan/SKILL.md
+++ b/core/skills/sw-plan/SKILL.md
@@ -72,6 +72,9 @@ instead of fabricating one.
   get their own unit.
 - Each unit: independently buildable, testable, single purpose, 3+ testable ACs.
 - Ordered by dependency. If exactly 1 unit, use flat layout.
+- When mutable concurrency would otherwise require multiple top-level worktrees
+  on one active workflow, split the effort into separate works and define
+  integration criteria between them instead of sharing one mutable workflow.
 - Record decomposition rationale in decisions.md per `protocols/decision.md` DISAMBIGUATION.
 - On re-entry to `sw-plan` after a structural pivot or decomposition revision,
   regenerate only the affected remaining-unit artifact set. Overwrite each
@@ -127,6 +130,9 @@ instead of fabricating one.
 For each unit sequentially: create directory, write context.md (self-contained),
 plan.md (task breakdown + file change map), spec.md (unit-scoped ACs). Each unit's
 context.md must be sufficient for an agent reading only that directory.
+If the remaining work truly needs mutable concurrency, stop decomposing it into
+one shared workflow and instead create separate works with explicit
+integration criteria.
 
 **Spec pre-review (MEDIUM freedom):**
 - After drafting each spec, delegate to `specwright-architect` per `protocols/spec-review.md`.

--- a/core/skills/sw-research/SKILL.md
+++ b/core/skills/sw-research/SKILL.md
@@ -36,6 +36,7 @@ briefs are consumed by sw-design (which has its own gate).
 **Stage boundary (LOW freedom):**
 Reads and researches. NEVER writes code, branches, mutates workflow state,
 or produces design artifacts. No `currentWork`, no lock. Can run anytime.
+It is not a core workflow stage and never claims top-level work ownership.
 
 **Triage (MEDIUM freedom):**
 - Break request into 1-5 tracks. Derive tracks from the argument + existing gaps.

--- a/core/skills/sw-review/SKILL.md
+++ b/core/skills/sw-review/SKILL.md
@@ -133,6 +133,7 @@ associated work can be matched, say so explicitly and use a diff-only fallback.
   workflow.json, never claims exclusive workflow ownership, and makes no state
   changes to the Specwright workflow. GitHub comment replies and resolutions
   are allowed, but the skill never writes Specwright project or runtime state.
+- It is not a core workflow stage and never claims top-level work ownership.
 - Reading config.json for `prTool` is permitted. No writes to
   `{projectArtifactsRoot}`, `{workArtifactsRoot}`, `{repoStateRoot}`, or
   `{worktreeStateRoot}`.

--- a/core/skills/sw-sync/SKILL.md
+++ b/core/skills/sw-sync/SKILL.md
@@ -100,6 +100,7 @@ claimed by a live Specwright session or a subordinate helper worktree.
 
 **No state mutation (LOW freedom):**
 - `sw-sync` never writes Specwright state.
+- It is not a core workflow stage and never claims top-level work ownership.
 - Reading session and workflow files to protect branches is allowed.
 
 ## Protocol References

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -105,9 +105,12 @@ Load calibration notes per `protocols/evidence.md#verdict-rendering`.
 
 Freshness is a prerequisite checkpoint, and gate-build plus gate-tests remain
 the ordered prerequisites before any parallel or read-only lane begins. When
-parallel verify execution is enabled, only gate-security, gate-wiring,
-gate-semantic, and gate-spec may run as read-only evidence producers after the
-freshness, build, and tests steps complete.
+parallel verify execution is enabled under the same `protocols/parallel-build.md`
+prerequisites (`config.experimental.agentTeams.enabled=true`,
+`SPECWRIGHT_AGENT_TEAMS=1`, and a selected work unit with 4 or more tasks),
+only gate-security, gate-wiring, gate-semantic, and gate-spec may run as
+read-only evidence producers after the freshness, build, and tests steps
+complete.
 
 Parallel lanes never become independent workflow owners. The parent or
 top-level verify execution remains the only authority that aggregates lane

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -118,6 +118,8 @@ Missing evidence, lane failure, or skipped prerequisite state must keep the
 aggregate verify result fail-closed. Parallel lanes may speed up evidence
 collection, but they must not upgrade the overall outcome to an aggregate PASS
 when prerequisite or lane evidence is incomplete.
+Verify must never report a soft success or soft PASS when required evidence is
+missing.
 
 **Gate invocation (MEDIUM freedom):**
 Gates are internal skills — load SKILL.md and execute inline. Pass work unit context.

--- a/core/skills/sw-verify/SKILL.md
+++ b/core/skills/sw-verify/SKILL.md
@@ -103,6 +103,22 @@ gate-security, gate-wiring → gate-semantic → gate-spec.
 If `--gate=<name>` argument, run only that gate.
 Load calibration notes per `protocols/evidence.md#verdict-rendering`.
 
+Freshness is a prerequisite checkpoint, and gate-build plus gate-tests remain
+the ordered prerequisites before any parallel or read-only lane begins. When
+parallel verify execution is enabled, only gate-security, gate-wiring,
+gate-semantic, and gate-spec may run as read-only evidence producers after the
+freshness, build, and tests steps complete.
+
+Parallel lanes never become independent workflow owners. The parent or
+top-level verify execution remains the only authority that aggregates lane
+results into shared work state, including the selected work's `workflow.json`
+`gates` section.
+
+Missing evidence, lane failure, or skipped prerequisite state must keep the
+aggregate verify result fail-closed. Parallel lanes may speed up evidence
+collection, but they must not upgrade the overall outcome to an aggregate PASS
+when prerequisite or lane evidence is incomplete.
+
 **Gate invocation (MEDIUM freedom):**
 Gates are internal skills — load SKILL.md and execute inline. Pass work unit context.
 

--- a/evals/tests/test_workflow_policy_docs.py
+++ b/evals/tests/test_workflow_policy_docs.py
@@ -100,5 +100,27 @@ class TestWorkflowOwnershipLanguage(unittest.TestCase):
         )
 
 
+class TestWorkflowPolicyProofHardening(unittest.TestCase):
+    """Task 3 RED: the proof surface must fail closed on helper writes and soft success."""
+
+    def setUp(self) -> None:
+        self.verify_text = load_text(VERIFY_SKILL).lower()
+        self.parallel_text = load_text(PARALLEL_PROTOCOL).lower()
+
+    def test_parallel_protocol_forbids_direct_helper_writes_to_shared_state(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.parallel_text,
+            r"directly write[\s\S]{0,120}workflow\.json[\s\S]{0,120}session\.json",
+        )
+
+    def test_verify_explicitly_rejects_soft_success_without_required_evidence(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text,
+            r"soft (success|pass)[\s\S]{0,160}(required evidence|missing evidence)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/evals/tests/test_workflow_policy_docs.py
+++ b/evals/tests/test_workflow_policy_docs.py
@@ -42,6 +42,15 @@ class TestVerifyParallelLanePolicy(unittest.TestCase):
             r"(read-only evidence producers|read-only lanes?)",
         )
 
+    def test_verify_reuses_parallel_build_prerequisites_before_parallel_lanes(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"parallel verify execution[\s\S]{0,220}parallel-build\.md"
+            r"[\s\S]{0,220}agentteams\.enabled[\s\S]{0,160}specwright_agent_teams"
+            r"[\s\S]{0,160}4 or more tasks",
+        )
+
     def test_verify_requires_parent_only_aggregation_of_lane_results(self) -> None:
         assert_multiline_regex(
             self,
@@ -56,6 +65,11 @@ class TestVerifyParallelLanePolicy(unittest.TestCase):
             self.verify_text.lower(),
             r"(missing evidence|lane failure|skipped prerequisite state)[\s\S]{0,220}"
             r"(prevents|block|cannot|must not)[\s\S]{0,160}(aggregate )?pass",
+        )
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"(missing evidence|lane failure|skipped prerequisite state)[\s\S]{0,120}fail-closed",
         )
 
     def test_parallel_protocol_restates_parent_only_shared_state_for_helpers(self) -> None:
@@ -112,6 +126,11 @@ class TestWorkflowPolicyProofHardening(unittest.TestCase):
             self,
             self.parallel_text,
             r"directly write[\s\S]{0,120}workflow\.json[\s\S]{0,120}session\.json",
+        )
+        assert_multiline_regex(
+            self,
+            self.parallel_text,
+            r"self-report[\s\S]{0,80}(passing aggregate verdict|aggregate verdict)",
         )
 
     def test_verify_explicitly_rejects_soft_success_without_required_evidence(self) -> None:

--- a/evals/tests/test_workflow_policy_docs.py
+++ b/evals/tests/test_workflow_policy_docs.py
@@ -7,6 +7,16 @@ from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 VERIFY_SKILL = "core/skills/sw-verify/SKILL.md"
 PARALLEL_PROTOCOL = "core/protocols/parallel-build.md"
+PLAN_SKILL = "core/skills/sw-plan/SKILL.md"
+BUILD_SKILL = "core/skills/sw-build/SKILL.md"
+SIDECAR_SKILLS = [
+    "core/skills/sw-research/SKILL.md",
+    "core/skills/sw-doctor/SKILL.md",
+    "core/skills/sw-review/SKILL.md",
+    "core/skills/sw-sync/SKILL.md",
+    "core/skills/sw-audit/SKILL.md",
+    "core/skills/sw-learn/SKILL.md",
+]
 
 
 class TestVerifyParallelLanePolicy(unittest.TestCase):
@@ -54,6 +64,39 @@ class TestVerifyParallelLanePolicy(unittest.TestCase):
             self.parallel_text.lower(),
             r"(parent|top-level)[\s\S]{0,180}(only authority|only writer|only mutator)"
             r"[\s\S]{0,180}(shared workflow state|workflow\.json|shared work state)",
+        )
+
+
+class TestWorkflowOwnershipLanguage(unittest.TestCase):
+    """Task 2 RED: sidecars and core stages must describe the same ownership model."""
+
+    def test_sidecar_skills_do_not_claim_core_stage_or_top_level_ownership(self) -> None:
+        for skill_path in SIDECAR_SKILLS:
+            with self.subTest(skill=skill_path):
+                skill_text = load_text(skill_path).lower()
+                assert_multiline_regex(
+                    self,
+                    skill_text,
+                    r"not a core workflow stage",
+                )
+                assert_multiline_regex(
+                    self,
+                    skill_text,
+                    r"never claims top-level work ownership",
+                )
+
+    def test_sw_plan_directs_mutable_concurrency_into_separate_works(self) -> None:
+        assert_multiline_regex(
+            self,
+            load_text(PLAN_SKILL).lower(),
+            r"mutable concurrency[\s\S]{0,220}separate works[\s\S]{0,220}integration criteria",
+        )
+
+    def test_sw_build_directs_mutable_concurrency_into_separate_works(self) -> None:
+        assert_multiline_regex(
+            self,
+            load_text(BUILD_SKILL).lower(),
+            r"mutable concurrency[\s\S]{0,220}separate works[\s\S]{0,220}integration criteria",
         )
 
 

--- a/evals/tests/test_workflow_policy_docs.py
+++ b/evals/tests/test_workflow_policy_docs.py
@@ -1,0 +1,61 @@
+"""Regression tests for Unit 05 workflow-policy documentation."""
+
+import unittest
+
+from evals.tests._text_helpers import assert_multiline_regex, load_text
+
+
+VERIFY_SKILL = "core/skills/sw-verify/SKILL.md"
+PARALLEL_PROTOCOL = "core/protocols/parallel-build.md"
+
+
+class TestVerifyParallelLanePolicy(unittest.TestCase):
+    """Task 1 RED: verify must describe prerequisite-first read-only lanes."""
+
+    def setUp(self) -> None:
+        self.verify_text = load_text(VERIFY_SKILL)
+        self.parallel_text = load_text(PARALLEL_PROTOCOL)
+
+    def test_verify_runs_freshness_build_and_tests_before_parallel_lanes(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"freshness[\s\S]{0,220}build[\s\S]{0,220}tests[\s\S]{0,260}"
+            r"(parallel|read-only lane|read-only lanes)",
+        )
+
+    def test_verify_limits_parallelism_to_read_only_evidence_producers(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"(security|wiring|semantic|spec)[\s\S]{0,220}"
+            r"(read-only evidence producers|read-only lanes?)",
+        )
+
+    def test_verify_requires_parent_only_aggregation_of_lane_results(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"(parent|top-level)[\s\S]{0,220}(aggregate|aggregates|aggregation)"
+            r"[\s\S]{0,220}(workflow state|shared work state|gates section)",
+        )
+
+    def test_verify_keeps_missing_evidence_or_lane_failure_fail_closed(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.verify_text.lower(),
+            r"(missing evidence|lane failure|skipped prerequisite state)[\s\S]{0,220}"
+            r"(prevents|block|cannot|must not)[\s\S]{0,160}(aggregate )?pass",
+        )
+
+    def test_parallel_protocol_restates_parent_only_shared_state_for_helpers(self) -> None:
+        assert_multiline_regex(
+            self,
+            self.parallel_text.lower(),
+            r"(parent|top-level)[\s\S]{0,180}(only authority|only writer|only mutator)"
+            r"[\s\S]{0,180}(shared workflow state|workflow\.json|shared work state)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This ships Unit 05 of `quality-first-devex-redesign`, the final work unit in the redesign. It aligns verify orchestration and workflow policy around prerequisite-first execution, read-only parallel evidence lanes, parent-only shared-state mutation, and sidecar skills that no longer present themselves as core workflow-stage owners.

## Approval Lineage

- `design`: `STALE (artifact-set-changed)` via `/sw-plan`
- `unit-spec`: `STALE (artifact-set-changed)` via `/sw-build`

The stale lineage is reviewer-visible in this PR rather than silently waived.

## What Changed

- Updated `core/skills/sw-verify/SKILL.md` and `core/protocols/parallel-build.md` so verify runs freshness, build, and tests before any parallel read-only lanes, and only the parent or top-level execution aggregates lane results into shared work state.
- Updated `core/skills/sw-plan/SKILL.md` and `core/skills/sw-build/SKILL.md` so mutable concurrency is directed into separate works plus integration criteria instead of sharing one mutable workflow across top-level worktrees.
- Updated the sidecar skills `sw-research`, `sw-doctor`, `sw-review`, `sw-sync`, `sw-audit`, and `sw-learn` so they explicitly do not claim core-stage or top-level workflow ownership.
- Added and extended `evals/tests/test_workflow_policy_docs.py` as the regression proof surface for read-only verify lanes, parent-only aggregation, direct helper write bans, sidecar ownership language, and soft-success rejection.

## Why The Agent Implemented It This Way

- The verify-lane contract was anchored in both the shared protocol and the verify skill so the concurrency model stays explicit in the two places operators and future contributors actually read.
- The sidecar wording was normalized instead of left implicit so support skills stop sounding like lifecycle owners.
- The proof surface uses exact fail-closed phrases such as `directly write` and `soft success`, turning wording drift into a deterministic regression rather than a reviewer judgment call.
- The unit kept one accumulating workflow-policy regression file instead of splitting proof across multiple files, which preserved a single auditable contract surface.

## Acceptance Criteria

- `AC-1`: `PASS`
  Evidence: `core/skills/sw-verify/SKILL.md:106-115`, `core/protocols/parallel-build.md:39-45`, and `evals/tests/test_workflow_policy_docs.py:29-35,45-67` prove prerequisite-first ordering and parent-only aggregation.
- `AC-2`: `PASS`
  Evidence: `core/skills/sw-verify/SKILL.md:106-122`, `core/protocols/parallel-build.md:42-50`, and `evals/tests/test_workflow_policy_docs.py:37-59,117-122` prove read-only evidence lanes and fail-closed aggregate PASS behavior.
- `AC-3`: `PASS`
  Evidence: `core/skills/sw-research/SKILL.md:37-39`, `core/skills/sw-doctor/SKILL.md:119-123`, `core/skills/sw-review/SKILL.md:132-136`, `core/skills/sw-sync/SKILL.md:101-104`, `core/skills/sw-audit/SKILL.md:41-43`, `core/skills/sw-learn/SKILL.md:50-54`, and `evals/tests/test_workflow_policy_docs.py:73-86` prove sidecars no longer claim core-stage ownership.
- `AC-4`: `PASS`
  Evidence: `core/skills/sw-plan/SKILL.md:75-77,85-116`, `core/skills/sw-build/SKILL.md:84-87`, and `evals/tests/test_workflow_policy_docs.py:88-100` prove mutable concurrency is redirected into separate works with integration criteria.
- `AC-5`: `PASS`
  Evidence: `core/protocols/parallel-build.md:48-50`, `core/skills/sw-verify/SKILL.md:117-122`, and `evals/tests/test_workflow_policy_docs.py:110-122` prove helper writes and soft-success regressions fail closed.

## Spec Conformance

- `gate-spec` recorded `PASS` for every unit acceptance criterion `AC-1` through `AC-5`.
- Final-unit behavioral integration criteria `IC-B1` through `IC-B6` also recorded `PASS` through the existing runtime-mode, ownership, operator-surface, and workflow-policy suites.
- No criterion is missing implementation evidence or test evidence.

## Gate Summary

| Gate | Verdict | Notes |
|---|---|---|
| `build` | `PASS` | `bash build/build.sh` succeeded for `claude-code`, `opencode`, and `codex`. |
| `tests` | `PASS` | Configured test command completed with `1111 passed, 1 skipped, 3 deselected` plus `278 passed, 0 failed`. |
| `security` | `PASS` | No secrets, credential handling, or executable mutation paths were introduced. |
| `wiring` | `PASS` | No runtime wiring drift was introduced; final structural integration criteria remain satisfied. |
| `semantic` | `PASS` | The changed executable surface is deterministic test code only. |
| `spec` | `PASS` | Every `AC-*` and `IC-B*` row recorded `PASS`. |

## Remaining Attention

- `WARN`: `design` approval lineage is stale (`artifact-set-changed`).
- `WARN`: `unit-spec` approval lineage is stale (`artifact-set-changed`).
- `WARN`: `commands.test:integration` is unconfigured, so deliverable verification could not run a dedicated integration command.
- `WARN`: `commands.test:e2e` is unconfigured, so deliverable verification could not run a dedicated end-to-end command.

## Evidence Links

Clone-local audit artifacts used for this PR body:

- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/review-packet.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/build-report.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/test-quality.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/security-report.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/wiring-report.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/semantic-report.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/spec-compliance.md`
- `quality-first-devex-redesign/units/05-verify-scheduling-and-workflow-policy-cutover/evidence/aggregate-report.md`
