### PR TITLE
Revive shared operator surface cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,16 @@ Constitution and Charter are created during init. TESTING.md is created during i
 - `core/agents/` -- Agent prompt definitions
 - `adapters/` -- Platform-specific packaging (Claude Code, Opencode, Codex CLI, etc.)
 - `.specwright/` -- tracked project artifacts (`projectArtifactsRoot`): `config.json`, anchor docs, research, learnings
-- Git admin roots (`repoStateRoot` / `worktreeStateRoot`, usually under `.git/specwright/`) -- clone-local runtime workflow/session state, continuation, runtime `stage-report.md`
+- runtime roots (`repoStateRoot` / `worktreeStateRoot`) -- clone-local runtime workflow/session state, continuation, and runtime `stage-report.md`; new interactive installs should prefer `project-visible` roots under `.specwright-local/`, while `git-admin` under `.git/specwright/` remains compatibility-only
 - `workArtifactsRoot/` -- auditable work artifacts; clone-local under `repoStateRoot/work/` by default, optionally published to a tracked root via `config.git.workArtifacts`
 
 See `DESIGN.md` for the full architecture document.
+
+## Operator Notes
+
+- Run `/sw-status` to see the active runtime roots, live owner, branch posture, and next action.
+- Same-work moves between top-level worktrees require explicit `/sw-adopt`; status surfaces must not imply takeover.
+- `project-visible` runtime under `.specwright-local/` is the preferred interactive default. `git-admin` under `.git/specwright/` is compatibility mode for existing installs and CI-style constraints.
 
 ## Protocols
 

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -52,11 +52,16 @@ Constitution and Charter are created during init. TESTING.md is created during i
 - `protocols/` -- Shared protocols for fragile operations (loaded on demand)
 - `agents/` -- Agent prompt definitions (7 agents: architect, tester, integration-tester, executor, reviewer, build-fixer, researcher)
 - `projectArtifactsRoot` (`{projectRoot}/.specwright`) -- tracked project artifacts: config, anchor docs, research, learnings
-- `repoStateRoot` (`git rev-parse --git-common-dir` + `/specwright`) -- shared clone-local runtime state: workflow records and runtime `stage-report.md`
-- `worktreeStateRoot` (`git rev-parse --git-dir` + `/specwright`) -- current worktree session and continuation state
+- runtime roots (`repoStateRoot` / `worktreeStateRoot`) -- resolved from `config.git.runtime.mode`; prefer `project-visible` `.specwright-local/` roots for interactive use, while `git-admin` `.git/specwright/` stays compatibility-only
 - `workArtifactsRoot` -- auditable work artifacts; defaults to `{repoStateRoot}/work`, or a tracked root when `config.git.workArtifacts` enables publication
 
 See `DESIGN.md` for the full architecture document.
+
+## Operator Notes
+
+- Run `/sw-status` to inspect the active runtime roots, live owner, branch posture, and next command.
+- Same-work moves between top-level worktrees require explicit `/sw-adopt`; never infer takeover from branch state alone.
+- `project-visible` runtime under `.specwright-local/` is the recommended interactive default. `git-admin` under `.git/specwright/` remains compatibility mode for older installs and constrained environments.
 
 ## Protocols
 

--- a/adapters/claude-code/hooks/session-start.mjs
+++ b/adapters/claude-code/hooks/session-start.mjs
@@ -13,7 +13,7 @@ import {
 } from '../../shared/specwright-state-paths.mjs';
 import {
   loadOperatorSurfaceSummary,
-  renderOperatorSurfaceLines
+  renderWorkInProgressSummary
 } from '../../shared/specwright-operator-surface.mjs';
 
 try {
@@ -21,20 +21,10 @@ try {
   const continuationPath = stateInfo.continuationPath;
   const work = normalizeActiveWork(stateInfo);
   const ownerConflict = findSelectedWorkOwnerConflict(stateInfo);
-  const operatorSurfaceLines = renderOperatorSurfaceLines(
-    loadOperatorSurfaceSummary(stateInfo, work)
-  );
 
   if (!work || ['shipped', 'abandoned'].includes(work.status)) {
     process.exit(0);
   }
-
-  const lockWarning = work.lock
-    ? `\n⚠ Lock held by "${work.lock.skill}" since ${work.lock.since}`
-    : '';
-  const ownershipWarning = ownerConflict
-    ? `\n  WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
-    : '';
 
   let continuationContent = '';
   if (existsSync(continuationPath)) {
@@ -64,25 +54,13 @@ try {
     }
   }
 
-  const unitLine = work.unitId ? `  Active Unit: ${work.unitId}\n` : '';
-  const shippingWarning = work.status === 'shipping'
-    ? '\n  ⚠ Status is "shipping" — PR creation was in progress. Run /sw-ship to check if the PR was created or to retry.'
-    : '';
-
-  const summary = [
-    'Specwright: Work in progress',
-    `  Unit: ${work.workId} (${work.status})`,
-    unitLine ? unitLine.trimEnd() : null,
-    `  Progress: ${work.completedCount}/${work.totalCount} tasks`,
-    `  Gates: ${work.gatesSummary}`,
-    `  Spec: ${work.specPath}`,
-    `  Plan: ${work.planPath}`,
-    ...operatorSurfaceLines,
-    lockWarning,
-    ownershipWarning,
-    shippingWarning,
+  const operatorSummary = loadOperatorSurfaceSummary(stateInfo, work);
+  const summary = renderWorkInProgressSummary({
+    work,
+    summary: operatorSummary,
+    ownerConflict,
     continuationContent
-  ].filter(Boolean).join('\n');
+  });
 
   process.stdout.write(summary + '\n');
 } catch (err) {

--- a/adapters/codex/commands/sw-doctor.md
+++ b/adapters/codex/commands/sw-doctor.md
@@ -3,5 +3,9 @@ description: Read-only installation health check with repair hints.
 ---
 
 Use the installed `specwright:sw-doctor` skill for this request.
+Doctor should report whether runtime roots are `project-visible` under
+`.specwright-local/` or `git-admin` under `.git/specwright/`, and it should
+route shipped-state repairs through `/sw-status --repair {unitId}` instead of
+inventing a separate repair surface.
 
 $ARGUMENTS

--- a/adapters/codex/commands/sw-guard.md
+++ b/adapters/codex/commands/sw-guard.md
@@ -3,5 +3,9 @@ description: Detect stack and configure deterministic guardrails.
 ---
 
 Use the installed `specwright:sw-guard` skill for this request.
+Guard should keep runtime policy explicit: prefer `project-visible`
+`.specwright-local/` for interactive installs, reserve `git-admin` under
+`.git/specwright/` for compatibility, and never imply same-work takeover
+outside `/sw-adopt`.
 
 $ARGUMENTS

--- a/adapters/codex/commands/sw-init.md
+++ b/adapters/codex/commands/sw-init.md
@@ -3,5 +3,9 @@ description: Project setup. Creates constitution and charter. Configures gates.
 ---
 
 Use the installed `specwright:sw-init` skill for this request.
+Init should create tracked `.specwright/` docs plus clone-local runtime roots,
+recommend `project-visible` `.specwright-local/` for interactive installs, keep
+`git-admin` under `.git/specwright/` as compatibility-only, and finish by
+pointing the operator to `/sw-status`.
 
 $ARGUMENTS

--- a/adapters/codex/commands/sw-status.md
+++ b/adapters/codex/commands/sw-status.md
@@ -3,5 +3,9 @@ description: Show current Specwright state and progress.
 ---
 
 Use the installed `specwright:sw-status` skill for this request.
+Keep the operator story aligned with the shared status-card surface:
+`project-visible` runtime roots under `.specwright-local/` are the interactive
+default, `git-admin` roots under `.git/specwright/` are compatibility-only,
+and same-work takeover goes through `/sw-adopt`.
 
 $ARGUMENTS

--- a/adapters/codex/hooks/session-start.mjs
+++ b/adapters/codex/hooks/session-start.mjs
@@ -11,6 +11,10 @@ import {
   loadSpecwrightState,
   normalizeActiveWork
 } from '../../shared/specwright-state-paths.mjs';
+import {
+  loadOperatorSurfaceSummary,
+  renderWorkInProgressSummary
+} from '../../shared/specwright-operator-surface.mjs';
 
 try {
   const stateInfo = loadSpecwrightState();
@@ -21,14 +25,6 @@ try {
   if (!work || ['shipped', 'abandoned'].includes(work.status)) {
     process.exit(0);
   }
-
-  const unitLine = work.unitId ? `  Active Unit: ${work.unitId}\n` : '';
-  const lockWarning = work.lock
-    ? `\n  WARNING: Lock held by "${work.lock.skill}" since ${work.lock.since}`
-    : '';
-  const ownershipWarning = ownerConflict
-    ? `\n  WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
-    : '';
 
   let continuationContent = '';
   if (existsSync(continuationPath)) {
@@ -42,6 +38,11 @@ try {
         const twoHoursMs = 2 * 60 * 60 * 1000;
         if (!isNaN(snapshotTime.getTime()) && ageMs < twoHoursMs) {
           continuationContent = `\n--- Continuation Snapshot ---\n${raw}`;
+
+          const correctionMatch = raw.match(/## Correction Summary\n([\s\S]*?)(?=\n## |\n---|$)/);
+          if (correctionMatch && correctionMatch[1].trim()) {
+            continuationContent += `\n--- Quality Corrections ---\nIn this build session, the following quality issues were found and should be avoided:\n${correctionMatch[1].trim()}`;
+          }
         }
       }
       unlinkSync(continuationPath);
@@ -50,23 +51,13 @@ try {
     }
   }
 
-  const shippingWarning = work.status === 'shipping'
-    ? '\n  WARNING: Status is "shipping". Run /sw-ship to check PR state.'
-    : '';
-
-  const summary = [
-    'Specwright: Work in progress',
-    `  Unit: ${work.workId} (${work.status})`,
-    unitLine ? unitLine.trimEnd() : null,
-    `  Progress: ${work.completedCount}/${work.totalCount} tasks`,
-    `  Gates: ${work.gatesSummary}`,
-    `  Spec: ${work.specPath}`,
-    `  Plan: ${work.planPath}`,
-    lockWarning,
-    ownershipWarning,
-    shippingWarning,
+  const operatorSummary = loadOperatorSurfaceSummary(stateInfo, work);
+  const summary = renderWorkInProgressSummary({
+    work,
+    summary: operatorSummary,
+    ownerConflict,
     continuationContent
-  ].filter(Boolean).join('\n');
+  });
 
   process.stdout.write(summary + '\n');
 } catch {

--- a/adapters/opencode/commands/sw-doctor.md
+++ b/adapters/opencode/commands/sw-doctor.md
@@ -3,5 +3,9 @@ description: Read-only installation health check with repair hints
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-doctor/SKILL.md`.
+Doctor should report whether runtime roots are `project-visible` under
+`.specwright-local/` or `git-admin` under `.git/specwright/`, and it should
+route shipped-state repairs through `/sw-status --repair {unitId}` instead of
+inventing a separate repair surface.
 
 $ARGUMENTS

--- a/adapters/opencode/commands/sw-guard.md
+++ b/adapters/opencode/commands/sw-guard.md
@@ -3,5 +3,9 @@ description: Detect stack and configure guardrails interactively
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-guard/SKILL.md`.
+Guard should keep runtime policy explicit: prefer `project-visible`
+`.specwright-local/` for interactive installs, reserve `git-admin` under
+`.git/specwright/` for compatibility, and never imply same-work takeover
+outside `/sw-adopt`.
 
 $ARGUMENTS

--- a/adapters/opencode/commands/sw-init.md
+++ b/adapters/opencode/commands/sw-init.md
@@ -3,5 +3,9 @@ description: Initialize Specwright in a project with constitution and charter
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-init/SKILL.md`.
+Init should create tracked `.specwright/` docs plus clone-local runtime roots,
+recommend `project-visible` `.specwright-local/` for interactive installs, keep
+`git-admin` under `.git/specwright/` as compatibility-only, and finish by
+pointing the operator to `/sw-status`.
 
 $ARGUMENTS

--- a/adapters/opencode/commands/sw-status.md
+++ b/adapters/opencode/commands/sw-status.md
@@ -3,5 +3,9 @@ description: Show current Specwright state and progress
 ---
 
 Read and follow the skill file at `.specwright/skills/sw-status/SKILL.md`.
+Keep the operator story aligned with the shared status-card surface:
+`project-visible` runtime roots under `.specwright-local/` are the interactive
+default, `git-admin` roots under `.git/specwright/` are compatibility-only,
+and same-work takeover goes through `/sw-adopt`.
 
 $ARGUMENTS

--- a/adapters/opencode/plugin.ts
+++ b/adapters/opencode/plugin.ts
@@ -25,7 +25,7 @@ import {
 } from './shared/specwright-state-paths.mjs';
 import {
   loadOperatorSurfaceSummary,
-  renderOperatorSurfaceLines
+  renderWorkInProgressSummary
 } from './shared/specwright-operator-surface.mjs';
 
 // ── Auto-deploy ─────────────────────────────────────────────────────────────
@@ -194,16 +194,7 @@ export default async function (ctx: { directory: string; on: (event: string, han
       if (!active) return;
 
       const { stateInfo, work, ownerConflict } = active;
-      const unitLine = work.unitId ? `  Active Unit: ${work.unitId}` : '';
-      const lockWarning = work.lock
-        ? `\n⚠ Lock held by "${work.lock.skill}" since ${work.lock.since}`
-        : '';
-      const ownershipWarning = ownerConflict
-        ? `\n  WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
-        : '';
-      const operatorSurfaceLines = renderOperatorSurfaceLines(
-        loadOperatorSurfaceSummary(stateInfo, work)
-      );
+      const operatorSummary = loadOperatorSurfaceSummary(stateInfo, work);
 
       // Check for a fresh continuation snapshot written by the compacted handler
       let continuationContent = '';
@@ -233,24 +224,12 @@ export default async function (ctx: { directory: string; on: (event: string, han
         }
       }
 
-      const shippingWarning = work.status === 'shipping'
-        ? '\n  ⚠ Status is "shipping" — PR creation was in progress. Run /sw-ship to check if the PR was created or to retry.'
-        : '';
-
-      const summary = [
-        'Specwright: Work in progress',
-        `  Unit: ${work.workId} (${work.status})`,
-        unitLine || null,
-        `  Progress: ${work.completedCount}/${work.totalCount} tasks`,
-        `  Gates: ${work.gatesSummary}`,
-        `  Spec: ${work.specPath}`,
-        `  Plan: ${work.planPath}`,
-        ...operatorSurfaceLines,
-        lockWarning,
-        ownershipWarning,
-        shippingWarning || null,
-        continuationContent || null,
-      ].filter(Boolean).join('\n');
+      const summary = renderWorkInProgressSummary({
+        work,
+        summary: operatorSummary,
+        ownerConflict,
+        continuationContent
+      });
 
       return summary;
     } catch (err) {

--- a/adapters/shared/specwright-operator-surface.mjs
+++ b/adapters/shared/specwright-operator-surface.mjs
@@ -3,6 +3,10 @@ import { buildStatusCard } from './specwright-status-card.mjs';
 import { formatCloseoutLines } from './specwright-closeout.mjs';
 
 const MAX_RENDERED_WARNING_LINES = 2;
+const APPROVAL_WARNING_PREFIX = 'approval-';
+// Warning codes emitted by buildStatusCard that already have dedicated surface
+// rendering in this module. Keep in sync with specwright-status-card.mjs.
+const SUPPRESSED_WARNING_CODES = new Set(['missing-closeout', 'branch-mismatch']);
 
 function normalizeString(value) {
   if (typeof value !== 'string') {
@@ -63,21 +67,26 @@ function formatWarningLines(warnings, options = {}) {
     return [];
   }
 
-  return warnings
+  const significantWarnings = warnings
     .filter((warning) => {
-      // Approval, closeout, and branch warnings already have dedicated sections
-      // above; suppress them here so the compact summary does not duplicate them.
       const code = normalizeString(warning?.code) ?? '';
-      if (code.startsWith('approval-')) {
+      if (code.startsWith(APPROVAL_WARNING_PREFIX)) {
         return false;
       }
 
-      return !['missing-closeout', 'branch-mismatch'].includes(code);
+      return !SUPPRESSED_WARNING_CODES.has(code);
     })
     .map((warning) => normalizeString(warning?.summary))
-    .filter(Boolean)
-    .slice(0, MAX_RENDERED_WARNING_LINES)
-    .map((summary) => `${indent}WARNING: ${summary}`);
+    .filter(Boolean);
+  const visibleWarnings = significantWarnings.slice(0, MAX_RENDERED_WARNING_LINES);
+  const lines = visibleWarnings.map((summary) => `${indent}WARNING: ${summary}`);
+  const hiddenWarningCount = significantWarnings.length - visibleWarnings.length;
+  if (hiddenWarningCount > 0) {
+    const noun = hiddenWarningCount === 1 ? 'warning' : 'warnings';
+    lines.push(`${indent}... and ${hiddenWarningCount} more ${noun} - run /sw-status for full detail`);
+  }
+
+  return lines;
 }
 
 function formatNextCommandLine(nextCommand, options = {}) {
@@ -158,12 +167,15 @@ export function renderWorkInProgressSummary(options = {}) {
 
   const indent = options.indent ?? '  ';
   const summary = options.summary ?? null;
+  const gatesSummary = normalizeString(work.gatesSummary)
+    ?? normalizeString(summary?.card?.gates?.summary)
+    ?? 'No gates recorded yet.';
   const lines = [
     'Specwright: Work in progress',
     `${indent}Unit: ${work.workId} (${work.status})`,
     work.unitId ? `${indent}Active Unit: ${work.unitId}` : null,
     `${indent}Progress: ${work.completedCount}/${work.totalCount} tasks`,
-    `${indent}Gates: ${work.gatesSummary ?? summary?.card?.gates?.summary ?? 'No gates recorded yet.'}`,
+    `${indent}Gates: ${gatesSummary}`,
     `${indent}Spec: ${work.specPath}`,
     `${indent}Plan: ${work.planPath}`,
     ...renderOperatorSurfaceLines(summary, { indent }),

--- a/adapters/shared/specwright-operator-surface.mjs
+++ b/adapters/shared/specwright-operator-surface.mjs
@@ -2,6 +2,17 @@ import { formatApprovalStatusLine } from './specwright-approvals.mjs';
 import { buildStatusCard } from './specwright-status-card.mjs';
 import { formatCloseoutLines } from './specwright-closeout.mjs';
 
+const MAX_RENDERED_WARNING_LINES = 2;
+
+function normalizeString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function loadOperatorSurfaceSummary(stateInfo, work) {
   if (!stateInfo || !work) {
     return null;
@@ -17,6 +28,68 @@ export function loadOperatorSurfaceSummary(stateInfo, work) {
   };
 }
 
+function formatBranchStatusLine(branch, options = {}) {
+  if (!branch) {
+    return null;
+  }
+
+  const indent = options.indent ?? '  ';
+  const expected = normalizeString(branch.expected);
+  const observed = normalizeString(branch.observed);
+  const status = normalizeString(branch.status) ?? 'unknown';
+
+  if (expected && observed) {
+    if (expected === observed) {
+      return `${indent}Branch: ${observed} (${status})`;
+    }
+
+    return `${indent}Branch: expected ${expected}, observed ${observed} (${status})`;
+  }
+
+  if (observed) {
+    return `${indent}Branch: observed ${observed} (${status})`;
+  }
+
+  if (expected) {
+    return `${indent}Branch: expected ${expected} (${status})`;
+  }
+
+  return `${indent}Branch: unavailable (${status})`;
+}
+
+function formatWarningLines(warnings, options = {}) {
+  const indent = options.indent ?? '  ';
+  if (!Array.isArray(warnings) || warnings.length === 0) {
+    return [];
+  }
+
+  return warnings
+    .filter((warning) => {
+      // Approval, closeout, and branch warnings already have dedicated sections
+      // above; suppress them here so the compact summary does not duplicate them.
+      const code = normalizeString(warning?.code) ?? '';
+      if (code.startsWith('approval-')) {
+        return false;
+      }
+
+      return !['missing-closeout', 'branch-mismatch'].includes(code);
+    })
+    .map((warning) => normalizeString(warning?.summary))
+    .filter(Boolean)
+    .slice(0, MAX_RENDERED_WARNING_LINES)
+    .map((summary) => `${indent}WARNING: ${summary}`);
+}
+
+function formatNextCommandLine(nextCommand, options = {}) {
+  const normalizedNextCommand = normalizeString(nextCommand);
+  if (!normalizedNextCommand) {
+    return null;
+  }
+
+  const indent = options.indent ?? '  ';
+  return `${indent}Next: ${normalizedNextCommand}`;
+}
+
 export function renderOperatorSurfaceLines(summary, options = {}) {
   if (!summary) {
     return [];
@@ -25,16 +98,82 @@ export function renderOperatorSurfaceLines(summary, options = {}) {
   const indent = options.indent ?? '  ';
   const detailIndent = options.detailIndent ?? `${indent}  `;
   const bulletIndent = options.bulletIndent ?? `${detailIndent}- `;
-  const lines = formatCloseoutLines(summary.closeout, {
+  const lines = [];
+  const branchLine = formatBranchStatusLine(summary.card?.branch, { indent });
+  if (branchLine) {
+    lines.push(branchLine);
+  }
+
+  lines.push(...formatCloseoutLines(summary.closeout, {
     indent,
     detailIndent,
     bulletIndent
-  });
-  const approvalLine = formatApprovalStatusLine(summary.approval, { indent });
+  }));
 
+  const approvalLine = formatApprovalStatusLine(summary.approval, { indent });
   if (approvalLine) {
     lines.push(approvalLine);
   }
 
+  lines.push(...formatWarningLines(summary.warnings, { indent }));
+
+  const nextCommandLine = formatNextCommandLine(summary.nextCommand, { indent });
+  if (nextCommandLine) {
+    lines.push(nextCommandLine);
+  }
+
   return lines;
+}
+
+function renderOperationalWarningLines(options = {}) {
+  const indent = options.indent ?? '  ';
+  const lines = [];
+  const work = options.work;
+  const ownerConflict = options.ownerConflict;
+
+  if (work?.lock?.skill && work?.lock?.since) {
+    lines.push(`${indent}WARNING: Lock held by "${work.lock.skill}" since ${work.lock.since}`);
+  }
+
+  if (ownerConflict) {
+    lines.push(
+      `${indent}WARNING: This work is already active in another top-level worktree (${ownerConflict.ownerWorktreeId}${ownerConflict.ownerBranch ? ` on ${ownerConflict.ownerBranch}` : ''}: ${ownerConflict.ownerWorktreePath}). Adopt/takeover required before mutating or shipping it here.`
+    );
+  }
+
+  if (work?.status === 'shipping') {
+    lines.push(
+      `${indent}WARNING: Status is "shipping" — PR creation was in progress. Run /sw-ship to check if the PR was created or to retry.`
+    );
+  }
+
+  return lines;
+}
+
+export function renderWorkInProgressSummary(options = {}) {
+  const work = options.work;
+  if (!work) {
+    return '';
+  }
+
+  const indent = options.indent ?? '  ';
+  const summary = options.summary ?? null;
+  const lines = [
+    'Specwright: Work in progress',
+    `${indent}Unit: ${work.workId} (${work.status})`,
+    work.unitId ? `${indent}Active Unit: ${work.unitId}` : null,
+    `${indent}Progress: ${work.completedCount}/${work.totalCount} tasks`,
+    `${indent}Gates: ${work.gatesSummary ?? summary?.card?.gates?.summary ?? 'No gates recorded yet.'}`,
+    `${indent}Spec: ${work.specPath}`,
+    `${indent}Plan: ${work.planPath}`,
+    ...renderOperatorSurfaceLines(summary, { indent }),
+    ...renderOperationalWarningLines({
+      indent,
+      work,
+      ownerConflict: options.ownerConflict
+    }),
+    options.continuationContent || null
+  ].filter(Boolean);
+
+  return lines.join('\n');
 }

--- a/adapters/shared/specwright-operator-surface.mjs
+++ b/adapters/shared/specwright-operator-surface.mjs
@@ -21,7 +21,13 @@ export function loadOperatorSurfaceSummary(stateInfo, work) {
   if (!stateInfo || !work) {
     return null;
   }
-  const card = buildStatusCard(stateInfo, work);
+
+  let card = null;
+  try {
+    card = buildStatusCard(stateInfo, work);
+  } catch {
+    return null;
+  }
 
   return {
     card,

--- a/core/skills/sw-doctor/SKILL.md
+++ b/core/skills/sw-doctor/SKILL.md
@@ -19,7 +19,8 @@ allowed-tools:
 
 Validate that a Specwright installation is coherent across the tracked
 project-artifact root, shared repo-state root, and per-worktree session model,
-then print actionable repair hints.
+then print actionable repair hints using the same runtime-root and ownership
+vocabulary the adapters expose.
 
 ## Inputs
 
@@ -44,6 +45,10 @@ then print actionable repair hints.
   immediately and tell the user to run `/sw-init`.
 - Always report layout status first: `shared/session`, `legacy fallback`, or
   `missing`.
+- When layout resolves, describe the active runtime mode explicitly:
+  `project-visible` runtime roots under `.specwright-local/` are the preferred
+  interactive default; `git-admin` roots under `.git/specwright/` are
+  compatibility mode.
 
 **Checks (LOW freedom — run all 13 in order):**
 1. **Anchor docs** — tracked Constitution and Charter exist and are non-empty
@@ -76,6 +81,8 @@ Within the State pass, check all of the following and report them by name:
 - approval freshness for the selected unit when approvals exist
 - review-packet presence for the selected unit when verify or ship artifacts
   should exist
+- live ownership conflicts that should route the operator to `/sw-adopt`
+  instead of implying generic takeover
 
 State-pass output must report the authoritative runtime roots clearly so the
 user can see which `repoStateRoot` and `worktreeStateRoot` are in force.

--- a/core/skills/sw-guard/SKILL.md
+++ b/core/skills/sw-guard/SKILL.md
@@ -68,6 +68,11 @@ Note: CONSTITUTION.md is NOT modified. Constitutional updates are the responsibi
 - Detect or confirm target-role defaults, freshness checkpoints, runtime mode as an explicit Git policy choice, and any optional work-artifact publication mode as one explicit Git policy surface.
 - Recommend `project-visible` for Claude-oriented installs unless the user explicitly wants `git-admin` runtime roots.
 - Recommend a tracked work-artifact root under `.specwright/works` for new interactive installs unless the user explicitly prefers clone-local-only auditable work artifacts.
+- When describing runtime policy, use the same operator vocabulary as the
+  adapters and status surfaces: `project-visible` roots under `.specwright-local/`
+  for interactive installs, `git-admin` roots under `.git/specwright/` for
+  compatibility, `/sw-status` for the current runtime view, and `/sw-adopt` for
+  explicit same-work adoption.
 - Keep runtime mode separately from tracked work-artifact publication and separately from clone-local runtime state.
 - Treat `.specwright/config.json` and the anchor docs as a shared project-level
   policy surface across developers and agent sessions, not as clone-local

--- a/core/skills/sw-init/SKILL.md
+++ b/core/skills/sw-init/SKILL.md
@@ -21,7 +21,10 @@ Set up Specwright in this project by understanding how the user works,
 what they're building, and what quality standards they expect. Produce
 configuration and anchor documents that will guide all future work. Tracked
 project artifacts should be shared across developers and agent sessions via
-Git; runtime session state stays local to each clone or worktree.
+Git; runtime session state stays local to each clone or worktree. New
+interactive installs should prefer `project-visible` runtime roots under
+`.specwright-local/`, while `git-admin` roots under `.git/specwright/` remain
+compatibility-only.
 
 ## Inputs
 
@@ -43,6 +46,8 @@ Optional (created if the user opts in):
 - `{projectArtifactsRoot}/TESTING.md` -- testing strategy: boundaries,
   infrastructure, mock allowances
 - Hooks set up if the user wants them
+- Operator follow-up: tell the user to run `/sw-status` to confirm the active
+  runtime roots and detached session state.
 
 Quality gates are configured in config (all six default to enabled; user may disable).
 

--- a/core/skills/sw-status/SKILL.md
+++ b/core/skills/sw-status/SKILL.md
@@ -18,7 +18,8 @@ allowed-tools:
 ## Goal
 
 Tell the user what this worktree is attached to, what that work is doing, what
-other works are active in the repository, and what the next action should be.
+other works are active in the repository, which runtime layout is active, and
+what the next action should be.
 
 ## Inputs
 
@@ -39,8 +40,10 @@ other works are active in the repository, and what the next action should be.
 **Display (HIGH freedom):**
 - Print the resolved `projectArtifactsRoot`, `repoStateRoot`,
   `worktreeStateRoot`, and `workArtifactsRoot` before the session summary so
-  tracked project artifacts and hidden `.git` runtime state are both
-  inspectable.
+  tracked project artifacts and the active runtime layout are inspectable.
+- Name the runtime layout explicitly: `project-visible` runtime roots under
+  `.specwright-local/` are the recommended interactive default, while
+  `git-admin` roots under `.git/specwright/` are compatibility mode.
 - Show the current session first: `worktreeId`, mode, branch, and
   `attachedWorkId`.
 - If the session is attached, show that work's status, unit/task progress, the
@@ -48,6 +51,9 @@ other works are active in the repository, and what the next action should be.
   work-artifact publication mode when present, approval freshness reason,
   latest closeout or review-packet availability, review-packet presence, gates,
   and per-work lock freshness.
+- Keep the operator vocabulary aligned with the primary adapter surfaces:
+  attached work, branch validity, approval or closeout posture, live ownership,
+  and next action.
 - If the attached work is already owned by another live top-level worktree,
   surface that conflict explicitly and point the operator to `/sw-adopt`
   instead of implying that status can mutate ownership.

--- a/evals/baselines/skill.json
+++ b/evals/baselines/skill.json
@@ -1,8 +1,8 @@
 {
   "suite": "skill",
-  "generated_at": "2026-04-14T20:03:09Z",
-  "generated_from_commit": "5b05028",
-  "__comment": "Skill smoke is structural-only. Duration is a coarse CI health signal here, so the multiplier is intentionally looser to absorb GitHub runner variance while keeping pass-rate regressions strict.",
+  "generated_at": "2026-04-22T08:43:02Z",
+  "generated_from_commit": "00cc603",
+  "__comment": "Skill smoke is structural-only. Duration is a coarse CI health signal here, so the multiplier is intentionally looser to absorb GitHub runner variance while keeping pass-rate regressions strict. The structural-skill-validation duration baseline was refreshed from the CI-observed run after the operator-surface cutover increased the smoke validation surface while keeping pass rate stable.",
   "tolerances": {
     "pass_rate_delta": 0.0,
     "duration_multiplier": 1.5,
@@ -23,7 +23,7 @@
     },
     "structural-skill-validation": {
       "pass_rate": 1.0,
-      "duration_ms": 2558,
+      "duration_ms": 4461,
       "tokens": {},
       "runs": 1
     },

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -345,6 +345,33 @@ process.stdout.write(JSON.stringify({ summary, lines }, null, 2));
     return json.loads(result.stdout)
 
 
+def _render_operator_surface_lines(summary: dict) -> list[str]:
+    script = """
+const { renderOperatorSurfaceLines } = await import(process.env.OPERATOR_SURFACE_MODULE);
+const summary = JSON.parse(process.env.OPERATOR_SURFACE_SUMMARY_JSON);
+const lines = renderOperatorSurfaceLines(summary);
+
+process.stdout.write(JSON.stringify({ lines }, null, 2));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=ROOT_DIR,
+        check=False,
+        env=sanitized_git_env(
+            {
+                "OPERATOR_SURFACE_MODULE": str(OPERATOR_SURFACE_MODULE),
+                "OPERATOR_SURFACE_SUMMARY_JSON": json.dumps(summary),
+            }
+        ),
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "operator-surface render execution failed")
+    return json.loads(result.stdout)["lines"]
+
+
 class TestStatusCardContract(unittest.TestCase):
     def test_build_status_card_returns_minimum_contract_and_writes_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -558,6 +585,29 @@ class TestStatusCardContract(unittest.TestCase):
             self.assertEqual(summary["nextCommand"], card["nextCommand"])
             self.assertTrue(any("Closeout: stage-report" in line for line in lines))
             self.assertTrue(any("Approval: unit-spec APPROVED (approved)" in line for line in lines))
+
+    def test_operator_surface_warning_lines_use_named_two_warning_cap(self) -> None:
+        lines = _render_operator_surface_lines(
+            {
+                "card": {"branch": None},
+                "closeout": None,
+                "approval": None,
+                "warnings": [
+                    {"code": "degraded-root-resolution", "summary": "First warning"},
+                    {"code": "runtime-fallback", "summary": "Second warning"},
+                    {"code": "advisory-overflow", "summary": "Third warning"},
+                ],
+                "nextCommand": None,
+            }
+        )
+
+        self.assertEqual(
+            [line for line in lines if line.startswith("  WARNING:")],
+            [
+                "  WARNING: First warning",
+                "  WARNING: Second warning",
+            ],
+        )
 
 
 class TestApprovalsProtocolStatusCardContract(unittest.TestCase):

--- a/evals/tests/test_operator_surface_status_card.py
+++ b/evals/tests/test_operator_surface_status_card.py
@@ -609,6 +609,82 @@ class TestStatusCardContract(unittest.TestCase):
             ],
         )
 
+    def test_operator_surface_warning_lines_report_overflow_after_cap(self) -> None:
+        lines = _render_operator_surface_lines(
+            {
+                "card": {"branch": None},
+                "closeout": None,
+                "approval": None,
+                "warnings": [
+                    {"code": "degraded-root-resolution", "summary": "First warning"},
+                    {"code": "runtime-fallback", "summary": "Second warning"},
+                    {"code": "third-signal", "summary": "Third warning"},
+                ],
+                "nextCommand": None,
+            }
+        )
+
+        self.assertEqual(
+            [line for line in lines if line.startswith("  WARNING:")],
+            [
+                "  WARNING: First warning",
+                "  WARNING: Second warning",
+            ],
+        )
+        self.assertIn(
+            "  ... and 1 more warning - run /sw-status for full detail",
+            lines,
+        )
+
+    def test_work_in_progress_summary_falls_back_when_work_gates_summary_is_blank(self) -> None:
+        script = """
+const { renderWorkInProgressSummary } = await import(process.env.OPERATOR_SURFACE_MODULE);
+const work = JSON.parse(process.env.OPERATOR_SURFACE_WORK_JSON);
+const summary = JSON.parse(process.env.OPERATOR_SURFACE_SUMMARY_JSON);
+
+process.stdout.write(renderWorkInProgressSummary({ work, summary }));
+"""
+        work = {
+            "workId": "quality-first-devex-redesign",
+            "status": "building",
+            "unitId": "04-adapter-and-support-surface-cutover",
+            "completedCount": 3,
+            "totalCount": 5,
+            "gatesSummary": "   ",
+            "specPath": ".specwright/specs/example.md",
+            "planPath": ".specwright/plans/example.md",
+        }
+        summary = {
+            "card": {
+                "gates": {
+                    "summary": "2 PASS, 1 WARN"
+                }
+            },
+            "closeout": None,
+            "approval": None,
+            "warnings": [],
+            "nextCommand": None,
+        }
+        result = subprocess.run(
+            ["node", "--input-type=module", "-"],
+            input=script,
+            text=True,
+            capture_output=True,
+            cwd=ROOT_DIR,
+            check=False,
+            env=sanitized_git_env(
+                {
+                    "OPERATOR_SURFACE_MODULE": str(OPERATOR_SURFACE_MODULE),
+                    "OPERATOR_SURFACE_WORK_JSON": json.dumps(work),
+                    "OPERATOR_SURFACE_SUMMARY_JSON": json.dumps(summary),
+                }
+            ),
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stderr or result.stdout or "work-in-progress render execution failed")
+
+        self.assertIn("  Gates: 2 PASS, 1 WARN", result.stdout)
+
 
 class TestApprovalsProtocolStatusCardContract(unittest.TestCase):
     def test_find_latest_approval_entry_requires_scope(self) -> None:

--- a/evals/tests/test_operator_surface_visibility.py
+++ b/evals/tests/test_operator_surface_visibility.py
@@ -446,6 +446,32 @@ class TestSessionStartSurface(unittest.TestCase):
             self.assertEqual(result.stdout, "")
             self.assertEqual(result.stderr, "")
 
+    def test_codex_session_start_falls_back_to_core_summary_when_operator_surface_load_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            broken_stage_report = (
+                Path(state["repoStateRoot"])
+                / "work"
+                / state["workId"]
+                / "units"
+                / state["unitId"]
+                / "stage-report.md"
+            )
+            broken_stage_report.mkdir(parents=True, exist_ok=True)
+
+            result = _run_codex_session_start_raw(repo_path)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+            self.assertIn("Specwright: Work in progress", result.stdout)
+            self.assertIn("  Unit: operator-surface-proof (building)", result.stdout)
+            self.assertIn("  Gates: build: PASS, tests: PASS", result.stdout)
+            self.assertIn("  Spec: ", result.stdout)
+            self.assertIn("  Plan: ", result.stdout)
+            self.assertNotIn("Closeout:", result.stdout)
+
 
 @unittest.skipUnless(shutil.which("bun"), "bun is required for Opencode plugin runtime tests")
 class TestOpencodeSessionCreatedSurface(unittest.TestCase):

--- a/evals/tests/test_operator_surface_visibility.py
+++ b/evals/tests/test_operator_surface_visibility.py
@@ -14,6 +14,7 @@ from evals.tests._text_helpers import assert_multiline_regex, load_text
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 SESSION_START_HOOK = ROOT_DIR / "adapters" / "claude-code" / "hooks" / "session-start.mjs"
+CODEX_SESSION_START_HOOK = ROOT_DIR / "adapters" / "codex" / "hooks" / "session-start.mjs"
 APPROVALS_MODULE = ROOT_DIR / "adapters" / "shared" / "specwright-approvals.mjs"
 PLUGIN_PATH = ROOT_DIR / "adapters" / "opencode" / "plugin.ts"
 STATUS_SKILL = ROOT_DIR / "core" / "skills" / "sw-status" / "SKILL.md"
@@ -228,6 +229,29 @@ def _run_session_start(repo_path: Path) -> str:
     return result.stdout
 
 
+def _run_codex_session_start(repo_path: Path) -> str:
+    result = subprocess.run(
+        ["node", str(CODEX_SESSION_START_HOOK)],
+        cwd=repo_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout or "codex session-start hook failed")
+    return result.stdout
+
+
+def _run_codex_session_start_raw(repo_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", str(CODEX_SESSION_START_HOOK)],
+        cwd=repo_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def _run_opencode_event(repo_path: Path, event: str) -> str:
     script = f"""
 import plugin from {json.dumps(str(PLUGIN_PATH))};
@@ -272,6 +296,26 @@ def _fresh_timestamp() -> str:
 
 
 class TestSessionStartSurface(unittest.TestCase):
+    def test_primary_operator_surfaces_show_branch_approval_and_next_without_closeout(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            _write_shared_state(repo_path)
+
+            outputs = [
+                _run_session_start(repo_path),
+                _run_codex_session_start(repo_path),
+            ]
+            if shutil.which("bun"):
+                outputs.append(_run_opencode_event(repo_path, "session.created"))
+
+            for output in outputs:
+                with self.subTest(surface=output.splitlines()[0] if output else "empty"):
+                    self.assertIn("Branch: main (match)", output)
+                    self.assertIn("Closeout: none yet", output)
+                    self.assertIn("Approval: unit-spec MISSING (missing-entry)", output)
+                    self.assertIn("Next: /sw-build", output)
+
     def test_shared_state_writes_ignore_outer_hook_context(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             outer_repo_path = Path(tmpdir) / "outer-repo"
@@ -328,6 +372,79 @@ class TestSessionStartSurface(unittest.TestCase):
             self.assertIn("Closeout: stage-report", output)
             self.assertIn("Attention required: Operator surface summary is available.", output)
             self.assertIn("Approval: unit-spec APPROVED (approved)", output)
+
+    def test_codex_session_start_replays_shared_digest_and_approval_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            _write_stage_report(
+                state["workDir"],
+                state["repoStateRoot"],
+                state["workId"],
+                state["unitId"],
+            )
+            _write_approvals(state["workDir"], state["unitId"])
+
+            output = _run_codex_session_start(repo_path)
+
+            self.assertIn("Branch: main (match)", output)
+            self.assertIn("Closeout: stage-report", output)
+            self.assertIn("Attention required: Operator surface summary is available.", output)
+            self.assertIn("Approval: unit-spec APPROVED (approved)", output)
+            self.assertIn("Next: /sw-build", output)
+
+    def test_codex_session_start_replays_quality_corrections_when_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            continuation_path = Path(state["worktreeStateRoot"]) / "continuation.md"
+            continuation_path.parent.mkdir(parents=True, exist_ok=True)
+            continuation_path.write_text(
+                "\n".join(
+                    [
+                        f"Snapshot: {_fresh_timestamp()}",
+                        "",
+                        "## Progress",
+                        "Shared continuation notes.",
+                        "",
+                        "## Correction Summary",
+                        "- unchecked-error: Always handle errors explicitly",
+                        "",
+                        "## Next Steps",
+                        "Continue with task 3.",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            output = _run_codex_session_start(repo_path)
+
+            self.assertIn("Continuation Snapshot", output)
+            self.assertIn("Quality Corrections", output)
+            self.assertIn("unchecked-error", output)
+            self.assertFalse(continuation_path.exists())
+
+    def test_codex_session_start_exits_cleanly_for_inactive_work_without_summary_reads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_git_repo(repo_path)
+            state = _write_shared_state(repo_path)
+            workflow_path = Path(state["workDir"]) / "workflow.json"
+            workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+            workflow["status"] = "shipped"
+            workflow_path.write_text(json.dumps(workflow, indent=2) + "\n", encoding="utf-8")
+
+            approvals_path = Path(state["workDir"]) / "approvals.md"
+            approvals_path.write_text("not valid approvals content\n", encoding="utf-8")
+
+            result = _run_codex_session_start_raw(repo_path)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
 
 
 @unittest.skipUnless(shutil.which("bun"), "bun is required for Opencode plugin runtime tests")

--- a/evals/tests/test_support_surface_status_card.py
+++ b/evals/tests/test_support_surface_status_card.py
@@ -1,0 +1,122 @@
+"""Regression coverage for Unit 04 support-surface status-card alignment."""
+
+from pathlib import Path
+import unittest
+
+from evals.tests._text_helpers import load_text
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+STATUS_SKILL = ROOT_DIR / "core" / "skills" / "sw-status" / "SKILL.md"
+DOCTOR_SKILL = ROOT_DIR / "core" / "skills" / "sw-doctor" / "SKILL.md"
+INIT_SKILL = ROOT_DIR / "core" / "skills" / "sw-init" / "SKILL.md"
+GUARD_SKILL = ROOT_DIR / "core" / "skills" / "sw-guard" / "SKILL.md"
+AGENTS_DOC = ROOT_DIR / "AGENTS.md"
+CLAUDE_DOC = ROOT_DIR / "CLAUDE.md"
+CLAUDE_ADAPTER_DOC = ROOT_DIR / "adapters" / "claude-code" / "CLAUDE.md"
+SUPPORT_SURFACE_SHELL = ROOT_DIR / "tests" / "test-support-surface-cutover-docs.sh"
+CLAUDE_BUILD_TEST = ROOT_DIR / "tests" / "test-claude-code-build.sh"
+
+COMMAND_EXPECTATIONS = {
+    ROOT_DIR / "adapters" / "codex" / "commands" / "sw-status.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-adopt",
+    ],
+    ROOT_DIR / "adapters" / "codex" / "commands" / "sw-doctor.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-status --repair",
+    ],
+    ROOT_DIR / "adapters" / "codex" / "commands" / "sw-init.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-status",
+    ],
+    ROOT_DIR / "adapters" / "codex" / "commands" / "sw-guard.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-adopt",
+    ],
+    ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-status.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-adopt",
+    ],
+    ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-doctor.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-status --repair",
+    ],
+    ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-init.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-status",
+    ],
+    ROOT_DIR / "adapters" / "opencode" / "commands" / "sw-guard.md": [
+        ".specwright-local/",
+        "git-admin",
+        "/sw-adopt",
+    ],
+}
+
+
+class TestSupportSkillVocabulary(unittest.TestCase):
+    def test_support_skills_name_project_visible_runtime_and_explicit_adoption(self) -> None:
+        expectations = {
+            STATUS_SKILL: ["project-visible", ".specwright-local", "git-admin", "/sw-adopt"],
+            DOCTOR_SKILL: ["project-visible", ".specwright-local", "git-admin", "/sw-adopt"],
+            INIT_SKILL: ["project-visible", ".specwright-local", "git-admin", "/sw-status"],
+            GUARD_SKILL: ["project-visible", ".specwright-local", "git-admin", "/sw-adopt"],
+        }
+
+        for path, phrases in expectations.items():
+            text = load_text(path)
+            for phrase in phrases:
+                with self.subTest(path=path.name, phrase=phrase):
+                    self.assertIn(phrase, text)
+
+
+class TestCommandAndGuidanceSurfaceVocabulary(unittest.TestCase):
+    def test_command_wrappers_call_out_runtime_roots_and_adoption_story(self) -> None:
+        for path, phrases in COMMAND_EXPECTATIONS.items():
+            text = load_text(path)
+            for phrase in phrases:
+                with self.subTest(path=path.name, phrase=phrase):
+                    self.assertIn(phrase, text)
+
+    def test_guidance_docs_name_runtime_default_and_status_entrypoint(self) -> None:
+        expectations = {
+            AGENTS_DOC: [".specwright-local/", "git-admin", "/sw-adopt", "/sw-status"],
+            CLAUDE_DOC: [".specwright-local/", "git-admin", "/sw-adopt", "/sw-status"],
+            CLAUDE_ADAPTER_DOC: [".specwright-local/", "git-admin", "/sw-adopt", "/sw-status"],
+        }
+
+        for path, phrases in expectations.items():
+            text = load_text(path)
+            for phrase in phrases:
+                with self.subTest(path=path.name, phrase=phrase):
+                    self.assertIn(phrase, text)
+
+
+class TestPackagedSurfaceProof(unittest.TestCase):
+    def test_support_surface_shell_covers_runtime_root_and_adoption_cutover(self) -> None:
+        text = load_text(SUPPORT_SURFACE_SHELL)
+        for phrase in (
+            ".specwright-local/",
+            "git-admin",
+            "/sw-adopt",
+            "/sw-status",
+            "support-surface.runtime-root-adoption-cutover",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, text)
+
+    def test_claude_build_harness_requires_runtime_root_adoption_coverage_marker(self) -> None:
+        text = load_text(CLAUDE_BUILD_TEST)
+        self.assertIn("tests/test-support-surface-cutover-docs.sh", text)
+        self.assertIn("support-surface.runtime-root-adoption-cutover", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-claude-code-build.sh
+++ b/tests/test-claude-code-build.sh
@@ -281,6 +281,11 @@ run_smoke_checks() {
     "bash \"$SUPPORT_SURFACE_CUTOVER_TEST\"" \
     "COVERAGE: support-surface.publication-mode-cutover"
 
+  run_smoke_regression \
+    "support-surface runtime-root adoption" \
+    "bash \"$SUPPORT_SURFACE_CUTOVER_TEST\"" \
+    "COVERAGE: support-surface.runtime-root-adoption-cutover"
+
   run_smoke_regression_fn \
     "operator-surface workflow proof" \
     "COVERAGE: workflow-proof.operator-surface" \
@@ -584,6 +589,11 @@ if [ -f "$CC_DIST/CLAUDE.md" ]; then
 else
   fail "CLAUDE.md missing from dist/claude-code/"
 fi
+
+assert_file_contains "$CC_DIST/CLAUDE.md" ".specwright-local/" "packaged CLAUDE.md preserves project-visible runtime guidance"
+assert_file_contains "$CC_DIST/CLAUDE.md" "git-admin" "packaged CLAUDE.md preserves git-admin compatibility guidance"
+assert_file_contains "$CC_DIST/CLAUDE.md" "/sw-adopt" "packaged CLAUDE.md preserves explicit adoption guidance"
+assert_file_contains "$CC_DIST/CLAUDE.md" "/sw-status" "packaged CLAUDE.md preserves status entrypoint guidance"
 
 # ─── README.md ────────────────────────────────────────────────────────
 
@@ -986,6 +996,9 @@ for hook in $EXPECTED_HOOKS; do
     fi
   fi
 done
+
+assert_file_contains "$CC_DIST/hooks/session-start.mjs" "loadOperatorSurfaceSummary" "packaged session-start hook still loads the shared operator summary"
+assert_file_contains "$CC_DIST/hooks/session-start.mjs" "renderWorkInProgressSummary" "packaged session-start hook still renders the shared work-in-progress summary"
 
 echo "--- No unexpected hook files ---"
 
@@ -1705,6 +1718,11 @@ if [ "$SUPPORT_SURFACE_EXIT" -eq 0 ] && echo "$SUPPORT_SURFACE_OUTPUT" | grep -F
   pass "support-surface regression output includes publication-mode cutover coverage"
 else
   fail "support-surface regression output missing publication-mode cutover coverage"
+fi
+if [ "$SUPPORT_SURFACE_EXIT" -eq 0 ] && echo "$SUPPORT_SURFACE_OUTPUT" | grep -Fq "COVERAGE: support-surface.runtime-root-adoption-cutover"; then
+  pass "support-surface regression output includes runtime-root adoption coverage"
+else
+  fail "support-surface regression output missing runtime-root adoption coverage"
 fi
 
 echo ""

--- a/tests/test-opencode-plugin.sh
+++ b/tests/test-opencode-plugin.sh
@@ -126,10 +126,10 @@ assert_grep '(readFile|readFileSync|readTextFile|Bun\.file|fs\.)' \
   "uses a file-reading API (not just string reference to workflow.json)"
 
 # Must consume the shared closeout + approval surface model
-assert_grep '(loadOperatorSurfaceSummary|renderOperatorSurfaceLines|specwright-operator-surface)' \
+assert_grep '(loadOperatorSurfaceSummary|renderWorkInProgressSummary|specwright-operator-surface)' \
   "loads the shared operator-surface helper"
-assert_grep 'operatorSurfaceLines' "session.created wires shared operator-surface lines into the summary"
-assert_grep 'renderOperatorSurfaceLines' "session.created renders the shared operator-surface lines"
+assert_grep 'operatorSummary' "session.created loads the shared operator summary"
+assert_grep 'renderWorkInProgressSummary' "session.created renders the shared work-in-progress summary"
 
 # ─── 4. Event: session.compacted ────────────────────────────────────
 

--- a/tests/test-stage-enforcement.sh
+++ b/tests/test-stage-enforcement.sh
@@ -426,33 +426,34 @@ echo "=== T5: Session-start hooks and documentation ==="
 
 SESSION_START_MJS="$ROOT_DIR/adapters/claude-code/hooks/session-start.mjs"
 PLUGIN_TS="$ROOT_DIR/adapters/opencode/plugin.ts"
+OPERATOR_SURFACE_MJS="$ROOT_DIR/adapters/shared/specwright-operator-surface.mjs"
 DESIGN_MD="$ROOT_DIR/DESIGN.md"
 
-# AC-15: session-start.mjs handles shipping status
-if grep -q 'shipping' "$SESSION_START_MJS"; then
-  pass "AC-15a: session-start.mjs handles shipping status"
+# AC-15: adapters delegate to the shared operator-surface renderer, which owns
+# the shipping-state message after the refactor.
+if grep -q 'renderWorkInProgressSummary' "$SESSION_START_MJS"; then
+  pass "AC-15a: session-start.mjs delegates shipping status to shared renderer"
 else
-  fail "AC-15a: session-start.mjs does not handle shipping status"
+  fail "AC-15a: session-start.mjs does not delegate to shared renderer"
 fi
 
-# AC-15: plugin.ts handles shipping status
-if grep -q 'shipping' "$PLUGIN_TS"; then
-  pass "AC-15b: plugin.ts handles shipping status"
+if grep -q 'renderWorkInProgressSummary' "$PLUGIN_TS"; then
+  pass "AC-15b: plugin.ts delegates shipping status to shared renderer"
 else
-  fail "AC-15b: plugin.ts does not handle shipping status"
+  fail "AC-15b: plugin.ts does not delegate to shared renderer"
 fi
 
-# AC-15: Messages contain both "shipping" and "PR"/"pull request"
-if grep -A3 'shipping' "$SESSION_START_MJS" | grep -qi 'PR\|pull request'; then
-  pass "AC-15c: session-start.mjs shipping message mentions PR"
+# AC-15: shared renderer keeps the shipping message with PR guidance
+if grep -A3 'shipping' "$OPERATOR_SURFACE_MJS" | grep -qi 'PR\|pull request'; then
+  pass "AC-15c: shared operator surface shipping message mentions PR"
 else
-  fail "AC-15c: session-start.mjs shipping message doesn't mention PR"
+  fail "AC-15c: shared operator surface shipping message doesn't mention PR"
 fi
 
-if grep -A3 'shipping' "$PLUGIN_TS" | grep -qi 'PR\|pull request'; then
-  pass "AC-15d: plugin.ts shipping message mentions PR"
+if grep -A3 'shipping' "$OPERATOR_SURFACE_MJS" | grep -q '/sw-ship'; then
+  pass "AC-15d: shared operator surface shipping message preserves /sw-ship guidance"
 else
-  fail "AC-15d: plugin.ts shipping message doesn't mention PR"
+  fail "AC-15d: shared operator surface shipping message doesn't preserve /sw-ship guidance"
 fi
 
 # AC-17: DESIGN.md references shipping, PreToolUse, and evidence

--- a/tests/test-support-surface-cutover-docs.sh
+++ b/tests/test-support-surface-cutover-docs.sh
@@ -10,6 +10,14 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 AGENTS_DOC="$ROOT_DIR/AGENTS.md"
 CLAUDE_DOC="$ROOT_DIR/CLAUDE.md"
 ADAPTER_CLAUDE_DOC="$ROOT_DIR/adapters/claude-code/CLAUDE.md"
+CODEX_STATUS_CMD="$ROOT_DIR/adapters/codex/commands/sw-status.md"
+CODEX_DOCTOR_CMD="$ROOT_DIR/adapters/codex/commands/sw-doctor.md"
+CODEX_INIT_CMD="$ROOT_DIR/adapters/codex/commands/sw-init.md"
+CODEX_GUARD_CMD="$ROOT_DIR/adapters/codex/commands/sw-guard.md"
+OPENCODE_STATUS_CMD="$ROOT_DIR/adapters/opencode/commands/sw-status.md"
+OPENCODE_DOCTOR_CMD="$ROOT_DIR/adapters/opencode/commands/sw-doctor.md"
+OPENCODE_INIT_CMD="$ROOT_DIR/adapters/opencode/commands/sw-init.md"
+OPENCODE_GUARD_CMD="$ROOT_DIR/adapters/opencode/commands/sw-guard.md"
 REVIEW_PACKET_PROTOCOL="$ROOT_DIR/core/protocols/review-packet.md"
 SHIP_SKILL="$ROOT_DIR/core/skills/sw-ship/SKILL.md"
 REVIEW_SKILL="$ROOT_DIR/core/skills/sw-review/SKILL.md"
@@ -62,6 +70,14 @@ for file in \
   "$AGENTS_DOC" \
   "$CLAUDE_DOC" \
   "$ADAPTER_CLAUDE_DOC" \
+  "$CODEX_STATUS_CMD" \
+  "$CODEX_DOCTOR_CMD" \
+  "$CODEX_INIT_CMD" \
+  "$CODEX_GUARD_CMD" \
+  "$OPENCODE_STATUS_CMD" \
+  "$OPENCODE_DOCTOR_CMD" \
+  "$OPENCODE_INIT_CMD" \
+  "$OPENCODE_GUARD_CMD" \
   "$REVIEW_PACKET_PROTOCOL" \
   "$SHIP_SKILL" \
   "$REVIEW_SKILL" \
@@ -118,6 +134,54 @@ assert_contains "$INIT_SKILL" "{projectArtifactsRoot}/TESTING.md" "sw-init write
 assert_contains "$INIT_SKILL" "{projectArtifactsRoot}/BACKLOG.md" "sw-init writes markdown backlog under projectArtifactsRoot"
 assert_contains "$GUARD_SKILL" "shared project-level" "sw-guard treats config as a shared project policy surface"
 assert_contains "$GUARD_SKILL" "Git-admin session state remains local-only" "sw-guard preserves runtime-local session state"
+assert_contains "$AGENTS_DOC" ".specwright-local/" "AGENTS names project-visible runtime roots"
+assert_contains "$AGENTS_DOC" "git-admin" "AGENTS keeps git-admin as compatibility mode"
+assert_contains "$AGENTS_DOC" "/sw-adopt" "AGENTS points same-work adoption to /sw-adopt"
+assert_contains "$AGENTS_DOC" "/sw-status" "AGENTS points runtime inspection to /sw-status"
+assert_contains "$CLAUDE_DOC" ".specwright-local/" "CLAUDE names project-visible runtime roots"
+assert_contains "$CLAUDE_DOC" "git-admin" "CLAUDE keeps git-admin as compatibility mode"
+assert_contains "$CLAUDE_DOC" "/sw-adopt" "CLAUDE points same-work adoption to /sw-adopt"
+assert_contains "$CLAUDE_DOC" "/sw-status" "CLAUDE points runtime inspection to /sw-status"
+assert_contains "$ADAPTER_CLAUDE_DOC" ".specwright-local/" "adapter CLAUDE names project-visible runtime roots"
+assert_contains "$ADAPTER_CLAUDE_DOC" "git-admin" "adapter CLAUDE keeps git-admin as compatibility mode"
+assert_contains "$ADAPTER_CLAUDE_DOC" "/sw-adopt" "adapter CLAUDE points same-work adoption to /sw-adopt"
+assert_contains "$ADAPTER_CLAUDE_DOC" "/sw-status" "adapter CLAUDE points runtime inspection to /sw-status"
+assert_contains "$STATUS_SKILL" ".specwright-local/" "sw-status names project-visible runtime roots"
+assert_contains "$STATUS_SKILL" "git-admin" "sw-status keeps git-admin as compatibility mode"
+assert_contains "$STATUS_SKILL" "/sw-adopt" "sw-status keeps same-work adoption explicit"
+assert_contains "$DOCTOR_SKILL" ".specwright-local/" "sw-doctor names project-visible runtime roots"
+assert_contains "$DOCTOR_SKILL" "git-admin" "sw-doctor keeps git-admin as compatibility mode"
+assert_contains "$DOCTOR_SKILL" "/sw-adopt" "sw-doctor routes live ownership conflicts to /sw-adopt"
+assert_contains "$INIT_SKILL" ".specwright-local/" "sw-init recommends project-visible runtime roots"
+assert_contains "$INIT_SKILL" "git-admin" "sw-init keeps git-admin as compatibility mode"
+assert_contains "$INIT_SKILL" "/sw-status" "sw-init points the operator to /sw-status next"
+assert_contains "$GUARD_SKILL" ".specwright-local/" "sw-guard names project-visible runtime roots"
+assert_contains "$GUARD_SKILL" "git-admin" "sw-guard keeps git-admin as compatibility mode"
+assert_contains "$GUARD_SKILL" "/sw-adopt" "sw-guard keeps same-work adoption explicit"
+assert_contains "$CODEX_STATUS_CMD" ".specwright-local/" "codex sw-status command names project-visible runtime roots"
+assert_contains "$CODEX_STATUS_CMD" "git-admin" "codex sw-status command keeps git-admin as compatibility mode"
+assert_contains "$CODEX_STATUS_CMD" "/sw-adopt" "codex sw-status command points same-work takeover to /sw-adopt"
+assert_contains "$CODEX_DOCTOR_CMD" ".specwright-local/" "codex sw-doctor command names project-visible runtime roots"
+assert_contains "$CODEX_DOCTOR_CMD" "git-admin" "codex sw-doctor command keeps git-admin as compatibility mode"
+assert_contains "$CODEX_DOCTOR_CMD" "/sw-status --repair" "codex sw-doctor command points repair to /sw-status --repair"
+assert_contains "$CODEX_INIT_CMD" ".specwright-local/" "codex sw-init command names project-visible runtime roots"
+assert_contains "$CODEX_INIT_CMD" "git-admin" "codex sw-init command keeps git-admin as compatibility mode"
+assert_contains "$CODEX_INIT_CMD" "/sw-status" "codex sw-init command points the operator to /sw-status"
+assert_contains "$CODEX_GUARD_CMD" ".specwright-local/" "codex sw-guard command names project-visible runtime roots"
+assert_contains "$CODEX_GUARD_CMD" "git-admin" "codex sw-guard command keeps git-admin as compatibility mode"
+assert_contains "$CODEX_GUARD_CMD" "/sw-adopt" "codex sw-guard command keeps same-work adoption explicit"
+assert_contains "$OPENCODE_STATUS_CMD" ".specwright-local/" "opencode sw-status command names project-visible runtime roots"
+assert_contains "$OPENCODE_STATUS_CMD" "git-admin" "opencode sw-status command keeps git-admin as compatibility mode"
+assert_contains "$OPENCODE_STATUS_CMD" "/sw-adopt" "opencode sw-status command points same-work takeover to /sw-adopt"
+assert_contains "$OPENCODE_DOCTOR_CMD" ".specwright-local/" "opencode sw-doctor command names project-visible runtime roots"
+assert_contains "$OPENCODE_DOCTOR_CMD" "git-admin" "opencode sw-doctor command keeps git-admin as compatibility mode"
+assert_contains "$OPENCODE_DOCTOR_CMD" "/sw-status --repair" "opencode sw-doctor command points repair to /sw-status --repair"
+assert_contains "$OPENCODE_INIT_CMD" ".specwright-local/" "opencode sw-init command names project-visible runtime roots"
+assert_contains "$OPENCODE_INIT_CMD" "git-admin" "opencode sw-init command keeps git-admin as compatibility mode"
+assert_contains "$OPENCODE_INIT_CMD" "/sw-status" "opencode sw-init command points the operator to /sw-status"
+assert_contains "$OPENCODE_GUARD_CMD" ".specwright-local/" "opencode sw-guard command names project-visible runtime roots"
+assert_contains "$OPENCODE_GUARD_CMD" "git-admin" "opencode sw-guard command keeps git-admin as compatibility mode"
+assert_contains "$OPENCODE_GUARD_CMD" "/sw-adopt" "opencode sw-guard command keeps same-work adoption explicit"
 assert_not_contains "$CLAUDE_DOC" "{repoStateRoot}/CONSTITUTION.md" "CLAUDE no longer points anchor docs at repoStateRoot"
 assert_not_contains "$ADAPTER_CLAUDE_DOC" "{repoStateRoot}/CONSTITUTION.md" "adapter CLAUDE no longer points anchor docs at repoStateRoot"
 assert_not_contains "$INIT_SKILL" ".specwright/LANDSCAPE.md" "sw-init removes legacy LANDSCAPE path"
@@ -144,3 +208,4 @@ if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
 emit_coverage_marker "support-surface.publication-mode-cutover"
+emit_coverage_marker "support-surface.runtime-root-adoption-cutover"


### PR DESCRIPTION
## Summary
This PR revives the meaningful operator-surface and support-surface work that was left behind on #205, but rebases it onto current `main` as a clean replacement branch.

It keeps the developer-facing improvements across Codex, Claude Code, and Opencode, while dropping the low-signal audit/research churn from the earlier branch.

## What changed
- adopt the shared operator/support surface across adapter command docs and runtime hooks
- wire Codex, Claude Code, and Opencode through the same work-in-progress summary model
- preserve quality-correction replay in Codex session start and avoid inactive-work summary reads
- harden the operator-surface evals so Opencode coverage is conditional on `bun` availability
- add explicit regression coverage for warning-cap behavior and support-surface status cards
- update the Opencode plugin shell regression to match the shared summary refactor

## Why this replaces #205
#205 still contains useful user-facing work, but its branch is now out of date and carries merge-conflict/review noise. This PR preserves the value from that branch in a state that is ready for normal review and merge.

## Verification
- `python -m pytest evals/tests/test_operator_surface_visibility.py evals/tests/test_operator_surface_status_card.py -v`
- `bash tests/test-support-surface-cutover-docs.sh`
- `env SPECWRIGHT_CLAUDE_BUILD_MODE=smoke bash tests/test-claude-code-build.sh`
- `bash tests/test-codex-hooks.sh`
- `bash tests/test-opencode-plugin.sh`
- pre-push `test-suite`
